### PR TITLE
Correct logging that contained non printable chars

### DIFF
--- a/pkg/controller/broker/v2alpha2/activemqartemis/activemqartemis_reconciler.go
+++ b/pkg/controller/broker/v2alpha2/activemqartemis/activemqartemis_reconciler.go
@@ -1326,8 +1326,8 @@ func GetPodStatus(cr *brokerv2alpha2.ActiveMQArtemis, client client.Client, name
 	}
 
 	// TODO: Remove global usage
-	log.V(5).Info("lastStatus.Ready len is " + string(len(lastStatus.Ready)))
-	log.V(5).Info("status.Ready len is " + string(len(status.Ready)))
+	log.V(5).Info("lastStatus.Ready len is " + fmt.Sprint(len(lastStatus.Ready)))
+	log.V(5).Info("status.Ready len is " + fmt.Sprint(len(lastStatus.Ready)))
 	if len(status.Ready) > len(lastStatus.Ready) {
 		// More pods ready, let the address controller know
 		newPodCount := len(status.Ready) - len(lastStatus.Ready)

--- a/pkg/controller/broker/v2alpha3/activemqartemis/activemqartemis_reconciler.go
+++ b/pkg/controller/broker/v2alpha3/activemqartemis/activemqartemis_reconciler.go
@@ -1559,8 +1559,8 @@ func GetPodStatus(cr *brokerv2alpha3.ActiveMQArtemis, client client.Client, name
 	}
 
 	// TODO: Remove global usage
-	reqLogger.V(1).Info("lastStatus.Ready len is " + string(len(lastStatus.Ready)))
-	reqLogger.V(1).Info("status.Ready len is " + string(len(status.Ready)))
+	reqLogger.V(1).Info("lastStatus.Ready len is " + fmt.Sprint(len(lastStatus.Ready)))
+	reqLogger.V(1).Info("status.Ready len is " + fmt.Sprint(len(lastStatus.Ready)))
 	if len(status.Ready) > len(lastStatus.Ready) {
 		// More pods ready, let the address controller know
 		newPodCount := len(status.Ready) - len(lastStatus.Ready)

--- a/pkg/controller/broker/v2alpha4/activemqartemis/activemqartemis_reconciler.go
+++ b/pkg/controller/broker/v2alpha4/activemqartemis/activemqartemis_reconciler.go
@@ -1729,8 +1729,8 @@ func GetPodStatus(cr *brokerv2alpha4.ActiveMQArtemis, client client.Client, name
 	}
 
 	// TODO: Remove global usage
-	reqLogger.V(1).Info("lastStatus.Ready len is " + string(len(lastStatus.Ready)))
-	reqLogger.V(1).Info("status.Ready len is " + string(len(status.Ready)))
+	reqLogger.V(1).Info("lastStatus.Ready len is " + fmt.Sprint(len(lastStatus.Ready)))
+	reqLogger.V(1).Info("status.Ready len is " + fmt.Sprint(len(status.Ready)))
 	if len(status.Ready) > len(lastStatus.Ready) {
 		// More pods ready, let the address controller know
 		newPodCount := len(status.Ready) - len(lastStatus.Ready)


### PR DESCRIPTION
While debugging we find out in logs that instead of the number of the
pods running there was a strange char shown. We found that chars printed
where ^C and ^B, which respectively corresponds to the char 3 and 2 of
ascii table. With this fix we use correct fmt function to print out the
correct value.