### PR TITLE
Fix ci build issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
           test-packages: 'test/smoke/basic/...'
           docker-images: 'activemq-artemis-operator:dev.latest'
           operator-image: 'activemq-artemis-operator:dev.latest'
+          operator-deploy-path: 'deploy'
 
       - name: Push the image
         if: ${{ github.event_name == 'push' }}


### PR DESCRIPTION
Ci build fails on PRs where the broker crd version
gets bumped. This is because the ci job deploys the
current CRDs instead of the new ones. When operator
is deployed it seeks the new version but not available.