### PR TITLE
ENTMQBR-4468 Encrypting amq broker pod credentials from env variables

### DIFF
--- a/controllers/activemqartemis_reconciler.go
+++ b/controllers/activemqartemis_reconciler.go
@@ -757,16 +757,13 @@ func sourceEnvVarFromSecret2(fsm *ActiveMQArtemisFSM, currentStatefulSet *appsv1
 			Value:     "",
 			ValueFrom: acceptorsEnvVarSource,
 		}
-		if retrievedEnvVar := environments.Retrieve(currentStatefulSet.Spec.Template.Spec.Containers, envVarName); nil == retrievedEnvVar {
-			log.V(1).Info("sourceEnvVarFromSecret failed to retrieve " + envVarName + " creating")
-			environments.Create(currentStatefulSet.Spec.Template.Spec.Containers, envVarDefinition)
-			retVal = statefulSetAcceptorsUpdated
-		}
+
 		//custom init container
 		if len(currentStatefulSet.Spec.Template.Spec.InitContainers) > 0 {
 			log.Info("we have custom init-containers")
 			if retrievedEnvVar := environments.Retrieve(currentStatefulSet.Spec.Template.Spec.InitContainers, envVarName); nil == retrievedEnvVar {
 				environments.Create(currentStatefulSet.Spec.Template.Spec.InitContainers, envVarDefinition)
+				retVal = statefulSetAcceptorsUpdated
 			}
 		}
 	}

--- a/controllers/activemqartemisaddress_controller.go
+++ b/controllers/activemqartemisaddress_controller.go
@@ -349,7 +349,7 @@ func getPodBrokers(instance *AddressDeployment, request ctrl.Request, client cli
 					}
 				} else {
 					reqLogger.Info("Pod found", "Namespace", request.Namespace, "Name", request.Name)
-					containers := pod.Spec.Containers //get env from this
+					containers := pod.Spec.InitContainers //get env from this
 
 					jolokiaUser, jolokiaPassword, jolokiaProtocol := resolveJolokiaRequestParams(request.Namespace, &instance.AddressResource, client, scheme, jolokiaSecretName, &containers, podNamespacedName, statefulset, info.Labels)
 

--- a/controllers/address_observer.go
+++ b/controllers/address_observer.go
@@ -154,7 +154,7 @@ func (c *AddressObserver) checkCRsForNewPod(newPod *corev1.Pod, labels map[strin
 			var jolokiaSecretName string = podCrName + "-jolokia-secret"
 			olog.Info("Recreating address resources on new Pod", "Name", newPod.Name, "secret name", jolokiaSecretName)
 			jolokiaUser, jolokiaPassword, jolokiaProtocol := resolveJolokiaRequestParams(newPod.Namespace,
-				&a, c.opclient, c.opscheme, jolokiaSecretName, &newPod.Spec.Containers, podNamespacedName, statefulset, labels)
+				&a, c.opclient, c.opscheme, jolokiaSecretName, &newPod.Spec.InitContainers, podNamespacedName, statefulset, labels)
 
 			olog.Info("New Jolokia with ", "User: ", jolokiaUser, "Protocol: ", jolokiaProtocol)
 			artemis := mgmt.GetArtemis(newPod.Status.PodIP, "8161", "amq-broker", jolokiaUser, jolokiaPassword, jolokiaProtocol)


### PR DESCRIPTION
Instead of encrypt the credentials we can simply remove them from the
main container (they are used only in init container)
Issue #166