### PR TITLE
Updating zap log config in operator.yaml

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -24,6 +24,7 @@ spec:
         # from most to least.
         # If running entrypoint_debug then use '-- --zap-level debug'
         - '--zap-level debug'
+        - '--zap-encoder console'
         command:
         - /home/activemq-artemis-operator/bin/entrypoint
         env:


### PR DESCRIPTION
Added '--zap-encoder console' to make operator logs

more readable.

sample logging after adding the option:
2020-11-02T10:11:35.207Z	INFO	package environments	Detect if openshift is running
2020-11-02T10:11:35.221Z	INFO	cmd	environment is not openshift
2020-11-02T10:11:35.221Z	INFO	cmd	Go Version: go1.13.4
2020-11-02T10:11:35.221Z	INFO	cmd	Go OS/Arch: linux/amd64
2020-11-02T10:11:35.221Z	INFO	cmd	Version of operator-sdk: v0.8.2
2020-11-02T10:11:35.221Z	INFO	cmd	Version of the operator: 0.17.0
2020-11-02T10:11:35.221Z	INFO	leader	Trying to become the leader.
2020-11-02T10:11:35.221Z	DEBUG	k8sutil	Found namespace	{"Namespace": "default"}
2020-11-02T10:11:35.280Z	DEBUG	k8sutil	Found podname	{"Pod.Name": "activemq-artemis-operator-788df76654-462lr"}
2020-11-02T10:11:35.296Z	DEBUG	k8sutil	Found Pod	{"Pod.Namespace": "default", "Pod.Name": "activemq-artemis-operator-788df76654-462lr"}
2020-11-02T10:11:35.299Z	INFO	leader	No pre-existing lock was found.
2020-11-02T10:11:35.306Z	INFO	leader	Became the leader.
2020-11-02T10:11:35.367Z	INFO	cmd	Registering Components.
2020-11-02T10:11:35.368Z	INFO	kubebuilder.controller	Starting EventSource	{"controller": "v2alpha3activemqartemis-controller", "source": "kind source: /, Kind="}
2020-11-02T10:11:35.369Z	INFO	kubebuilder.controller	Starting EventSource	{"controller": "v2alpha3activemqartemis-controller", "source": "kind source: /, Kind="}
2020-11-02T10:11:35.369Z	INFO	kubebuilder.controller	Starting EventSource	{"controller": "v2alpha3activemqartemis-controller", "source": "kind source: /, Kind="}
2020-11-02T10:11:35.369Z	INFO	controller_v2alpha2activemqartemisaddress	Setting up address observer
2020-11-02T10:11:35.370Z	INFO	kubebuilder.controller	Starting EventSource	{"controller": "v2alpha2activemqartemisaddress-controller", "source": "kind source: /, Kind="}
2020-11-02T10:11:35.370Z	INFO	kubebuilder.controller	Starting EventSource	{"controller": "v2alpha2activemqartemisaddress-controller", "source": "kind source: /, Kind="}
2020-11-02T10:11:35.371Z	INFO	kubebuilder.controller	Starting EventSource	{"controller": "v2alpha1activemqartemisscaledown-controller", "source": "kind source: /, Kind="}
2020-11-02T10:11:35.371Z	INFO	kubebuilder.controller	Starting EventSource	{"controller": "v2alpha1activemqartemisscaledown-controller", "source": "kind source: /, Kind="}
2020-11-02T10:11:35.382Z	INFO	controller_v2alpha2activemqartemisaddress	#### Started workers
2020-11-02T10:11:35.437Z	DEBUG	k8sutil	Found namespace	{"Namespace": "default"}
2020-11-02T10:11:35.437Z	DEBUG	k8sutil	Found podname	{"Pod.Name": "activemq-artemis-operator-788df76654-462lr"}
2020-11-02T10:11:35.442Z	DEBUG	k8sutil	Found Pod	{"Pod.Namespace": "default", "Pod.Name": "activemq-artemis-operator-788df76654-462lr"}
2020-11-02T10:11:35.450Z	DEBUG	metrics	Pods owner found	{"Kind": "Deployment", "Name": "activemq-artemis-operator", "Namespace": "default"}
2020-11-02T10:11:35.471Z	INFO	metrics	Metrics Service object created	{"Service.Name": "activemq-artemis-operator", "Service.Namespace": "default"}
2020-11-02T10:11:35.471Z	INFO	cmd	Starting the Cmd.
2020-11-02T10:11:35.673Z	INFO	kubebuilder.controller	Starting Controller	{"controller": "v2alpha1activemqartemisscaledown-controller"}
2020-11-02T10:11:35.673Z	INFO	kubebuilder.controller	Starting Controller	{"controller": "v2alpha2activemqartemisaddress-controller"}
2020-11-02T10:11:35.673Z	INFO	kubebuilder.controller	Starting Controller	{"controller": "v2alpha3activemqartemis-controller"}
2020-11-02T10:11:35.774Z	INFO	kubebuilder.controller	Starting workers	{"controller": "v2alpha1activemqartemisscaledown-controller", "worker count": 1}
2020-11-02T10:11:35.774Z	INFO	kubebuilder.controller	Starting workers	{"controller": "v2alpha3activemqartemis-controller", "worker count": 1}
2020-11-02T10:11:35.775Z	INFO	kubebuilder.controller	Starting workers	{"controller": "v2alpha2activemqartemisaddress-controller", "worker count": 1}
