### PR TITLE
Added ENABLE_WEBHOOKS option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,8 +83,16 @@ help: ## Display this help.
 
 ##@ Development
 
-manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
+manifests: controller-gen kustomize
+ifeq ($(ENABLE_WEBHOOKS),true)
+## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
+	cd config/manager && $(KUSTOMIZE) edit add resource webhook_secret.yaml 
 	$(CONTROLLER_GEN) rbac:roleName=$(OPERATOR_CLUSTER_ROLE_NAME) crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+else
+## Generate ClusterRole and CustomResourceDefinition objects.
+	cd config/manager && $(KUSTOMIZE) edit remove resource webhook_secret.yaml 
+	$(CONTROLLER_GEN) rbac:roleName=$(OPERATOR_CLUSTER_ROLE_NAME) crd paths="./..." output:crd:artifacts:config=config/crd/bases
+endif
 
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -18,13 +18,13 @@ bases:
 - ../manager
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
-- ../webhook
+#- ../webhook
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
 #- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
 
-patchesStrategicMerge:
+#patchesStrategicMerge:
 # Protect the /metrics endpoint by putting it behind auth.
 # If you want your controller-manager to expose the /metrics
 # endpoint w/o any authn/z, please comment the following line.
@@ -36,7 +36,7 @@ patchesStrategicMerge:
 
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
-- manager_webhook_patch.yaml
+#- manager_webhook_patch.yaml
 
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
 # Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
@@ -44,7 +44,7 @@ patchesStrategicMerge:
 #- webhookcainjection_patch.yaml
 
 # the following config is for teaching kustomize how to do var substitution
-vars:
+#vars:
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
 #- name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
 #  objref:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -73,6 +73,8 @@ spec:
           value: quay.io/artemiscloud/activemq-artemis-broker-kubernetes:0.2.7
         - name: RELATED_IMAGE_ActiveMQ_Artemis_Broker_Kubernetes_2200
           value: quay.io/artemiscloud/activemq-artemis-broker-kubernetes:0.2.9
+        - name: ENABLE_WEBHOOKS
+          value: "false"
         image: controller:latest
         # imagePullPolicy: Always
         name: manager

--- a/main.go
+++ b/main.go
@@ -232,19 +232,25 @@ func main() {
 		os.Exit(1)
 	}
 
-	log.Info("Setting up webhook functions")
-	if err = (&brokerv1beta1.ActiveMQArtemis{}).SetupWebhookWithManager(mgr); err != nil {
-		log.Error(err, "unable to create webhook", "webhook", "ActiveMQArtemis")
-		os.Exit(1)
+	enableWebhooks := os.Getenv("ENABLE_WEBHOOKS")
+	if enableWebhooks != "false" {
+		log.Info("Setting up webhook functions", "ENABLE_WEBHOOKS", enableWebhooks)
+		if err = (&brokerv1beta1.ActiveMQArtemis{}).SetupWebhookWithManager(mgr); err != nil {
+			log.Error(err, "unable to create webhook", "webhook", "ActiveMQArtemis")
+			os.Exit(1)
+		}
+		if err = (&brokerv1beta1.ActiveMQArtemisSecurity{}).SetupWebhookWithManager(mgr); err != nil {
+			log.Error(err, "unable to create webhook", "webhook", "ActiveMQArtemisSecurity")
+			os.Exit(1)
+		}
+		if err = (&brokerv1beta1.ActiveMQArtemisAddress{}).SetupWebhookWithManager(mgr); err != nil {
+			log.Error(err, "unable to create webhook", "webhook", "ActiveMQArtemisAddress")
+			os.Exit(1)
+		}
+	} else {
+		log.Info("NOT Setting up webhook functions", "ENABLE_WEBHOOKS", enableWebhooks)
 	}
-	if err = (&brokerv1beta1.ActiveMQArtemisSecurity{}).SetupWebhookWithManager(mgr); err != nil {
-		log.Error(err, "unable to create webhook", "webhook", "ActiveMQArtemisSecurity")
-		os.Exit(1)
-	}
-	if err = (&brokerv1beta1.ActiveMQArtemisAddress{}).SetupWebhookWithManager(mgr); err != nil {
-		log.Error(err, "unable to create webhook", "webhook", "ActiveMQArtemisAddress")
-		os.Exit(1)
-	}
+
 	//+kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {


### PR DESCRIPTION
Initial take at utilizing ENABLE_WEBHOOKS env var both at runtime and at build time. Not a full usage throughout however as some sections in the config/default/kustomization.yaml are commented out without an obvious way to use the kustomize tool to manipulate them even though the bases could be modified. Note that if kustomize edit add/remove base is used it removes the following commented entries which includes the [WEBHOOK] and [CERT-MANAGER] required sections.

Behaviour by default is to transparently apply ENABLE_WEBHOOKS=false at both build and runtime, i.e. you should be able to build, deploy and run without webhooks WITHOUT specifying ENABLE_WEBHOOKS manually.