### PR TITLE
Fix deploy resources values

### DIFF
--- a/deploy/crs/broker_activemqartemis_cr.yaml
+++ b/deploy/crs/broker_activemqartemis_cr.yaml
@@ -15,10 +15,10 @@ spec:
     resources:
       limits:
         cpu: 500m
-        memory: 1024m
+        memory: 1024Mi
       requests:
         cpu: 250m
-        memory: 512m
+        memory: 512Mi
     storage:
       size: "4Gi"
   console:

--- a/deploy/examples/artemis-basic-resources-deployment.yaml
+++ b/deploy/examples/artemis-basic-resources-deployment.yaml
@@ -8,9 +8,9 @@ spec:
     image: quay.io/artemiscloud/activemq-artemis-broker-kubernetes:0.2.0
     resources:
       limits:
-        cpu: "500Mi"
+        cpu: "500m"
         memory: "1024Mi"
       requests:
-        cpu: "250Mi"
+        cpu: "250m"
         memory: "512Mi"
 


### PR DESCRIPTION
The resource abbreviation m denotes "Mili" and Mi denotes "Mega".
Specifying a very low value (e.g. 400m) instead of an appropriate
value (e.g. 400Mi) will lead to the FailedCreatePodSandBox error.