### PR TITLE
ENTMQBR-5622 ActiveMQArtemisAddress CR is not resilient to the scale up

### DIFF
--- a/pkg/client/clientset/versioned/typed/broker/v2alpha3/activemqartemisaddress.go
+++ b/pkg/client/clientset/versioned/typed/broker/v2alpha3/activemqartemisaddress.go
@@ -1,0 +1,172 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v2alpha3
+
+import (
+	v2alpha3 "github.com/artemiscloud/activemq-artemis-operator/pkg/apis/broker/v2alpha3"
+	scheme "github.com/artemiscloud/activemq-artemis-operator/pkg/client/clientset/versioned/scheme"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	types "k8s.io/apimachinery/pkg/types"
+	watch "k8s.io/apimachinery/pkg/watch"
+	rest "k8s.io/client-go/rest"
+)
+
+// ActiveMQArtemisAddressesGetter has a method to return a ActiveMQArtemisAddressInterface.
+// A group's client should implement this interface.
+type ActiveMQArtemisAddressesGetter interface {
+	ActiveMQArtemisAddresses(namespace string) ActiveMQArtemisAddressInterface
+}
+
+// ActiveMQArtemisAddressInterface has methods to work with ActiveMQArtemisAddress resources.
+type ActiveMQArtemisAddressInterface interface {
+	Create(*v2alpha3.ActiveMQArtemisAddress) (*v2alpha3.ActiveMQArtemisAddress, error)
+	Update(*v2alpha3.ActiveMQArtemisAddress) (*v2alpha3.ActiveMQArtemisAddress, error)
+	UpdateStatus(*v2alpha3.ActiveMQArtemisAddress) (*v2alpha3.ActiveMQArtemisAddress, error)
+	Delete(name string, options *v1.DeleteOptions) error
+	DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error
+	Get(name string, options v1.GetOptions) (*v2alpha3.ActiveMQArtemisAddress, error)
+	List(opts v1.ListOptions) (*v2alpha3.ActiveMQArtemisAddressList, error)
+	Watch(opts v1.ListOptions) (watch.Interface, error)
+	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v2alpha3.ActiveMQArtemisAddress, err error)
+	ActiveMQArtemisAddressExpansion
+}
+
+// activeMQArtemisAddresses implements ActiveMQArtemisAddressInterface
+type activeMQArtemisAddresses struct {
+	client rest.Interface
+	ns     string
+}
+
+// newActiveMQArtemisAddresses returns a ActiveMQArtemisAddresses
+func newActiveMQArtemisAddresses(c *BrokerV2alpha3Client, namespace string) *activeMQArtemisAddresses {
+	return &activeMQArtemisAddresses{
+		client: c.RESTClient(),
+		ns:     namespace,
+	}
+}
+
+// Get takes name of the activeMQArtemisAddress, and returns the corresponding activeMQArtemisAddress object, and an error if there is any.
+func (c *activeMQArtemisAddresses) Get(name string, options v1.GetOptions) (result *v2alpha3.ActiveMQArtemisAddress, err error) {
+	result = &v2alpha3.ActiveMQArtemisAddress{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("activemqartemisaddresses").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of ActiveMQArtemisAddresses that match those selectors.
+func (c *activeMQArtemisAddresses) List(opts v1.ListOptions) (result *v2alpha3.ActiveMQArtemisAddressList, err error) {
+	result = &v2alpha3.ActiveMQArtemisAddressList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("activemqartemisaddresses").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested activeMQArtemisAddresses.
+func (c *activeMQArtemisAddresses) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("activemqartemisaddresses").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
+// Create takes the representation of a activeMQArtemisAddress and creates it.  Returns the server's representation of the activeMQArtemisAddress, and an error, if there is any.
+func (c *activeMQArtemisAddresses) Create(activeMQArtemisAddress *v2alpha3.ActiveMQArtemisAddress) (result *v2alpha3.ActiveMQArtemisAddress, err error) {
+	result = &v2alpha3.ActiveMQArtemisAddress{}
+	err = c.client.Post().
+		Namespace(c.ns).
+		Resource("activemqartemisaddresses").
+		Body(activeMQArtemisAddress).
+		Do().
+		Into(result)
+	return
+}
+
+// Update takes the representation of a activeMQArtemisAddress and updates it. Returns the server's representation of the activeMQArtemisAddress, and an error, if there is any.
+func (c *activeMQArtemisAddresses) Update(activeMQArtemisAddress *v2alpha3.ActiveMQArtemisAddress) (result *v2alpha3.ActiveMQArtemisAddress, err error) {
+	result = &v2alpha3.ActiveMQArtemisAddress{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("activemqartemisaddresses").
+		Name(activeMQArtemisAddress.Name).
+		Body(activeMQArtemisAddress).
+		Do().
+		Into(result)
+	return
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+
+func (c *activeMQArtemisAddresses) UpdateStatus(activeMQArtemisAddress *v2alpha3.ActiveMQArtemisAddress) (result *v2alpha3.ActiveMQArtemisAddress, err error) {
+	result = &v2alpha3.ActiveMQArtemisAddress{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("activemqartemisaddresses").
+		Name(activeMQArtemisAddress.Name).
+		SubResource("status").
+		Body(activeMQArtemisAddress).
+		Do().
+		Into(result)
+	return
+}
+
+// Delete takes name of the activeMQArtemisAddress and deletes it. Returns an error if one occurs.
+func (c *activeMQArtemisAddresses) Delete(name string, options *v1.DeleteOptions) error {
+	return c.client.Delete().
+		Namespace(c.ns).
+		Resource("activemqartemisaddresses").
+		Name(name).
+		Body(options).
+		Do().
+		Error()
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *activeMQArtemisAddresses) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	return c.client.Delete().
+		Namespace(c.ns).
+		Resource("activemqartemisaddresses").
+		VersionedParams(&listOptions, scheme.ParameterCodec).
+		Body(options).
+		Do().
+		Error()
+}
+
+// Patch applies the patch and returns the patched activeMQArtemisAddress.
+func (c *activeMQArtemisAddresses) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v2alpha3.ActiveMQArtemisAddress, err error) {
+	result = &v2alpha3.ActiveMQArtemisAddress{}
+	err = c.client.Patch(pt).
+		Namespace(c.ns).
+		Resource("activemqartemisaddresses").
+		SubResource(subresources...).
+		Name(name).
+		Body(data).
+		Do().
+		Into(result)
+	return
+}

--- a/pkg/client/clientset/versioned/typed/broker/v2alpha3/broker_client.go
+++ b/pkg/client/clientset/versioned/typed/broker/v2alpha3/broker_client.go
@@ -26,6 +26,7 @@ import (
 type BrokerV2alpha3Interface interface {
 	RESTClient() rest.Interface
 	ActiveMQArtemisesGetter
+	ActiveMQArtemisAddressesGetter
 }
 
 // BrokerV2alpha3Client is used to interact with features provided by the broker.amq.io group.
@@ -35,6 +36,10 @@ type BrokerV2alpha3Client struct {
 
 func (c *BrokerV2alpha3Client) ActiveMQArtemises(namespace string) ActiveMQArtemisInterface {
 	return newActiveMQArtemises(c, namespace)
+}
+
+func (c *BrokerV2alpha3Client) ActiveMQArtemisAddresses(namespace string) ActiveMQArtemisAddressInterface {
+	return newActiveMQArtemisAddresses(c, namespace)
 }
 
 // NewForConfig creates a new BrokerV2alpha3Client for the given config.

--- a/pkg/client/clientset/versioned/typed/broker/v2alpha3/generated_expansion.go
+++ b/pkg/client/clientset/versioned/typed/broker/v2alpha3/generated_expansion.go
@@ -17,3 +17,5 @@ limitations under the License.
 package v2alpha3
 
 type ActiveMQArtemisExpansion interface{}
+
+type ActiveMQArtemisAddressExpansion interface{}

--- a/pkg/controller/broker/v2alpha3/activemqartemisaddress/address_observer.go
+++ b/pkg/controller/broker/v2alpha3/activemqartemisaddress/address_observer.go
@@ -21,18 +21,22 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/artemiscloud/activemq-artemis-operator/pkg/utils/namer"
+
 	mgmt "github.com/artemiscloud/activemq-artemis-management"
-	clientv2alpha1 "github.com/artemiscloud/activemq-artemis-operator/pkg/client/clientset/versioned/typed/broker/v2alpha1"
+	v2alpha3 "github.com/artemiscloud/activemq-artemis-operator/pkg/apis/broker/v2alpha3"
+	clientv2alpha3 "github.com/artemiscloud/activemq-artemis-operator/pkg/client/clientset/versioned/typed/broker/v2alpha3"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-//var log = logf.Log.WithName("addressobserver_v2alpha1activemqartemisaddress")
+//var log = logf.Log.WithName("addressobserver_v2alpha3activemqartemisaddress")
 
 const AnnotationStatefulSet = "statefulsets.kubernetes.io/drainer-pod-owner"
 const AnnotationDrainerPodTemplate = "statefulsets.kubernetes.io/drainer-pod-template"
@@ -41,16 +45,19 @@ type AddressObserver struct {
 	// kubeclientset is a standard kubernetes clientset
 	kubeclientset kubernetes.Interface
 	opclient      client.Client
+	opscheme      *runtime.Scheme
 }
 
 func NewAddressObserver(
 	kubeclientset kubernetes.Interface,
 	namespace string,
-	client client.Client) *AddressObserver {
+	client client.Client,
+	scheme *runtime.Scheme) *AddressObserver {
 
 	observer := &AddressObserver{
 		kubeclientset: kubeclientset,
 		opclient:      client,
+		opscheme:      scheme,
 	}
 
 	return observer
@@ -118,70 +125,96 @@ func (c *AddressObserver) newPodReady(ready *types.NamespacedName) {
 }
 
 func (c *AddressObserver) checkCRsForNewPod(newPod *corev1.Pod) {
-
-	cfg, err := clientcmd.BuildConfigFromFlags("", "")
-	if err != nil {
-		log.Error(err, "Error building kubeconfig: %s", err.Error())
-	}
-
-	brokerClient, err2 := clientv2alpha1.NewForConfig(cfg)
-	if err2 != nil {
-		log.Error(err2, "Error building brokerclient: %s", err2.Error())
-	}
-
-	addressInterface := brokerClient.ActiveMQArtemisAddresses((*newPod).Namespace)
-	result, listerr := addressInterface.List(metav1.ListOptions{})
-	if listerr != nil {
-		log.Error(listerr, "Failed to get address resources")
+	//get the address cr instances
+	addressInstances, err := c.getAddressInstances(newPod)
+	if err != nil || len(addressInstances.Items) == 0 {
+		log.Info("No available address CRs")
 		return
 	}
 
-	if len(result.Items) == 0 {
-		log.Info("No pre-installed CRs so nothing to do")
-		return
-	}
-
-	if ownerRef := metav1.GetControllerOf(newPod); ownerRef != nil {
-
-		podNamespacedName := types.NamespacedName{newPod.Name, newPod.Namespace}
-
-		sts := &appsv1.StatefulSet{}
-
-		err := c.opclient.Get(context.TODO(), types.NamespacedName{newPod.Namespace, ownerRef.Name}, sts)
-		if err != nil {
-			log.Error(err, "Error finding the statefulset")
+	// go over each address instance for the new pod
+	for _, a := range addressInstances.Items {
+		//get the target namespaces
+		targetCrNamespacedNames := createTargetCrNamespacedNames(newPod.Namespace, a.Spec.ApplyToCrNames)
+		//e.g. ex-aao-ss
+		podSSName, statefulset := c.getSSNameForPod(newPod)
+		log.Info("Got pod's ss name", "value", *podSSName)
+		if podSSName == nil {
+			log.Info("Can't find pod's statefulset name", "pod", newPod.Name)
+			continue
 		}
+		podCrName := namer.SSToCr(*podSSName)
+		log.Info("got pod's CR name", "value", podCrName)
+		//if the new pod is a target for this address cr, create
+		isTargetPod := false
+		if targetCrNamespacedNames == nil {
+			log.Info("The new pod is the target as the address CR doesn't have applyToCrNames specified.")
+			isTargetPod = true
+		} else {
 
-		containers := newPod.Spec.Containers
-		var jolokiaUser string
-		var jolokiaPassword string
-		if len(containers) == 1 {
-			envVars := containers[0].Env
-			for _, oneVar := range envVars {
-				if "AMQ_USER" == oneVar.Name {
-					jolokiaUser = getEnvVarValue(&oneVar, &podNamespacedName, sts, c.opclient)
-				}
-				if "AMQ_PASSWORD" == oneVar.Name {
-					jolokiaPassword = getEnvVarValue(&oneVar, &podNamespacedName, sts, c.opclient)
-				}
-				if jolokiaUser != "" && jolokiaPassword != "" {
+			newPodSSNamespacedName := types.NamespacedName{
+				Name:      podCrName,
+				Namespace: newPod.Namespace,
+			}
+			for _, ns := range targetCrNamespacedNames {
+				if ns == newPodSSNamespacedName {
+					log.Info("The new pod is the target", "namespace", ns)
+					isTargetPod = true
 					break
 				}
 			}
 		}
-
-		log.Info("New Jolokia with ", "User: ", jolokiaUser, "podIP: ", newPod.Status.PodIP)
-		artemis := mgmt.NewArtemis(newPod.Status.PodIP, "8161", "amq-broker", jolokiaUser, jolokiaPassword)
-
-		for _, a := range result.Items {
-			log.Info("Creating pre-installed address", "address", a.Spec.AddressName, "queue", a.Spec.QueueName, "routing type", a.Spec.RoutingType)
-
-			_, err := artemis.CreateQueue(a.Spec.AddressName, a.Spec.QueueName, a.Spec.RoutingType)
-			if nil != err {
-				log.Error(err, "Error creating address")
-			} else {
-				log.Info("Successfully Created ActiveMQArtemisAddress")
+		if isTargetPod {
+			podNamespacedName := types.NamespacedName{
+				Name:      newPod.Name,
+				Namespace: newPod.Namespace,
 			}
+			var jolokiaSecretName string = podCrName + "-jolokia-secret"
+			log.Info("Recreating address resources on new Pod", "Name", newPod.Name, "secret name", jolokiaSecretName)
+			jolokiaUser, jolokiaPassword, jolokiaProtocol := resolveJolokiaRequestParams(newPod.Namespace,
+				&a, c.opclient, c.opscheme, jolokiaSecretName, &newPod.Spec.Containers, podNamespacedName, statefulset)
+
+			log.Info("New Jolokia with ", "User: ", jolokiaUser, "Protocol: ", jolokiaProtocol)
+			artemis := mgmt.GetArtemis(newPod.Status.PodIP, "8161", "amq-broker", jolokiaUser, jolokiaPassword, jolokiaProtocol)
+			createAddressResource(artemis, &a)
 		}
 	}
+}
+
+func (c *AddressObserver) getSSNameForPod(newPod *corev1.Pod) (*string, *appsv1.StatefulSet) {
+
+	if ownerRef := metav1.GetControllerOf(newPod); ownerRef != nil {
+		sts := &appsv1.StatefulSet{}
+		err := c.opclient.Get(context.TODO(), types.NamespacedName{newPod.Namespace, ownerRef.Name}, sts)
+		if err != nil {
+			log.Error(err, "Error finding the statefulset")
+			return nil, nil
+		}
+		return &ownerRef.Name, sts
+	}
+	return nil, nil
+}
+
+func (c *AddressObserver) getAddressInstances(newPod *corev1.Pod) (*v2alpha3.ActiveMQArtemisAddressList, error) {
+
+	cfg, err := clientcmd.BuildConfigFromFlags("", "")
+	if err != nil {
+		//log error here
+		return nil, err
+	}
+
+	brokerClient, err2 := clientv2alpha3.NewForConfig(cfg)
+	if err2 != nil {
+		log.Error(err2, "Error building brokerclient: %s", err2.Error())
+		return nil, err2
+	}
+
+	addressInterface := brokerClient.ActiveMQArtemisAddresses(newPod.Namespace)
+	result, listerr := addressInterface.List(metav1.ListOptions{})
+	if listerr != nil {
+		log.Error(listerr, "Failed to get address resources")
+		return nil, listerr
+	}
+
+	return result, nil
 }

--- a/pkg/controller/broker/v2alpha3/activemqartemisaddress/queue_config.go
+++ b/pkg/controller/broker/v2alpha3/activemqartemisaddress/queue_config.go
@@ -3,6 +3,8 @@ package v2alpha3activemqartemisaddress
 import (
 	"encoding/json"
 	"strings"
+
+	brokerv2alpha3 "github.com/artemiscloud/activemq-artemis-operator/pkg/apis/broker/v2alpha3"
 )
 
 var defaultRoutingType string = "MULTICAST"
@@ -41,10 +43,10 @@ type ActiveMQArtemisQueueConfiguration struct {
 }
 
 // convert QueueConfiguration to json string
-func GetQueueConfig(instance *AddressDeployment) (string, bool, error) {
+func GetQueueConfig(addressRes *brokerv2alpha3.ActiveMQArtemisAddress) (string, bool, error) {
 	ignoreIfExists := false
-	addressSpec := instance.AddressResource.Spec
-	configSpec := instance.AddressResource.Spec.QueueConfiguration
+	addressSpec := addressRes.Spec
+	configSpec := addressRes.Spec.QueueConfiguration
 
 	if configSpec.IgnoreIfExists != nil {
 		ignoreIfExists = *configSpec.IgnoreIfExists

--- a/test/utils/namer/namer_test.go
+++ b/test/utils/namer/namer_test.go
@@ -1,0 +1,91 @@
+package namer_test
+
+import (
+	"testing"
+
+	"fmt"
+
+	"github.com/artemiscloud/activemq-artemis-operator/pkg/utils/namer"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestConfigUtils(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Namer Utils Suite")
+}
+
+var _ = BeforeSuite(func() {
+	fmt.Println("=======Before Config Suite========")
+})
+
+var _ = AfterSuite(func() {
+	fmt.Println("=======After Config Suite========")
+})
+
+var _ = Describe("Namer Util Test", func() {
+	Context("TestMatchPodNameAndStatefulSetName: match", func() {
+		podName := "ex-aao-ss-0"
+		podNamespace := "default"
+		ssName := "ex-aao-ss"
+		ssNamespace := "default"
+
+		It("Testing pod belonging to statefulset", func() {
+			podNamespacedName := types.NamespacedName{
+				Name:      podName,
+				Namespace: podNamespace,
+			}
+			ssNamespacedName := types.NamespacedName{
+				Name:      ssName,
+				Namespace: ssNamespace,
+			}
+			err, ok, podSerial := namer.PodBelongsToStatefulset(&podNamespacedName, &ssNamespacedName)
+			Expect(err).To(BeNil())
+			Expect(ok).To(BeTrue())
+			Expect(podSerial).To(Equal(0))
+		})
+	})
+	Context("TestMatchPodNameAndStatefulSetName: namespace mismatch", func() {
+		podName := "ex-aao-ss-0"
+		podNamespace := "default"
+		ssName := "ex-aao-ss"
+		ssNamespace := "another"
+
+		It("Testing different namespaces", func() {
+			podNamespacedName := types.NamespacedName{
+				Name:      podName,
+				Namespace: podNamespace,
+			}
+			ssNamespacedName := types.NamespacedName{
+				Name:      ssName,
+				Namespace: ssNamespace,
+			}
+			err, ok, podSerial := namer.PodBelongsToStatefulset(&podNamespacedName, &ssNamespacedName)
+			Expect(err).NotTo(BeNil())
+			Expect(ok).To(BeFalse())
+			Expect(podSerial).To(Equal(-1))
+		})
+	})
+	Context("TestMatchPodNameAndStatefulSetName: mismatch-different ss names", func() {
+		podName := "ex-aao-ss-0"
+		podNamespace := "default"
+		ssName := "ex-aao1-ss"
+		ssNamespace := "default"
+
+		It("Testing different statefulset name", func() {
+			podNamespacedName := types.NamespacedName{
+				Name:      podName,
+				Namespace: podNamespace,
+			}
+			ssNamespacedName := types.NamespacedName{
+				Name:      ssName,
+				Namespace: ssNamespace,
+			}
+			err, ok, podSerial := namer.PodBelongsToStatefulset(&podNamespacedName, &ssNamespacedName)
+			Expect(err).NotTo(BeNil())
+			Expect(ok).To(BeFalse())
+			Expect(podSerial).To(Equal(-1))
+		})
+	})
+})


### PR DESCRIPTION
  The handling for early-deployed address CRs is not up to date with
  the new changes in operator's multi-statefulset, multi-namespace
  support. Code is refactored in order to make it work.
Issue #108