### PR TITLE
Adding multi-arch image support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,5 @@
 name: Release
-
-env:
-  IMAGE_NAME: activemq-artemis-operator
-
+  
 on:
   push:
     tags:
@@ -18,15 +15,35 @@ jobs:
 
       - name: Checkout the repo
         uses: actions/checkout@v2
+      
+      - name: "Set up QEMU"
+        uses: docker/setup-qemu-action@v1
 
-      - name: Build the image
-        run: docker build --file ./build/Dockerfile --tag $IMAGE_NAME:latest .
+      - name: "Set up Docker Buildx"
+        uses: docker/setup-buildx-action@v1
+      
+      - name: Prepare
+        id: prep
+        run: |
+          IMAGE_TAG=${GITHUB_REF#refs/tags/v}
+          echo ::set-output name=image_tag::${IMAGE_TAG}
+          PLATFORMS=linux/amd64,linux/ppc64le
+          echo ::set-output name=platforms::${PLATFORMS}
+          IMAGE_NAME=activemq-artemis-operator
+          echo ::set-output name=image_name::${IMAGE_NAME}
+          
+      - name: Login to quay.io
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
 
-      - name: Push the image
-        run: >
-          export IMAGE_TAG=${GITHUB_REF#refs/tags/v} &&
-          docker login --username=${{ secrets.QUAY_USERNAME }} --password=${{ secrets.QUAY_PASSWORD }} quay.io &&
-          docker tag $IMAGE_NAME:latest quay.io/${{ secrets.QUAY_NAMESPACE }}/$IMAGE_NAME:$IMAGE_TAG &&
-          docker push quay.io/${{ secrets.QUAY_NAMESPACE }}/$IMAGE_NAME:$IMAGE_TAG &&
-          docker tag $IMAGE_NAME:latest quay.io/${{ secrets.QUAY_NAMESPACE }}/$IMAGE_NAME:latest &&
-          docker push quay.io/${{ secrets.QUAY_NAMESPACE }}/$IMAGE_NAME:latest
+      - name: "Build and push"
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./build/Dockerfile
+          platforms: ${{ steps.prep.outputs.platforms }}
+          tags:  quay.io/${{ secrets.QUAY_NAMESPACE }}/${{ steps.prep.outputs.image_name }}:${{ steps.prep.outputs.image_tag }},quay.io/${{ secrets.QUAY_NAMESPACE }}/${{ steps.prep.outputs.image_name }}:latest
+          push: true

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -5,13 +5,22 @@ ENV GOOS=linux
 ENV CGO_ENABLED=0
 ENV BROKER_NAME=activemq-artemis
 
+#If buildx is not used, ARG can be passed for normal docker build
+ARG GOARCH=amd64
+RUN echo $GOARCH > /tmp/goarch
+
+#This arg is passed by docker buildx & contains the platform info in the form linux/amd64, linux/ppc64le etc.
+ARG TARGETPLATFORM
+#Capture ARCH and write to /tmp/goarch file for further reference
+RUN [ ! "x" = "x$TARGETPLATFORM" ] && `echo $TARGETPLATFORM |  awk '{split($0,a,"/"); print a[2]}' > /tmp/goarch` || echo "$GOARCH"
+
 RUN mkdir -p /tmp/go/src/github.com/artemiscloud/activemq-artemis-operator/bin
 RUN mkdir -p /tmp/activemq-artemis-operator
 
 ADD . ${GOPATH}/src/github.com/artemiscloud/activemq-artemis-operator
 WORKDIR ${GOPATH}/src/github.com/artemiscloud/activemq-artemis-operator
 
-RUN /opt/rh/go-toolset-1.13/root/usr/bin/go build -o /tmp/activemq-artemis-operator/${BROKER_NAME}-operator /tmp/go/src/github.com/artemiscloud/activemq-artemis-operator/cmd/manager
+RUN GOARCH=$(cat /tmp/goarch) /opt/rh/go-toolset-1.13/root/usr/bin/go build -o /tmp/activemq-artemis-operator/${BROKER_NAME}-operator /tmp/go/src/github.com/artemiscloud/activemq-artemis-operator/cmd/manager
 
 
 FROM registry.access.redhat.com/ubi8:8.3-289 AS base-env
@@ -55,7 +64,7 @@ RUN useradd ${BROKER_NAME}-operator
 RUN mkdir -p /home/${BROKER_NAME}-operator/bin && chown -R `id -u`:0 /home/${BROKER_NAME}-operator/bin && chmod -R 755 /home/${BROKER_NAME}-operator/bin
 
 USER ${USER_UID}
-ENTRYPOINT ["/home/${BROKER_NAME}-operator/bin/entrypoint"]
+ENTRYPOINT ["/home/activemq-artemis-operator/bin/entrypoint"]
 
 LABEL \
       com.redhat.component="amq-broker-rhel8-operator-container"  \

--- a/build/Dockerfile_debug
+++ b/build/Dockerfile_debug
@@ -6,6 +6,15 @@ ENV CGO_ENABLED=0
 ENV BROKER_NAME=activemq-artemis
 ENV PATH=$PATH:/opt/rh/go-toolset-1.13/root/usr/bin
 
+#If buildx is not used, ARG can be passed for normal docker build
+ARG GOARCH=amd64
+RUN echo $GOARCH > /tmp/goarch
+
+#This arg is passed by docker buildx & contains the platform info in the form linux/amd64, linux/ppc64le etc.
+ARG TARGETPLATFORM
+#Capture ARCH and write to /tmp/goarch file for further reference
+RUN [ ! "x" = "x$TARGETPLATFORM" ] && `echo $TARGETPLATFORM |  awk '{split($0,a,"/"); print a[2]}' > /tmp/goarch` || echo "$GOARCH"
+
 RUN mkdir -p /tmp/go/src/github.com/artemiscloud/activemq-artemis-operator/bin
 RUN mkdir -p /tmp/activemq-artemis-operator
 
@@ -22,7 +31,7 @@ RUN /opt/rh/go-toolset-1.13/root/usr/bin/go get github.com/go-delve/delve/cmd/dl
 #RUN /opt/rh/go-toolset-1.13/root/usr/bin/go run _scripts/make.go install
 
 WORKDIR ${GOPATH}/src/github.com/artemiscloud/activemq-artemis-operator
-RUN /opt/rh/go-toolset-1.13/root/usr/bin/go build -gcflags \"all=-N\" -v -o /tmp/activemq-artemis-operator/${BROKER_NAME}-operator /tmp/go/src/github.com/artemiscloud/activemq-artemis-operator/cmd/manager
+RUN GOARCH=$(cat /tmp/goarch) /opt/rh/go-toolset-1.13/root/usr/bin/go build -gcflags \"all=-N\" -v -o /tmp/activemq-artemis-operator/${BROKER_NAME}-operator /tmp/go/src/github.com/artemiscloud/activemq-artemis-operator/cmd/manager
 
 FROM registry.access.redhat.com/ubi8:8.3-289 AS base-env
 
@@ -72,7 +81,7 @@ RUN mkdir -p ${XDG_CONFIG_HOME}/dlv && chown -R `id -u`:0 ${XDG_CONFIG_HOME}/dlv
 RUN touch ${XDG_CONFIG_HOME}/dlv/config.yml && chown -R `id -u`:0 ${XDG_CONFIG_HOME}/dlv/config.yml && chmod -R 777 ${XDG_CONFIG_HOME}/dlv/config.yml
 
 USER ${USER_UID}
-ENTRYPOINT ["/home/${BROKER_NAME}-operator/bin/entrypoint_debug"]
+ENTRYPOINT ["/home/activemq-artemis-operator/bin/entrypoint_debug"]
 
 LABEL \
       com.redhat.component="amq-broker-rhel8-operator-container"  \


### PR DESCRIPTION
This PR adds the IBM power (ppc64le) support to AMQ Operator image. The changes are minimal and can be easily extended to support  other architecutres.

A sample [image](https://hub.docker.com/r/ptcttest/activemq-artemis-operator/tags?page=1&ordering=last_updated) published on dockerhub for reference.

Also refer github action [logs](https://github.com/bahetiamit/activemq-artemis-operator/runs/2006258617?check_suite_focus=true) which shows the release workflow run with these changes.