### PR TITLE
ENTMQBR-4177/issue #37 ConfigDeleteAddresses parameter is interpreted wrong

### DIFF
--- a/tools/cr2jinjia2/cr2jinjia2.go
+++ b/tools/cr2jinjia2/cr2jinjia2.go
@@ -79,6 +79,7 @@ func processCr(decoder *k8syaml.YAMLOrJSONDecoder, envVar *string, outputVar *st
 		return ""
 	}
 
-	return cr2jinja2.MakeBrokerCfgOverrides(brokerCr, envVar, outputVar)
+	result, _ := cr2jinja2.MakeBrokerCfgOverrides(brokerCr, envVar, outputVar)
 
+	return result
 }


### PR DESCRIPTION

To workaround this problem we add a map of special values and pass it
to yacfg so it can overrides those wrong conversions.

Depends on https://github.com/rh-messaging-qe/yacfg/issues/24