### PR TITLE
Fixing CI -  Release Version 1.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         run: go get github.com/onsi/ginkgo/ginkgo && $(go env GOPATH)/bin/ginkgo ./...
 
       - name: Build the image
-        run: docker build --file ./build/Dockerfile --label \"quay.expires-after=1w\" --label \"git-sha=$GITHUB_SHA\" --tag $IMAGE_NAME:dev.latest .
+        run: docker build --label \"quay.expires-after=1w\" --label \"git-sha=$GITHUB_SHA\" --tag $IMAGE_NAME:dev.latest .
 
       - name: Execute the test suite
         uses: artemiscloud/activemq-artemis-operator-test-action@v1.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Build the image
-        run: docker build --file ./build/Dockerfile --tag $IMAGE_NAME:latest .
+        run: docker build --tag $IMAGE_NAME:latest .
 
       - name: Push the image
         run: >


### PR DESCRIPTION
Your Version 1.0.0 has not been released properly. The CI scripts still referenced build/Dockerfile but this has been moved to the repository root. Please merge and re release Version 1.0.0 as it is currently broken and can not be used ( Image is not available in the registry).