### PR TITLE
Broker Operator has hardcoded value of init container image

### DIFF
--- a/pkg/controller/broker/v2alpha4/activemqartemis/activemqartemis_reconciler.go
+++ b/pkg/controller/broker/v2alpha4/activemqartemis/activemqartemis_reconciler.go
@@ -250,7 +250,20 @@ func (reconciler *ActiveMQArtemisReconciler) ProcessAddressSettings(customResour
 //returns true if currentAddressSettings need update
 func compareAddressSettings(currentAddressSettings *brokerv2alpha4.AddressSettingsType, newAddressSettings *brokerv2alpha4.AddressSettingsType) bool {
 
-	if len((*currentAddressSettings).AddressSetting) != len((*newAddressSettings).AddressSetting) || *(*currentAddressSettings).ApplyRule != *(*newAddressSettings).ApplyRule || !config.IsEqualV2Alpha4((*currentAddressSettings).AddressSetting, (*newAddressSettings).AddressSetting) {
+	if (*currentAddressSettings).ApplyRule == nil {
+		if (*newAddressSettings).ApplyRule != nil {
+			return true
+		}
+	} else {
+		if (*newAddressSettings).ApplyRule != nil {
+			if *(*currentAddressSettings).ApplyRule != *(*newAddressSettings).ApplyRule {
+				return true
+			}
+		} else {
+			return true
+		}
+	}
+	if len((*currentAddressSettings).AddressSetting) != len((*newAddressSettings).AddressSetting) || !config.IsEqualV2Alpha4((*currentAddressSettings).AddressSetting, (*newAddressSettings).AddressSetting) {
 		return true
 	}
 	return false


### PR DESCRIPTION
Reported bug under this ENTMQBR-4135 Jira but in fact it's an issue of nil values
when comparing two address-settings when user applying update.
The applyRule for address-settings might be nil so it must be taken
care of.