### PR TITLE
#146 Write the deployed yaml resources to separate yaml files

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -16,6 +16,7 @@ rules:
   - pods
   - routes
   - secrets
+  - serviceaccounts
   - services
   verbs:
   - '*'
@@ -168,6 +169,15 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  - roles
+  verbs:
+  - create
+  - delete
+  - get
 - apiGroups:
   - route.openshift.io
   resources:

--- a/controllers/activemqartemis_controller.go
+++ b/controllers/activemqartemis_controller.go
@@ -105,13 +105,14 @@ type ActiveMQArtemisReconciler struct {
 //+kubebuilder:rbac:groups=broker.amq.io,resources=activemqartemises/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=broker.amq.io,resources=activemqartemises/finalizers,verbs=update
 //+kubebuilder:rbac:groups=broker.amq.io,resources=pods,verbs=get;list
-//+kubebuilder:rbac:groups="",resources=pods;services;endpoints;persistentvolumeclaims;events;configmaps;secrets;routes,verbs=*
+//+kubebuilder:rbac:groups="",resources=pods;services;endpoints;persistentvolumeclaims;events;configmaps;secrets;routes;serviceaccounts,verbs=*
 //+kubebuilder:rbac:groups="",resources=namespaces,verbs=get
 //+kubebuilder:rbac:groups=apps,resources=deployments;daemonsets;replicasets;statefulsets,verbs=*
 //+kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list;watch;create;delete
 //+kubebuilder:rbac:groups=route.openshift.io,resources=routes;routes/custom-host;routes/status,verbs=get;list;watch;create;delete;update
 //+kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors,verbs=get;create
 //+kubebuilder:rbac:groups=apps,resources=deployments/finalizers,verbs=update
+//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings,verbs=create;get;delete
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,75 @@
+# What are these yaml files
+
+The yaml files in this directory are resource files necessary to manually deploy an operator.
+They are generated from the *generate-deploy* make target.
+
+## Note ##
+
+If you have changed the CRD definitions or any other config resources, you need to regenerate these yamls
+by run the following command from the project root.
+
+```
+make generate-deploy
+```
+
+# How to use the yamls in this dir to deploy an operator
+
+## To deploy an operator watching single namespace (operator's namespace)
+
+Assuming the target namespace is current namespace (if not use kubectl's -n option to specify the target namespace)
+
+1. Deploy all the crds
+```
+kubectl create -f ./crds
+```
+
+2. Deploy operator
+
+You need to deploy all the yamls from this dir except *cluster_role.yaml* and *cluster_role_binding.yaml*:
+```
+kubectl create -f ./deploy/service_account.yaml
+kubectl create -f ./deploy/role.yaml
+kubectl create -f ./deploy/role_binding.yaml
+kubectl create -f ./deploy/election_role.yaml
+kubectl create -f ./deploy/election_role_binding.yaml
+kubectl create -f ./deploy/operator_config.yaml
+kubectl create -f ./deploy/operator.yaml
+```
+
+## To deploy an operator watching all namespace
+
+The steps are similar to those for single namespace operators except that you replace the *role.yaml* and *role_binding.yaml* with *cluster_role.yaml* and *cluster_role_binding.yaml* respectively.
+
+**Note**
+Before deploy, you should edit operator.yaml and change the **WATCH_NAMESPACE** env var value to be empty string
+and also change the subjects namespace to match your target namespace in cluster_role_binding.yaml
+as illustrated in following
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: activemq-artemis-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: activemq-artemis-activemq-artemis-operator
+subjects:
+- kind: ServiceAccount
+  name: activemq-artemis-controller-manager
+  namespace: <<This must match your operator's target namespace>>
+```
+
+After making the above changes deploy the operator as follows
+(Assuming the target namespace is current namespace. You can use kubectl's -n option to specify otherwise)
+
+```
+kubectl create -f ./deploy/crds
+kubectl create -f ./deploy/service_account.yaml
+kubectl create -f ./deploy/cluster_role.yaml
+kubectl create -f ./deploy/cluster_role_binding.yaml
+kubectl create -f ./deploy/election_role.yaml
+kubectl create -f ./deploy/election_role_binding.yaml
+kubectl create -f ./deploy/operator_config.yaml
+kubectl create -f ./deploy/operator.yaml
+```

--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -1,0 +1,191 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: activemq-artemis-activemq-artemis-operator
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - endpoints
+  - events
+  - persistentvolumeclaims
+  - pods
+  - routes
+  - secrets
+  - serviceaccounts
+  - services
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - apps
+  resources:
+  - deployments/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - broker.amq.io
+  resources:
+  - activemqartemisaddresses
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - broker.amq.io
+  resources:
+  - activemqartemisaddresses/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - broker.amq.io
+  resources:
+  - activemqartemisaddresses/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - broker.amq.io
+  resources:
+  - activemqartemises
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - broker.amq.io
+  resources:
+  - activemqartemises/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - broker.amq.io
+  resources:
+  - activemqartemises/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - broker.amq.io
+  resources:
+  - activemqartemisscaledowns
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - broker.amq.io
+  resources:
+  - activemqartemisscaledowns/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - broker.amq.io
+  resources:
+  - activemqartemisscaledowns/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - broker.amq.io
+  resources:
+  - activemqartemissecurities
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - broker.amq.io
+  resources:
+  - activemqartemissecurities/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - broker.amq.io
+  resources:
+  - activemqartemissecurities/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - broker.amq.io
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - create
+  - get
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  - roles
+  verbs:
+  - create
+  - delete
+  - get
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  - routes/custom-host
+  - routes/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch

--- a/deploy/cluster_role_binding.yaml
+++ b/deploy/cluster_role_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: activemq-artemis-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: activemq-artemis-activemq-artemis-operator
+subjects:
+- kind: ServiceAccount
+  name: activemq-artemis-controller-manager
+  namespace: activemq-artemis-operator

--- a/deploy/crds/broker_activemqartemis_crd.yaml
+++ b/deploy/crds/broker_activemqartemis_crd.yaml
@@ -1,0 +1,2683 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.7.0
+  name: activemqartemises.broker.amq.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUdpekNDQkhPZ0F3SUJBZ0lVWXh6UkpyemJuUnFBUDhqQ1pETnA5QlRFMW5Zd0RRWUpLb1pJaHZjTkFRRUwKQlFBd2dhc3hDekFKQmdOVkJBWVRBbFZUTVJNd0VRWURWUVFJREFwRFlXeHBabTl5Ym1saE1SUXdFZ1lEVlFRSApEQXRNYjNNZ1FXNW5aV3hsY3pFVk1CTUdBMVVFQ2d3TVFYSjBaVzFwYzBOc2IzVmtNUkV3RHdZRFZRUUxEQWhQCmNHVnlZWFJ2Y2pGSE1FVUdBMVVFQXd3K1lXTjBhWFpsYlhFdFlYSjBaVzFwY3kxM1pXSm9iMjlyTFhObGNuWnAKWTJVdVlXTjBhWFpsYlhFdFlYSjBaVzFwY3kxdmNHVnlZWFJ2Y2k1emRtTXdIaGNOTWpFeE1qSTBNVE0xTXpBegpXaGNOTXpFeE1qSXlNVE0xTXpBeldqQ0JxekVMTUFrR0ExVUVCaE1DVlZNeEV6QVJCZ05WQkFnTUNrTmhiR2xtCmIzSnVhV0V4RkRBU0JnTlZCQWNNQzB4dmN5QkJibWRsYkdWek1SVXdFd1lEVlFRS0RBeEJjblJsYldselEyeHYKZFdReEVUQVBCZ05WQkFzTUNFOXdaWEpoZEc5eU1VY3dSUVlEVlFRRERENWhZM1JwZG1WdGNTMWhjblJsYldsegpMWGRsWW1odmIyc3RjMlZ5ZG1salpTNWhZM1JwZG1WdGNTMWhjblJsYldsekxXOXdaWEpoZEc5eUxuTjJZekNDCkFpSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnSVBBRENDQWdvQ2dnSUJBS3VRT0Y0aHdLK0xRejJnRGZ3aENQczAKeTJVVXp3SmN5SVhWY1VDeElXNDhMeWw1NXdvZkZhWmk1MHRyRisxUzM0OVAvNHFieDZQQVlmbk53Z0gvZmxKNQpXaFZoTG5DTFVrUjZYS3N0WWZIVjZBcW5BSlNXYWZPR2lGb2JHWVI4L1ZrdytKK3dCZHlGamRRc3NDNHczL0J1Cms2U3dLOFVEOFFFa1BKMGpyWHdPNkxvZnRxcVloWmd6N2poTEQxcXkyTDJmTFV6TVh0bEtReHI1Z2FNMzQwZ0cKaU9oNS96SGE1WmNsNXNMSzlRMlRtSk4vMVZGQjNNK2RzOEEreG1oS0pOSVNYaHMzRkpha2FYM05kQ2R4SVdYRQorOUtVU1BteXFKMmFaVEVlUHY2cXpCcVJOSlB6TjFhWURNZitFS2wwZ09hOG9NUzNVQVc3azRyZ2pNVWJ5dVFMCkExb0poVEdQcThiZWEwYUNGK1VaUCtEWFQ1YVJ3UWI4WCt1dWdqSFV4WGkrVndpUnJ1bXFFNWJlZ1kyK0h2Z1EKQWRNM0tSaTBVYVR2UXA4ajJUUG5pMVRCK0FYdmxlNjZwMFp3NE5HcWpaQTdVZGdTZlNBQzkxT1B5bnE0T0QvdQowYnloZVFFTjUvVmtJVzE4UVV6TkMxMVBFWmhFOXhXQ0JvdnEvSytEMjRNcllEb3MrQm84blFSY3c5UjN4ZW8vCmJpd3o2dXlVamJSUEgreStzVlJXeXhsdUNnRnVMdFVuMFlyZTE3Q1FQZnp3aXRNaStZWjhBb3ZYeHZZSlhFSm0KSE9nbzdqOFpFWVlTWDNCNS9GOVoyei9hSlJtc3dTUHVrT0RtZ0REZEJDWURZNk1ya1BYVTZocS8rYmtQcGZJbQp0N05sSHB3N0RuOEYzRzNDdjRBWEFnTUJBQUdqZ2FRd2dhRXdDd1lEVlIwUEJBUURBZ1F3TUJNR0ExVWRKUVFNCk1Bb0dDQ3NHQVFVRkJ3TUJNSDBHQTFVZEVRUjJNSFNDUG1GamRHbDJaVzF4TFdGeWRHVnRhWE10ZDJWaWFHOXYKYXkxelpYSjJhV05sTG1GamRHbDJaVzF4TFdGeWRHVnRhWE10YjNCbGNtRjBiM0l1YzNaamdqSmhiWEV0WW5KdgphMlZ5TFhkbFltaHZiMnN0YzJWeWRtbGpaUzVoYlhFdFluSnZhMlZ5TFc5d1pYSmhkRzl5TG5OMll6QU5CZ2txCmhraUc5dzBCQVFzRkFBT0NBZ0VBU0ZqT1NyMWVaVzh5dlpXTkx0L0hXaU1TK0E3MlNTODkySnhlTlZCTTNEVWUKMEVrSllnaXk1QzJqaWN6WFdLWXl4ZUo2TDdIVWwzNmZRbFptOC9Ea1NETUlrOTByd1dFWE45RUdIRUpIdEN0WAo0L0l4elJsTVJYK1Ric3FJZFF3SjlpNkFtVjBqaUdlcFpEOStpTi9nL2pYT2NSSFAza3dFVWkxcG9Uc3E5ZkZ0ClRtYU9HYjRZeXN5dWx4S1VtcTlDU1NpbkpNeW01S2o0cUFJSEVDS2RaaTg4b2JUeHl6b1VvY1RNeWw5ZXdTU0UKZDQrakRiWTBQWEc5OXpCZ0FKbjVSSEs3Qm0yL1N0MnNZMy9xUWhsbVZSTWg4eU9sZk9OVDc0WlRJSlFvZDljVwpZOHdqMGY4dmx5VVFreGd6OHZyTVpSV3kvNHhhazViTWw0NkE2SEk4SWJ6eldXaEUwTVdPWkprR1MxMHo1dVdHCkNMYyswdHJVcHprNWFoNXU5QVZZQXhYNUlKeDIxdVBYUnUydmZ6VDBYOE9kNkF1SXd3djFLUUxpSFBNWG9sTysKdjhKejNlZEhVMDBlajFPeGN3OGkzbVNyUDVKNVlONkQrdUFhVWtWNTZzMlk0SlNiME41a0kyT2tRNjMwbGRZUApROGNxQVBRczFwODRuK2xveVVrWnZsSUdkNVVYSTZuWXFNTFQ4dGZoVGFzQVNuOW4zREtGRGJ3VE85eG01bldWCjlrZk1HVWdHNWVoLzFVZmxQWlA4UmhkVTlVbjZob1dla3doMkMzTnZTUFhZL1l0ZHVKK295ZjJ2QTdQMXdHSzMKdjJVRDIwL09YUnZxd2dTUlBVOHVtK3NxU0Rab0NKeWxFZXZ4aHFmZXFzUk5vdDAwNGJPY2ZjQlUydnpnR0wwPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
+        service:
+          name: webhook-service
+          namespace: activemq-artemis-operator
+          path: /convert
+      conversionReviewVersions:
+      - v1beta1
+      - v2alpha5
+      - v2alpha4
+      - v2alpha3
+  group: broker.amq.io
+  names:
+    kind: ActiveMQArtemis
+    listKind: ActiveMQArtemisList
+    plural: activemqartemises
+    singular: activemqartemis
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: ActiveMQArtemis is the Schema for the activemqartemises API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ActiveMQArtemisSpec defines the desired state of ActiveMQArtemis
+            properties:
+              acceptors:
+                description: Acceptor configuration
+                items:
+                  properties:
+                    amqpMinLargeMessageSize:
+                      description: AMQP Minimum Large Message Size
+                      type: integer
+                    anycastPrefix:
+                      description: To indicate which kind of routing type to use.
+                      type: string
+                    bindToAllInterfaces:
+                      description: Whether to let the acceptor to bind to all interfaces (0.0.0.0)
+                      type: boolean
+                    connectionsAllowed:
+                      description: Max number of connections allowed to make
+                      type: integer
+                    enabledCipherSuites:
+                      description: Comma separated list of cipher suites used for SSL communication.
+                      type: string
+                    enabledProtocols:
+                      description: Comma separated list of protocols used for SSL communication.
+                      type: string
+                    expose:
+                      description: Whether or not to expose this acceptor
+                      type: boolean
+                    multicastPrefix:
+                      description: To indicate which kind of routing type to use
+                      type: string
+                    name:
+                      type: string
+                    needClientAuth:
+                      description: Tells a client connecting to this acceptor that 2-way SSL is required. This property takes precedence over wantClientAuth.
+                      type: boolean
+                    port:
+                      description: Port number
+                      format: int32
+                      type: integer
+                    protocols:
+                      description: The protocols to enable for this acceptor
+                      type: string
+                    sniHost:
+                      description: A regular expression used to match the server_name extension on incoming SSL connections. If the name doesn't match then the connection to the acceptor will be rejected.
+                      type: string
+                    sslEnabled:
+                      description: Whether or not to enable SSL on this port
+                      type: boolean
+                    sslProvider:
+                      description: Used to change the SSL Provider between JDK and OPENSSL. The default is JDK.
+                      type: string
+                    sslSecret:
+                      description: Name of the secret to use for ssl information
+                      type: string
+                    supportAdvisory:
+                      description: For openwire protocol if advisory topics are enabled, default false
+                      type: boolean
+                    suppressInternalManagementObjects:
+                      description: If prevents advisory addresses/queues to be registered to management service, default false
+                      type: boolean
+                    verifyHost:
+                      description: The CN of the connecting client's SSL certificate will be compared to its hostname to verify they match. This is useful only for 2-way SSL.
+                      type: boolean
+                    wantClientAuth:
+                      description: Tells a client connecting to this acceptor that 2-way SSL is requested but not required. Overridden by needClientAuth.
+                      type: boolean
+                  required:
+                  - name
+                  type: object
+                type: array
+              addressSettings:
+                properties:
+                  addressSetting:
+                    items:
+                      properties:
+                        addressFullPolicy:
+                          description: what happens when an address where maxSizeBytes is specified becomes full
+                          type: string
+                        autoCreateAddresses:
+                          description: whether or not to automatically create addresses when a client sends a message to or attempts to consume a message from a queue mapped to an address that doesnt exist
+                          type: boolean
+                        autoCreateDeadLetterResources:
+                          description: whether or not to automatically create the dead-letter-address and/or a corresponding queue on that address when a message found to be undeliverable
+                          type: boolean
+                        autoCreateExpiryResources:
+                          description: whether or not to automatically create the expiry-address and/or a corresponding queue on that address when a message is sent to a matching queue
+                          type: boolean
+                        autoCreateJmsQueues:
+                          description: DEPRECATED. whether or not to automatically create JMS queues when a producer sends or a consumer connects to a queue
+                          type: boolean
+                        autoCreateJmsTopics:
+                          description: DEPRECATED. whether or not to automatically create JMS topics when a producer sends or a consumer subscribes to a topic
+                          type: boolean
+                        autoCreateQueues:
+                          description: whether or not to automatically create a queue when a client sends a message to or attempts to consume a message from a queue
+                          type: boolean
+                        autoDeleteAddresses:
+                          description: whether or not to delete auto-created addresses when it no longer has any queues
+                          type: boolean
+                        autoDeleteAddressesDelay:
+                          description: how long to wait (in milliseconds) before deleting auto-created addresses after they no longer have any queues
+                          format: int32
+                          type: integer
+                        autoDeleteCreatedQueues:
+                          description: whether or not to delete created queues when the queue has 0 consumers and 0 messages
+                          type: boolean
+                        autoDeleteJmsQueues:
+                          description: DEPRECATED. whether or not to delete auto-created JMS queues when the queue has 0 consumers and 0 messages
+                          type: boolean
+                        autoDeleteJmsTopics:
+                          description: DEPRECATED. whether or not to delete auto-created JMS topics when the last subscription is closed
+                          type: boolean
+                        autoDeleteQueues:
+                          description: whether or not to delete auto-created queues when the queue has 0 consumers and 0 messages
+                          type: boolean
+                        autoDeleteQueuesDelay:
+                          description: how long to wait (in milliseconds) before deleting auto-created queues after the queue has 0 consumers.
+                          format: int32
+                          type: integer
+                        autoDeleteQueuesMessageCount:
+                          description: the message count the queue must be at or below before it can be evaluated to be auto deleted, 0 waits until empty queue (default) and -1 disables this check.
+                          format: int32
+                          type: integer
+                        configDeleteAddresses:
+                          description: What to do when an address is no longer in broker.xml.  OFF = will do nothing addresses will remain, FORCE = delete address and its queues even if messages remaining.
+                          type: string
+                        configDeleteQueues:
+                          description: What to do when a queue is no longer in broker.xml.  OFF = will do nothing queues will remain, FORCE = delete queues even if messages remaining.
+                          type: string
+                        deadLetterAddress:
+                          description: the address to send dead messages to
+                          type: string
+                        deadLetterQueuePrefix:
+                          description: the prefix to use for auto-created dead letter queues
+                          type: string
+                        deadLetterQueueSuffix:
+                          description: the suffix to use for auto-created dead letter queues
+                          type: string
+                        defaultAddressRoutingType:
+                          description: the routing-type used on auto-created addresses
+                          type: string
+                        defaultConsumerWindowSize:
+                          description: the default window size for a consumer
+                          format: int32
+                          type: integer
+                        defaultConsumersBeforeDispatch:
+                          description: the default number of consumers needed before dispatch can start for queues under the address.
+                          format: int32
+                          type: integer
+                        defaultDelayBeforeDispatch:
+                          description: the default delay (in milliseconds) to wait before dispatching if number of consumers before dispatch is not met for queues under the address.
+                          format: int32
+                          type: integer
+                        defaultExclusiveQueue:
+                          description: whether to treat the queues under the address as exclusive queues by default
+                          type: boolean
+                        defaultGroupBuckets:
+                          description: number of buckets to use for grouping, -1 (default) is unlimited and uses the raw group, 0 disables message groups.
+                          format: int32
+                          type: integer
+                        defaultGroupFirstKey:
+                          description: key used to mark a message is first in a group for a consumer
+                          type: string
+                        defaultGroupRebalance:
+                          description: whether to rebalance groups when a consumer is added
+                          type: boolean
+                        defaultGroupRebalancePauseDispatch:
+                          description: whether to pause dispatch when rebalancing groups
+                          type: boolean
+                        defaultLastValueKey:
+                          description: the property to use as the key for a last value queue by default
+                          type: string
+                        defaultLastValueQueue:
+                          description: whether to treat the queues under the address as a last value queues by default
+                          type: boolean
+                        defaultMaxConsumers:
+                          description: the maximum number of consumers allowed on this queue at any one time
+                          format: int32
+                          type: integer
+                        defaultNonDestructive:
+                          description: whether the queue should be non-destructive by default
+                          type: boolean
+                        defaultPurgeOnNoConsumers:
+                          description: purge the contents of the queue once there are no consumers
+                          type: boolean
+                        defaultQueueRoutingType:
+                          description: the routing-type used on auto-created queues
+                          type: string
+                        defaultRingSize:
+                          description: the default ring-size value for any matching queue which doesnt have ring-size explicitly defined
+                          format: int32
+                          type: integer
+                        enableIngressTimestamp:
+                          description: Whether or not set the timestamp of arrival on messages. default false
+                          type: boolean
+                        enableMetrics:
+                          description: whether or not to enable metrics for metrics plugins on the matching address
+                          type: boolean
+                        expiryAddress:
+                          description: the address to send expired messages to
+                          type: string
+                        expiryDelay:
+                          description: Overrides the expiration time for messages using the default value for expiration time. "-1" disables this setting.
+                          format: int32
+                          type: integer
+                        expiryQueuePrefix:
+                          description: the prefix to use for auto-created expiry queues
+                          type: string
+                        expiryQueueSuffix:
+                          description: the suffix to use for auto-created expiry queues
+                          type: string
+                        lastValueQueue:
+                          description: This is deprecated please use default-last-value-queue instead.
+                          type: boolean
+                        managementBrowsePageSize:
+                          description: how many message a management resource can browse
+                          format: int32
+                          type: integer
+                        managementMessageAttributeSizeLimit:
+                          description: max size of the message returned from management API, default 256
+                          format: int32
+                          type: integer
+                        match:
+                          description: pattern for matching settings against addresses; can use wildards
+                          type: string
+                        maxDeliveryAttempts:
+                          description: how many times to attempt to deliver a message before sending to dead letter address
+                          format: int32
+                          type: integer
+                        maxExpiryDelay:
+                          description: Overrides the expiration time for messages using a higher value. "-1" disables this setting.
+                          format: int32
+                          type: integer
+                        maxRedeliveryDelay:
+                          description: Maximum value for the redelivery-delay
+                          format: int32
+                          type: integer
+                        maxSizeBytes:
+                          description: the maximum size in bytes for an address. -1 means no limits. This is used in PAGING, BLOCK and FAIL policies. Supports byte notation like K, Mb, GB, etc.
+                          type: string
+                        maxSizeBytesRejectThreshold:
+                          description: used with the address full BLOCK policy, the maximum size in bytes an address can reach before messages start getting rejected. Works in combination with max-size-bytes for AMQP protocol only.  Default = -1 (no limit).
+                          format: int32
+                          type: integer
+                        messageCounterHistoryDayLimit:
+                          description: how many days to keep message counter history for this address
+                          format: int32
+                          type: integer
+                        minExpiryDelay:
+                          description: Overrides the expiration time for messages using a lower value. "-1" disables this setting.
+                          format: int32
+                          type: integer
+                        pageMaxCacheSize:
+                          description: Number of paging files to cache in memory to avoid IO during paging navigation
+                          format: int32
+                          type: integer
+                        pageSizeBytes:
+                          description: The page size in bytes to use for an address. Supports byte notation like K, Mb, GB, etc.
+                          type: string
+                        redeliveryCollisionAvoidanceFactor:
+                          description: factor by which to modify the redelivery delay slightly to avoid collisions
+                          type: string
+                        redeliveryDelay:
+                          description: the time (in ms) to wait before redelivering a cancelled message.
+                          format: int32
+                          type: integer
+                        redeliveryDelayMultiplier:
+                          description: multiplier to apply to the redelivery-delay
+                          type: string
+                        redistributionDelay:
+                          description: how long (in ms) to wait after the last consumer is closed on a queue before redistributing messages.
+                          format: int32
+                          type: integer
+                        retroactiveMessageCount:
+                          description: the number of messages to preserve for future queues created on the matching address
+                          format: int32
+                          type: integer
+                        sendToDlaOnNoRoute:
+                          description: if there are no queues matching this address, whether to forward message to DLA (if it exists for this address)
+                          type: boolean
+                        slowConsumerCheckPeriod:
+                          description: How often to check for slow consumers on a particular queue. Measured in seconds.
+                          format: int32
+                          type: integer
+                        slowConsumerPolicy:
+                          description: what happens when a slow consumer is identified
+                          type: string
+                        slowConsumerThreshold:
+                          description: The minimum rate of message consumption allowed before a consumer is considered "slow." Measured in messages-per-second.
+                          format: int32
+                          type: integer
+                        slowConsumerThresholdMeasurementUnit:
+                          description: Unit used in specifying slow consumer threshold, default is MESSAGE_PER_SECOND
+                          type: string
+                      type: object
+                    type: array
+                  applyRule:
+                    description: How to merge the address settings to broker configuration
+                    type: string
+                type: object
+              adminPassword:
+                description: Password for standard broker user. It is required for connecting to the broker and the web console. If left empty, it will be generated.
+                type: string
+              adminUser:
+                description: User name for standard broker user. It is required for connecting to the broker and the web console. If left empty, it will be generated.
+                type: string
+              brokerProperties:
+                additionalProperties:
+                  type: string
+                type: object
+              connectors:
+                items:
+                  properties:
+                    enabledCipherSuites:
+                      description: Comma separated list of cipher suites used for SSL communication.
+                      type: string
+                    enabledProtocols:
+                      description: Comma separated list of protocols used for SSL communication.
+                      type: string
+                    expose:
+                      description: Whether or not to expose this connector
+                      type: boolean
+                    host:
+                      description: Hostname or IP to connect to
+                      type: string
+                    name:
+                      description: The name of the connector
+                      type: string
+                    needClientAuth:
+                      description: Tells a client connecting to this connector that 2-way SSL is required. This property takes precedence over wantClientAuth.
+                      type: boolean
+                    port:
+                      description: Port number
+                      format: int32
+                      type: integer
+                    sniHost:
+                      description: A regular expression used to match the server_name extension on incoming SSL connections. If the name doesn't match then the connection to the acceptor will be rejected.
+                      type: string
+                    sslEnabled:
+                      description: ' Whether or not to enable SSL on this port'
+                      type: boolean
+                    sslProvider:
+                      description: Used to change the SSL Provider between JDK and OPENSSL. The default is JDK.
+                      type: string
+                    sslSecret:
+                      description: Name of the secret to use for ssl information
+                      type: string
+                    type:
+                      description: The type either tcp or vm
+                      type: string
+                    verifyHost:
+                      description: The CN of the connecting client's SSL certificate will be compared to its hostname to verify they match. This is useful only for 2-way SSL.
+                      type: boolean
+                    wantClientAuth:
+                      description: Tells a client connecting to this connector that 2-way SSL is requested but not required. Overridden by needClientAuth.
+                      type: boolean
+                  required:
+                  - host
+                  - name
+                  - port
+                  type: object
+                type: array
+              console:
+                properties:
+                  expose:
+                    description: Whether or not to expose this port
+                    type: boolean
+                  sslEnabled:
+                    description: Whether or not to enable SSL on this port
+                    type: boolean
+                  sslSecret:
+                    description: Name of the secret to use for ssl information
+                    type: string
+                  useClientAuth:
+                    description: If the embedded server requires client authentication
+                    type: boolean
+                type: object
+              deploymentPlan:
+                properties:
+                  affinity:
+                    description: custom Affinity
+                    properties:
+                      nodeAffinity:
+                        description: Describes node affinity scheduling rules for the pod.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                              properties:
+                                preference:
+                                  description: A node selector term, associated with the corresponding weight.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements by node's labels.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements by node's fields.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                weight:
+                                  description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - preference
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                            properties:
+                              nodeSelectorTerms:
+                                description: Required. A list of node selector terms. The terms are ORed.
+                                items:
+                                  description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements by node's labels.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements by node's fields.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                type: array
+                            required:
+                            - nodeSelectorTerms
+                            type: object
+                        type: object
+                      podAffinity:
+                        description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaceSelector:
+                                      description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources, in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                      podAntiAffinity:
+                        description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaceSelector:
+                                      description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources, in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  clustered:
+                    description: Whether broker is clustered
+                    type: boolean
+                  enableMetricsPlugin:
+                    description: Whether or not to install the artemis metrics plugin
+                    type: boolean
+                  extraMounts:
+                    properties:
+                      configMaps:
+                        description: Name of ConfigMap
+                        items:
+                          type: string
+                        type: array
+                      secrets:
+                        description: Name of Secret
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  image:
+                    description: The image used for the broker deployment
+                    type: string
+                  initImage:
+                    description: The init container image used to configure broker
+                    type: string
+                  jolokiaAgentEnabled:
+                    description: If true enable the Jolokia JVM Agent
+                    type: boolean
+                  journalType:
+                    description: If aio use ASYNCIO, if nio use NIO for journal IO
+                    type: string
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: custom labels provided in the cr
+                    type: object
+                  livenessProbe:
+                    description: Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.
+                    properties:
+                      exec:
+                        description: One and only one of the following should be specified. Exec specifies the action to take.
+                        properties:
+                          command:
+                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      failureThreshold:
+                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      httpGet:
+                        description: HTTPGet specifies the http request to perform.
+                        properties:
+                          host:
+                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                            type: string
+                          httpHeaders:
+                            description: Custom headers to set in the request. HTTP allows repeated headers.
+                            items:
+                              description: HTTPHeader describes a custom header to be used in HTTP probes
+                              properties:
+                                name:
+                                  description: The header field name
+                                  type: string
+                                value:
+                                  description: The header field value
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                          path:
+                            description: Path to access on the HTTP server.
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                          scheme:
+                            description: Scheme to use for connecting to the host. Defaults to HTTP.
+                            type: string
+                        required:
+                        - port
+                        type: object
+                      initialDelaySeconds:
+                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                      periodSeconds:
+                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      successThreshold:
+                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      tcpSocket:
+                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                        properties:
+                          host:
+                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                        required:
+                        - port
+                        type: object
+                      terminationGracePeriodSeconds:
+                        description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                        format: int64
+                        type: integer
+                      timeoutSeconds:
+                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                    type: object
+                  managementRBACEnabled:
+                    description: If true enable the management role based access control
+                    type: boolean
+                  messageMigration:
+                    description: If true migrate messages on scaledown
+                    type: boolean
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: custom node selector
+                    type: object
+                  persistenceEnabled:
+                    description: If true use persistent volume via persistent volume claim for journal storage
+                    type: boolean
+                  podSecurity:
+                    properties:
+                      runAsUser:
+                        description: runAsUser as defined in PodSecurityContext for the pod
+                        format: int64
+                        type: integer
+                      serviceAccountName:
+                        description: ServiceAccount Name of the pod
+                        type: string
+                    type: object
+                  readinessProbe:
+                    description: Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.
+                    properties:
+                      exec:
+                        description: One and only one of the following should be specified. Exec specifies the action to take.
+                        properties:
+                          command:
+                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      failureThreshold:
+                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      httpGet:
+                        description: HTTPGet specifies the http request to perform.
+                        properties:
+                          host:
+                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                            type: string
+                          httpHeaders:
+                            description: Custom headers to set in the request. HTTP allows repeated headers.
+                            items:
+                              description: HTTPHeader describes a custom header to be used in HTTP probes
+                              properties:
+                                name:
+                                  description: The header field name
+                                  type: string
+                                value:
+                                  description: The header field value
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                          path:
+                            description: Path to access on the HTTP server.
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                          scheme:
+                            description: Scheme to use for connecting to the host. Defaults to HTTP.
+                            type: string
+                        required:
+                        - port
+                        type: object
+                      initialDelaySeconds:
+                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                      periodSeconds:
+                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      successThreshold:
+                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      tcpSocket:
+                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                        properties:
+                          host:
+                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                        required:
+                        - port
+                        type: object
+                      terminationGracePeriodSeconds:
+                        description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                        format: int64
+                        type: integer
+                      timeoutSeconds:
+                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                    type: object
+                  requireLogin:
+                    description: If true require user password login credentials for broker protocol ports
+                    type: boolean
+                  resources:
+                    description: ResourceRequirements describes the compute resource requirements.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                    type: object
+                  size:
+                    description: The number of broker pods to deploy
+                    format: int32
+                    type: integer
+                  storage:
+                    properties:
+                      size:
+                        type: string
+                      storageClassName:
+                        description: The storageClassName to be used in PVC
+                        type: string
+                    type: object
+                  tolerations:
+                    items:
+                      description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              upgrades:
+                description: ActiveMQArtemis App product upgrade flags
+                properties:
+                  enabled:
+                    description: Set to true to enable automatic micro version product upgrades, disabled by default.
+                    type: boolean
+                  minor:
+                    description: Set to true to enable automatic micro version product upgrades, disabled by default. Requires spec.upgrades.enabled true.
+                    type: boolean
+                required:
+                - enabled
+                - minor
+                type: object
+              version:
+                description: The version of the broker deployment.
+                type: string
+            type: object
+          status:
+            description: ActiveMQArtemisStatus defines the observed state of ActiveMQArtemis
+            properties:
+              podStatus:
+                description: Pod Status
+                properties:
+                  ready:
+                    description: Deployments are ready to serve requests
+                    items:
+                      type: string
+                    type: array
+                  starting:
+                    description: Deployments are starting, may or may not succeed
+                    items:
+                      type: string
+                    type: array
+                  stopped:
+                    description: Deployments are not starting, unclear what next step will be
+                    items:
+                      type: string
+                    type: array
+                type: object
+            required:
+            - podStatus
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - name: v2alpha1
+    schema:
+      openAPIV3Schema:
+        description: ActiveMQArtemis is the Schema for the activemqartemises API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ActiveMQArtemisSpec defines the desired state of ActiveMQArtemis
+            properties:
+              acceptors:
+                items:
+                  properties:
+                    anycastPrefix:
+                      type: string
+                    connectionsAllowed:
+                      type: integer
+                    enabledCipherSuites:
+                      type: string
+                    enabledProtocols:
+                      type: string
+                    expose:
+                      type: boolean
+                    multicastPrefix:
+                      type: string
+                    name:
+                      type: string
+                    needClientAuth:
+                      type: boolean
+                    port:
+                      format: int32
+                      type: integer
+                    protocols:
+                      type: string
+                    sniHost:
+                      type: string
+                    sslEnabled:
+                      type: boolean
+                    sslProvider:
+                      type: string
+                    sslSecret:
+                      type: string
+                    verifyHost:
+                      type: boolean
+                    wantClientAuth:
+                      type: boolean
+                  required:
+                  - name
+                  type: object
+                type: array
+              adminPassword:
+                type: string
+              adminUser:
+                type: string
+              connectors:
+                items:
+                  properties:
+                    enabledCipherSuites:
+                      type: string
+                    enabledProtocols:
+                      type: string
+                    expose:
+                      type: boolean
+                    host:
+                      type: string
+                    name:
+                      type: string
+                    needClientAuth:
+                      type: boolean
+                    port:
+                      format: int32
+                      type: integer
+                    sniHost:
+                      type: string
+                    sslEnabled:
+                      type: boolean
+                    sslProvider:
+                      type: string
+                    sslSecret:
+                      type: string
+                    type:
+                      type: string
+                    verifyHost:
+                      type: boolean
+                    wantClientAuth:
+                      type: boolean
+                  required:
+                  - host
+                  - name
+                  - port
+                  type: object
+                type: array
+              console:
+                properties:
+                  expose:
+                    type: boolean
+                  sslEnabled:
+                    type: boolean
+                  sslSecret:
+                    type: string
+                  useClientAuth:
+                    type: boolean
+                type: object
+              deploymentPlan:
+                properties:
+                  image:
+                    type: string
+                  journalType:
+                    type: string
+                  messageMigration:
+                    type: boolean
+                  persistenceEnabled:
+                    type: boolean
+                  requireLogin:
+                    type: boolean
+                  size:
+                    format: int32
+                    type: integer
+                type: object
+            type: object
+          status:
+            description: ActiveMQArtemisStatus defines the observed state of ActiveMQArtemis
+            properties:
+              podStatus:
+                properties:
+                  ready:
+                    description: Deployments are ready to serve requests
+                    items:
+                      type: string
+                    type: array
+                  starting:
+                    description: Deployments are starting, may or may not succeed
+                    items:
+                      type: string
+                    type: array
+                  stopped:
+                    description: Deployments are not starting, unclear what next step will be
+                    items:
+                      type: string
+                    type: array
+                type: object
+            required:
+            - podStatus
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v2alpha2
+    schema:
+      openAPIV3Schema:
+        description: ActiveMQArtemis is the Schema for the activemqartemises API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ActiveMQArtemisSpec defines the desired state of ActiveMQArtemis
+            properties:
+              acceptors:
+                items:
+                  properties:
+                    anycastPrefix:
+                      type: string
+                    connectionsAllowed:
+                      type: integer
+                    enabledCipherSuites:
+                      type: string
+                    enabledProtocols:
+                      type: string
+                    expose:
+                      type: boolean
+                    multicastPrefix:
+                      type: string
+                    name:
+                      type: string
+                    needClientAuth:
+                      type: boolean
+                    port:
+                      format: int32
+                      type: integer
+                    protocols:
+                      type: string
+                    sniHost:
+                      type: string
+                    sslEnabled:
+                      type: boolean
+                    sslProvider:
+                      type: string
+                    sslSecret:
+                      type: string
+                    verifyHost:
+                      type: boolean
+                    wantClientAuth:
+                      type: boolean
+                  required:
+                  - name
+                  type: object
+                type: array
+              adminPassword:
+                type: string
+              adminUser:
+                type: string
+              connectors:
+                items:
+                  properties:
+                    enabledCipherSuites:
+                      type: string
+                    enabledProtocols:
+                      type: string
+                    expose:
+                      type: boolean
+                    host:
+                      type: string
+                    name:
+                      type: string
+                    needClientAuth:
+                      type: boolean
+                    port:
+                      format: int32
+                      type: integer
+                    sniHost:
+                      type: string
+                    sslEnabled:
+                      type: boolean
+                    sslProvider:
+                      type: string
+                    sslSecret:
+                      type: string
+                    type:
+                      type: string
+                    verifyHost:
+                      type: boolean
+                    wantClientAuth:
+                      type: boolean
+                  required:
+                  - host
+                  - name
+                  - port
+                  type: object
+                type: array
+              console:
+                properties:
+                  expose:
+                    type: boolean
+                  sslEnabled:
+                    type: boolean
+                  sslSecret:
+                    type: string
+                  useClientAuth:
+                    type: boolean
+                type: object
+              deploymentPlan:
+                properties:
+                  image:
+                    type: string
+                  journalType:
+                    type: string
+                  messageMigration:
+                    type: boolean
+                  persistenceEnabled:
+                    type: boolean
+                  requireLogin:
+                    type: boolean
+                  size:
+                    format: int32
+                    type: integer
+                type: object
+              upgrades:
+                description: ActiveMQArtemis App product upgrade flags
+                properties:
+                  enabled:
+                    type: boolean
+                  minor:
+                    type: boolean
+                required:
+                - enabled
+                - minor
+                type: object
+              version:
+                type: string
+            type: object
+          status:
+            description: ActiveMQArtemisStatus defines the observed state of ActiveMQArtemis
+            properties:
+              podStatus:
+                properties:
+                  ready:
+                    description: Deployments are ready to serve requests
+                    items:
+                      type: string
+                    type: array
+                  starting:
+                    description: Deployments are starting, may or may not succeed
+                    items:
+                      type: string
+                    type: array
+                  stopped:
+                    description: Deployments are not starting, unclear what next step will be
+                    items:
+                      type: string
+                    type: array
+                type: object
+            required:
+            - podStatus
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v2alpha3
+    schema:
+      openAPIV3Schema:
+        description: ActiveMQArtemis is the Schema for the activemqartemises API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ActiveMQArtemisSpec defines the desired state of ActiveMQArtemis
+            properties:
+              acceptors:
+                items:
+                  properties:
+                    amqpMinLargeMessageSize:
+                      type: integer
+                    anycastPrefix:
+                      type: string
+                    connectionsAllowed:
+                      type: integer
+                    enabledCipherSuites:
+                      type: string
+                    enabledProtocols:
+                      type: string
+                    expose:
+                      type: boolean
+                    multicastPrefix:
+                      type: string
+                    name:
+                      type: string
+                    needClientAuth:
+                      type: boolean
+                    port:
+                      format: int32
+                      type: integer
+                    protocols:
+                      type: string
+                    sniHost:
+                      type: string
+                    sslEnabled:
+                      type: boolean
+                    sslProvider:
+                      type: string
+                    sslSecret:
+                      type: string
+                    verifyHost:
+                      type: boolean
+                    wantClientAuth:
+                      type: boolean
+                  required:
+                  - name
+                  type: object
+                type: array
+              addressSettings:
+                properties:
+                  addressSetting:
+                    items:
+                      properties:
+                        addressFullPolicy:
+                          type: string
+                        autoCreateAddresses:
+                          type: boolean
+                        autoCreateDeadLetterResources:
+                          type: boolean
+                        autoCreateExpiryResources:
+                          type: boolean
+                        autoCreateJmsQueues:
+                          type: boolean
+                        autoCreateJmsTopics:
+                          type: boolean
+                        autoCreateQueues:
+                          type: boolean
+                        autoDeleteAddresses:
+                          type: boolean
+                        autoDeleteAddressesDelay:
+                          format: int32
+                          type: integer
+                        autoDeleteCreatedQueues:
+                          type: boolean
+                        autoDeleteJmsQueues:
+                          type: boolean
+                        autoDeleteJmsTopics:
+                          type: boolean
+                        autoDeleteQueues:
+                          type: boolean
+                        autoDeleteQueuesDelay:
+                          format: int32
+                          type: integer
+                        autoDeleteQueuesMessageCount:
+                          format: int32
+                          type: integer
+                        configDeleteAddresses:
+                          type: string
+                        configDeleteQueues:
+                          type: string
+                        deadLetterAddress:
+                          type: string
+                        deadLetterQueuePrefix:
+                          type: string
+                        deadLetterQueueSuffix:
+                          type: string
+                        defaultAddressRoutingType:
+                          type: string
+                        defaultConsumerWindowSize:
+                          format: int32
+                          type: integer
+                        defaultConsumersBeforeDispatch:
+                          format: int32
+                          type: integer
+                        defaultDelayBeforeDispatch:
+                          format: int32
+                          type: integer
+                        defaultExclusiveQueue:
+                          type: boolean
+                        defaultGroupBuckets:
+                          format: int32
+                          type: integer
+                        defaultGroupFirstKey:
+                          type: string
+                        defaultGroupRebalance:
+                          type: boolean
+                        defaultGroupRebalancePauseDispatch:
+                          type: boolean
+                        defaultLastValueKey:
+                          type: string
+                        defaultLastValueQueue:
+                          type: boolean
+                        defaultMaxConsumers:
+                          format: int32
+                          type: integer
+                        defaultNonDestructive:
+                          type: boolean
+                        defaultPurgeOnNoConsumers:
+                          type: boolean
+                        defaultQueueRoutingType:
+                          type: string
+                        defaultRingSize:
+                          format: int32
+                          type: integer
+                        enableMetrics:
+                          type: boolean
+                        expiryAddress:
+                          type: string
+                        expiryDelay:
+                          format: int32
+                          type: integer
+                        expiryQueuePrefix:
+                          type: string
+                        expiryQueueSuffix:
+                          type: string
+                        lastValueQueue:
+                          type: boolean
+                        managementBrowsePageSize:
+                          format: int32
+                          type: integer
+                        match:
+                          type: string
+                        maxDeliveryAttempts:
+                          format: int32
+                          type: integer
+                        maxExpiryDelay:
+                          format: int32
+                          type: integer
+                        maxRedeliveryDelay:
+                          format: int32
+                          type: integer
+                        maxSizeBytes:
+                          type: string
+                        maxSizeBytesRejectThreshold:
+                          format: int32
+                          type: integer
+                        messageCounterHistoryDayLimit:
+                          format: int32
+                          type: integer
+                        minExpiryDelay:
+                          format: int32
+                          type: integer
+                        pageMaxCacheSize:
+                          format: int32
+                          type: integer
+                        pageSizeBytes:
+                          type: string
+                        redeliveryCollisionAvoidanceFactor:
+                          description: controller-gen currently doesn't support float types RedeliveryCollisionAvoidanceFactor *float32 `json:"redeliveryCollisionAvoidanceFactor,omitempty"`
+                          type: string
+                        redeliveryDelay:
+                          format: int32
+                          type: integer
+                        redeliveryDelayMultiplier:
+                          format: int32
+                          type: integer
+                        redistributionDelay:
+                          format: int32
+                          type: integer
+                        retroactiveMessageCount:
+                          format: int32
+                          type: integer
+                        sendToDlaOnNoRoute:
+                          type: boolean
+                        slowConsumerCheckPeriod:
+                          format: int32
+                          type: integer
+                        slowConsumerPolicy:
+                          type: string
+                        slowConsumerThreshold:
+                          format: int32
+                          type: integer
+                      type: object
+                    type: array
+                  applyRule:
+                    type: string
+                type: object
+              adminPassword:
+                type: string
+              adminUser:
+                type: string
+              connectors:
+                items:
+                  properties:
+                    enabledCipherSuites:
+                      type: string
+                    enabledProtocols:
+                      type: string
+                    expose:
+                      type: boolean
+                    host:
+                      type: string
+                    name:
+                      type: string
+                    needClientAuth:
+                      type: boolean
+                    port:
+                      format: int32
+                      type: integer
+                    sniHost:
+                      type: string
+                    sslEnabled:
+                      type: boolean
+                    sslProvider:
+                      type: string
+                    sslSecret:
+                      type: string
+                    type:
+                      type: string
+                    verifyHost:
+                      type: boolean
+                    wantClientAuth:
+                      type: boolean
+                  required:
+                  - host
+                  - name
+                  - port
+                  type: object
+                type: array
+              console:
+                properties:
+                  expose:
+                    type: boolean
+                  sslEnabled:
+                    type: boolean
+                  sslSecret:
+                    type: string
+                  useClientAuth:
+                    type: boolean
+                type: object
+              deploymentPlan:
+                properties:
+                  image:
+                    type: string
+                  journalType:
+                    type: string
+                  messageMigration:
+                    type: boolean
+                  persistenceEnabled:
+                    type: boolean
+                  requireLogin:
+                    type: boolean
+                  resources:
+                    description: ResourceRequirements describes the compute resource requirements.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                    type: object
+                  size:
+                    format: int32
+                    type: integer
+                  storage:
+                    properties:
+                      size:
+                        type: string
+                    type: object
+                type: object
+              upgrades:
+                description: ActiveMQArtemis App product upgrade flags
+                properties:
+                  enabled:
+                    type: boolean
+                  minor:
+                    type: boolean
+                required:
+                - enabled
+                - minor
+                type: object
+              version:
+                type: string
+            type: object
+          status:
+            description: ActiveMQArtemisStatus defines the observed state of ActiveMQArtemis
+            properties:
+              podStatus:
+                properties:
+                  ready:
+                    description: Deployments are ready to serve requests
+                    items:
+                      type: string
+                    type: array
+                  starting:
+                    description: Deployments are starting, may or may not succeed
+                    items:
+                      type: string
+                    type: array
+                  stopped:
+                    description: Deployments are not starting, unclear what next step will be
+                    items:
+                      type: string
+                    type: array
+                type: object
+            required:
+            - podStatus
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v2alpha4
+    schema:
+      openAPIV3Schema:
+        description: ActiveMQArtemis is the Schema for the activemqartemises API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ActiveMQArtemisSpec defines the desired state of ActiveMQArtemis
+            properties:
+              acceptors:
+                items:
+                  properties:
+                    amqpMinLargeMessageSize:
+                      type: integer
+                    anycastPrefix:
+                      type: string
+                    connectionsAllowed:
+                      type: integer
+                    enabledCipherSuites:
+                      type: string
+                    enabledProtocols:
+                      type: string
+                    expose:
+                      type: boolean
+                    multicastPrefix:
+                      type: string
+                    name:
+                      type: string
+                    needClientAuth:
+                      type: boolean
+                    port:
+                      format: int32
+                      type: integer
+                    protocols:
+                      type: string
+                    sniHost:
+                      type: string
+                    sslEnabled:
+                      type: boolean
+                    sslProvider:
+                      type: string
+                    sslSecret:
+                      type: string
+                    verifyHost:
+                      type: boolean
+                    wantClientAuth:
+                      type: boolean
+                  required:
+                  - name
+                  type: object
+                type: array
+              addressSettings:
+                properties:
+                  addressSetting:
+                    items:
+                      properties:
+                        addressFullPolicy:
+                          type: string
+                        autoCreateAddresses:
+                          type: boolean
+                        autoCreateDeadLetterResources:
+                          type: boolean
+                        autoCreateExpiryResources:
+                          type: boolean
+                        autoCreateJmsQueues:
+                          type: boolean
+                        autoCreateJmsTopics:
+                          type: boolean
+                        autoCreateQueues:
+                          type: boolean
+                        autoDeleteAddresses:
+                          type: boolean
+                        autoDeleteAddressesDelay:
+                          format: int32
+                          type: integer
+                        autoDeleteCreatedQueues:
+                          type: boolean
+                        autoDeleteJmsQueues:
+                          type: boolean
+                        autoDeleteJmsTopics:
+                          type: boolean
+                        autoDeleteQueues:
+                          type: boolean
+                        autoDeleteQueuesDelay:
+                          format: int32
+                          type: integer
+                        autoDeleteQueuesMessageCount:
+                          format: int32
+                          type: integer
+                        configDeleteAddresses:
+                          type: string
+                        configDeleteQueues:
+                          type: string
+                        deadLetterAddress:
+                          type: string
+                        deadLetterQueuePrefix:
+                          type: string
+                        deadLetterQueueSuffix:
+                          type: string
+                        defaultAddressRoutingType:
+                          type: string
+                        defaultConsumerWindowSize:
+                          format: int32
+                          type: integer
+                        defaultConsumersBeforeDispatch:
+                          format: int32
+                          type: integer
+                        defaultDelayBeforeDispatch:
+                          format: int32
+                          type: integer
+                        defaultExclusiveQueue:
+                          type: boolean
+                        defaultGroupBuckets:
+                          format: int32
+                          type: integer
+                        defaultGroupFirstKey:
+                          type: string
+                        defaultGroupRebalance:
+                          type: boolean
+                        defaultGroupRebalancePauseDispatch:
+                          type: boolean
+                        defaultLastValueKey:
+                          type: string
+                        defaultLastValueQueue:
+                          type: boolean
+                        defaultMaxConsumers:
+                          format: int32
+                          type: integer
+                        defaultNonDestructive:
+                          type: boolean
+                        defaultPurgeOnNoConsumers:
+                          type: boolean
+                        defaultQueueRoutingType:
+                          type: string
+                        defaultRingSize:
+                          format: int32
+                          type: integer
+                        enableMetrics:
+                          type: boolean
+                        expiryAddress:
+                          type: string
+                        expiryDelay:
+                          format: int32
+                          type: integer
+                        expiryQueuePrefix:
+                          type: string
+                        expiryQueueSuffix:
+                          type: string
+                        lastValueQueue:
+                          type: boolean
+                        managementBrowsePageSize:
+                          format: int32
+                          type: integer
+                        match:
+                          type: string
+                        maxDeliveryAttempts:
+                          format: int32
+                          type: integer
+                        maxExpiryDelay:
+                          format: int32
+                          type: integer
+                        maxRedeliveryDelay:
+                          format: int32
+                          type: integer
+                        maxSizeBytes:
+                          type: string
+                        maxSizeBytesRejectThreshold:
+                          format: int32
+                          type: integer
+                        messageCounterHistoryDayLimit:
+                          format: int32
+                          type: integer
+                        minExpiryDelay:
+                          format: int32
+                          type: integer
+                        pageMaxCacheSize:
+                          format: int32
+                          type: integer
+                        pageSizeBytes:
+                          type: string
+                        redeliveryCollisionAvoidanceFactor:
+                          description: currentl controller-gen doesn't support float type RedeliveryCollisionAvoidanceFactor *float32 `json:"redeliveryCollisionAvoidanceFactor,omitempty"`
+                          type: string
+                        redeliveryDelay:
+                          format: int32
+                          type: integer
+                        redeliveryDelayMultiplier:
+                          format: int32
+                          type: integer
+                        redistributionDelay:
+                          format: int32
+                          type: integer
+                        retroactiveMessageCount:
+                          format: int32
+                          type: integer
+                        sendToDlaOnNoRoute:
+                          type: boolean
+                        slowConsumerCheckPeriod:
+                          format: int32
+                          type: integer
+                        slowConsumerPolicy:
+                          type: string
+                        slowConsumerThreshold:
+                          format: int32
+                          type: integer
+                      type: object
+                    type: array
+                  applyRule:
+                    type: string
+                type: object
+              adminPassword:
+                type: string
+              adminUser:
+                type: string
+              connectors:
+                items:
+                  properties:
+                    enabledCipherSuites:
+                      type: string
+                    enabledProtocols:
+                      type: string
+                    expose:
+                      type: boolean
+                    host:
+                      type: string
+                    name:
+                      type: string
+                    needClientAuth:
+                      type: boolean
+                    port:
+                      format: int32
+                      type: integer
+                    sniHost:
+                      type: string
+                    sslEnabled:
+                      type: boolean
+                    sslProvider:
+                      type: string
+                    sslSecret:
+                      type: string
+                    type:
+                      type: string
+                    verifyHost:
+                      type: boolean
+                    wantClientAuth:
+                      type: boolean
+                  required:
+                  - host
+                  - name
+                  - port
+                  type: object
+                type: array
+              console:
+                properties:
+                  expose:
+                    type: boolean
+                  sslEnabled:
+                    type: boolean
+                  sslSecret:
+                    type: string
+                  useClientAuth:
+                    type: boolean
+                type: object
+              deploymentPlan:
+                properties:
+                  image:
+                    type: string
+                  initImage:
+                    type: string
+                  jolokiaAgentEnabled:
+                    type: boolean
+                  journalType:
+                    type: string
+                  managementRBACEnabled:
+                    type: boolean
+                  messageMigration:
+                    type: boolean
+                  persistenceEnabled:
+                    type: boolean
+                  requireLogin:
+                    type: boolean
+                  resources:
+                    description: ResourceRequirements describes the compute resource requirements.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                    type: object
+                  size:
+                    format: int32
+                    type: integer
+                  storage:
+                    properties:
+                      size:
+                        type: string
+                    type: object
+                type: object
+              upgrades:
+                description: ActiveMQArtemis App product upgrade flags
+                properties:
+                  enabled:
+                    type: boolean
+                  minor:
+                    type: boolean
+                required:
+                - enabled
+                - minor
+                type: object
+              version:
+                type: string
+            type: object
+          status:
+            description: ActiveMQArtemisStatus defines the observed state of ActiveMQArtemis
+            properties:
+              podStatus:
+                properties:
+                  ready:
+                    description: Deployments are ready to serve requests
+                    items:
+                      type: string
+                    type: array
+                  starting:
+                    description: Deployments are starting, may or may not succeed
+                    items:
+                      type: string
+                    type: array
+                  stopped:
+                    description: Deployments are not starting, unclear what next step will be
+                    items:
+                      type: string
+                    type: array
+                type: object
+            required:
+            - podStatus
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v2alpha5
+    schema:
+      openAPIV3Schema:
+        description: ActiveMQArtemis is the Schema for the activemqartemises API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ActiveMQArtemisSpec defines the desired state of ActiveMQArtemis
+            properties:
+              acceptors:
+                items:
+                  properties:
+                    amqpMinLargeMessageSize:
+                      type: integer
+                    anycastPrefix:
+                      type: string
+                    connectionsAllowed:
+                      type: integer
+                    enabledCipherSuites:
+                      type: string
+                    enabledProtocols:
+                      type: string
+                    expose:
+                      type: boolean
+                    multicastPrefix:
+                      type: string
+                    name:
+                      type: string
+                    needClientAuth:
+                      type: boolean
+                    port:
+                      format: int32
+                      type: integer
+                    protocols:
+                      type: string
+                    sniHost:
+                      type: string
+                    sslEnabled:
+                      type: boolean
+                    sslProvider:
+                      type: string
+                    sslSecret:
+                      type: string
+                    supportAdvisory:
+                      type: boolean
+                    suppressInternalManagementObjects:
+                      type: boolean
+                    verifyHost:
+                      type: boolean
+                    wantClientAuth:
+                      type: boolean
+                  required:
+                  - name
+                  type: object
+                type: array
+              addressSettings:
+                properties:
+                  addressSetting:
+                    items:
+                      properties:
+                        addressFullPolicy:
+                          type: string
+                        autoCreateAddresses:
+                          type: boolean
+                        autoCreateDeadLetterResources:
+                          type: boolean
+                        autoCreateExpiryResources:
+                          type: boolean
+                        autoCreateJmsQueues:
+                          type: boolean
+                        autoCreateJmsTopics:
+                          type: boolean
+                        autoCreateQueues:
+                          type: boolean
+                        autoDeleteAddresses:
+                          type: boolean
+                        autoDeleteAddressesDelay:
+                          format: int32
+                          type: integer
+                        autoDeleteCreatedQueues:
+                          type: boolean
+                        autoDeleteJmsQueues:
+                          type: boolean
+                        autoDeleteJmsTopics:
+                          type: boolean
+                        autoDeleteQueues:
+                          type: boolean
+                        autoDeleteQueuesDelay:
+                          format: int32
+                          type: integer
+                        autoDeleteQueuesMessageCount:
+                          format: int32
+                          type: integer
+                        configDeleteAddresses:
+                          type: string
+                        configDeleteQueues:
+                          type: string
+                        deadLetterAddress:
+                          type: string
+                        deadLetterQueuePrefix:
+                          type: string
+                        deadLetterQueueSuffix:
+                          type: string
+                        defaultAddressRoutingType:
+                          type: string
+                        defaultConsumerWindowSize:
+                          format: int32
+                          type: integer
+                        defaultConsumersBeforeDispatch:
+                          format: int32
+                          type: integer
+                        defaultDelayBeforeDispatch:
+                          format: int32
+                          type: integer
+                        defaultExclusiveQueue:
+                          type: boolean
+                        defaultGroupBuckets:
+                          format: int32
+                          type: integer
+                        defaultGroupFirstKey:
+                          type: string
+                        defaultGroupRebalance:
+                          type: boolean
+                        defaultGroupRebalancePauseDispatch:
+                          type: boolean
+                        defaultLastValueKey:
+                          type: string
+                        defaultLastValueQueue:
+                          type: boolean
+                        defaultMaxConsumers:
+                          format: int32
+                          type: integer
+                        defaultNonDestructive:
+                          type: boolean
+                        defaultPurgeOnNoConsumers:
+                          type: boolean
+                        defaultQueueRoutingType:
+                          type: string
+                        defaultRingSize:
+                          format: int32
+                          type: integer
+                        enableIngressTimestamp:
+                          type: boolean
+                        enableMetrics:
+                          type: boolean
+                        expiryAddress:
+                          type: string
+                        expiryDelay:
+                          format: int32
+                          type: integer
+                        expiryQueuePrefix:
+                          type: string
+                        expiryQueueSuffix:
+                          type: string
+                        lastValueQueue:
+                          type: boolean
+                        managementBrowsePageSize:
+                          format: int32
+                          type: integer
+                        managementMessageAttributeSizeLimit:
+                          format: int32
+                          type: integer
+                        match:
+                          type: string
+                        maxDeliveryAttempts:
+                          format: int32
+                          type: integer
+                        maxExpiryDelay:
+                          format: int32
+                          type: integer
+                        maxRedeliveryDelay:
+                          format: int32
+                          type: integer
+                        maxSizeBytes:
+                          type: string
+                        maxSizeBytesRejectThreshold:
+                          format: int32
+                          type: integer
+                        messageCounterHistoryDayLimit:
+                          format: int32
+                          type: integer
+                        minExpiryDelay:
+                          format: int32
+                          type: integer
+                        pageMaxCacheSize:
+                          format: int32
+                          type: integer
+                        pageSizeBytes:
+                          type: string
+                        redeliveryCollisionAvoidanceFactor:
+                          type: string
+                        redeliveryDelay:
+                          format: int32
+                          type: integer
+                        redeliveryDelayMultiplier:
+                          description: controller-gen currently doesn't support float types RedeliveryDelayMultiplier            *float32 `json:"redeliveryDelayMultiplier,omitempty"` RedeliveryCollisionAvoidanceFactor   *float32 `json:"redeliveryCollisionAvoidanceFactor,omitempty"`
+                          type: string
+                        redistributionDelay:
+                          format: int32
+                          type: integer
+                        retroactiveMessageCount:
+                          format: int32
+                          type: integer
+                        sendToDlaOnNoRoute:
+                          type: boolean
+                        slowConsumerCheckPeriod:
+                          format: int32
+                          type: integer
+                        slowConsumerPolicy:
+                          type: string
+                        slowConsumerThreshold:
+                          format: int32
+                          type: integer
+                        slowConsumerThresholdMeasurementUnit:
+                          type: string
+                      type: object
+                    type: array
+                  applyRule:
+                    type: string
+                type: object
+              adminPassword:
+                type: string
+              adminUser:
+                type: string
+              connectors:
+                items:
+                  properties:
+                    enabledCipherSuites:
+                      type: string
+                    enabledProtocols:
+                      type: string
+                    expose:
+                      type: boolean
+                    host:
+                      type: string
+                    name:
+                      type: string
+                    needClientAuth:
+                      type: boolean
+                    port:
+                      format: int32
+                      type: integer
+                    sniHost:
+                      type: string
+                    sslEnabled:
+                      type: boolean
+                    sslProvider:
+                      type: string
+                    sslSecret:
+                      type: string
+                    type:
+                      type: string
+                    verifyHost:
+                      type: boolean
+                    wantClientAuth:
+                      type: boolean
+                  required:
+                  - host
+                  - name
+                  - port
+                  type: object
+                type: array
+              console:
+                properties:
+                  expose:
+                    type: boolean
+                  sslEnabled:
+                    type: boolean
+                  sslSecret:
+                    type: string
+                  useClientAuth:
+                    type: boolean
+                type: object
+              deploymentPlan:
+                properties:
+                  clustered:
+                    type: boolean
+                  enableMetricsPlugin:
+                    type: boolean
+                  extraMounts:
+                    properties:
+                      configMaps:
+                        items:
+                          type: string
+                        type: array
+                      secrets:
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  image:
+                    type: string
+                  initImage:
+                    type: string
+                  jolokiaAgentEnabled:
+                    type: boolean
+                  journalType:
+                    type: string
+                  livenessProbe:
+                    properties:
+                      timeoutSeconds:
+                        format: int32
+                        type: integer
+                    type: object
+                  managementRBACEnabled:
+                    type: boolean
+                  messageMigration:
+                    type: boolean
+                  persistenceEnabled:
+                    type: boolean
+                  podSecurity:
+                    properties:
+                      runAsUser:
+                        format: int64
+                        type: integer
+                      serviceAccountName:
+                        type: string
+                    type: object
+                  readinessProbe:
+                    properties:
+                      timeoutSeconds:
+                        format: int32
+                        type: integer
+                    type: object
+                  requireLogin:
+                    type: boolean
+                  resources:
+                    description: ResourceRequirements describes the compute resource requirements.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                    type: object
+                  size:
+                    format: int32
+                    type: integer
+                  storage:
+                    properties:
+                      size:
+                        type: string
+                    type: object
+                type: object
+              upgrades:
+                description: ActiveMQArtemis App product upgrade flags
+                properties:
+                  enabled:
+                    type: boolean
+                  minor:
+                    type: boolean
+                required:
+                - enabled
+                - minor
+                type: object
+              version:
+                type: string
+            type: object
+          status:
+            description: ActiveMQArtemisStatus defines the observed state of ActiveMQArtemis
+            properties:
+              podStatus:
+                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state of cluster Important: Run "make" to regenerate code after modifying this file'
+                properties:
+                  ready:
+                    description: Deployments are ready to serve requests
+                    items:
+                      type: string
+                    type: array
+                  starting:
+                    description: Deployments are starting, may or may not succeed
+                    items:
+                      type: string
+                    type: array
+                  stopped:
+                    description: Deployments are not starting, unclear what next step will be
+                    items:
+                      type: string
+                    type: array
+                type: object
+            required:
+            - podStatus
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/deploy/crds/broker_activemqartemisaddress_crd.yaml
+++ b/deploy/crds/broker_activemqartemisaddress_crd.yaml
@@ -1,0 +1,352 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.7.0
+  name: activemqartemisaddresses.broker.amq.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUdpekNDQkhPZ0F3SUJBZ0lVWXh6UkpyemJuUnFBUDhqQ1pETnA5QlRFMW5Zd0RRWUpLb1pJaHZjTkFRRUwKQlFBd2dhc3hDekFKQmdOVkJBWVRBbFZUTVJNd0VRWURWUVFJREFwRFlXeHBabTl5Ym1saE1SUXdFZ1lEVlFRSApEQXRNYjNNZ1FXNW5aV3hsY3pFVk1CTUdBMVVFQ2d3TVFYSjBaVzFwYzBOc2IzVmtNUkV3RHdZRFZRUUxEQWhQCmNHVnlZWFJ2Y2pGSE1FVUdBMVVFQXd3K1lXTjBhWFpsYlhFdFlYSjBaVzFwY3kxM1pXSm9iMjlyTFhObGNuWnAKWTJVdVlXTjBhWFpsYlhFdFlYSjBaVzFwY3kxdmNHVnlZWFJ2Y2k1emRtTXdIaGNOTWpFeE1qSTBNVE0xTXpBegpXaGNOTXpFeE1qSXlNVE0xTXpBeldqQ0JxekVMTUFrR0ExVUVCaE1DVlZNeEV6QVJCZ05WQkFnTUNrTmhiR2xtCmIzSnVhV0V4RkRBU0JnTlZCQWNNQzB4dmN5QkJibWRsYkdWek1SVXdFd1lEVlFRS0RBeEJjblJsYldselEyeHYKZFdReEVUQVBCZ05WQkFzTUNFOXdaWEpoZEc5eU1VY3dSUVlEVlFRRERENWhZM1JwZG1WdGNTMWhjblJsYldsegpMWGRsWW1odmIyc3RjMlZ5ZG1salpTNWhZM1JwZG1WdGNTMWhjblJsYldsekxXOXdaWEpoZEc5eUxuTjJZekNDCkFpSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnSVBBRENDQWdvQ2dnSUJBS3VRT0Y0aHdLK0xRejJnRGZ3aENQczAKeTJVVXp3SmN5SVhWY1VDeElXNDhMeWw1NXdvZkZhWmk1MHRyRisxUzM0OVAvNHFieDZQQVlmbk53Z0gvZmxKNQpXaFZoTG5DTFVrUjZYS3N0WWZIVjZBcW5BSlNXYWZPR2lGb2JHWVI4L1ZrdytKK3dCZHlGamRRc3NDNHczL0J1Cms2U3dLOFVEOFFFa1BKMGpyWHdPNkxvZnRxcVloWmd6N2poTEQxcXkyTDJmTFV6TVh0bEtReHI1Z2FNMzQwZ0cKaU9oNS96SGE1WmNsNXNMSzlRMlRtSk4vMVZGQjNNK2RzOEEreG1oS0pOSVNYaHMzRkpha2FYM05kQ2R4SVdYRQorOUtVU1BteXFKMmFaVEVlUHY2cXpCcVJOSlB6TjFhWURNZitFS2wwZ09hOG9NUzNVQVc3azRyZ2pNVWJ5dVFMCkExb0poVEdQcThiZWEwYUNGK1VaUCtEWFQ1YVJ3UWI4WCt1dWdqSFV4WGkrVndpUnJ1bXFFNWJlZ1kyK0h2Z1EKQWRNM0tSaTBVYVR2UXA4ajJUUG5pMVRCK0FYdmxlNjZwMFp3NE5HcWpaQTdVZGdTZlNBQzkxT1B5bnE0T0QvdQowYnloZVFFTjUvVmtJVzE4UVV6TkMxMVBFWmhFOXhXQ0JvdnEvSytEMjRNcllEb3MrQm84blFSY3c5UjN4ZW8vCmJpd3o2dXlVamJSUEgreStzVlJXeXhsdUNnRnVMdFVuMFlyZTE3Q1FQZnp3aXRNaStZWjhBb3ZYeHZZSlhFSm0KSE9nbzdqOFpFWVlTWDNCNS9GOVoyei9hSlJtc3dTUHVrT0RtZ0REZEJDWURZNk1ya1BYVTZocS8rYmtQcGZJbQp0N05sSHB3N0RuOEYzRzNDdjRBWEFnTUJBQUdqZ2FRd2dhRXdDd1lEVlIwUEJBUURBZ1F3TUJNR0ExVWRKUVFNCk1Bb0dDQ3NHQVFVRkJ3TUJNSDBHQTFVZEVRUjJNSFNDUG1GamRHbDJaVzF4TFdGeWRHVnRhWE10ZDJWaWFHOXYKYXkxelpYSjJhV05sTG1GamRHbDJaVzF4TFdGeWRHVnRhWE10YjNCbGNtRjBiM0l1YzNaamdqSmhiWEV0WW5KdgphMlZ5TFhkbFltaHZiMnN0YzJWeWRtbGpaUzVoYlhFdFluSnZhMlZ5TFc5d1pYSmhkRzl5TG5OMll6QU5CZ2txCmhraUc5dzBCQVFzRkFBT0NBZ0VBU0ZqT1NyMWVaVzh5dlpXTkx0L0hXaU1TK0E3MlNTODkySnhlTlZCTTNEVWUKMEVrSllnaXk1QzJqaWN6WFdLWXl4ZUo2TDdIVWwzNmZRbFptOC9Ea1NETUlrOTByd1dFWE45RUdIRUpIdEN0WAo0L0l4elJsTVJYK1Ric3FJZFF3SjlpNkFtVjBqaUdlcFpEOStpTi9nL2pYT2NSSFAza3dFVWkxcG9Uc3E5ZkZ0ClRtYU9HYjRZeXN5dWx4S1VtcTlDU1NpbkpNeW01S2o0cUFJSEVDS2RaaTg4b2JUeHl6b1VvY1RNeWw5ZXdTU0UKZDQrakRiWTBQWEc5OXpCZ0FKbjVSSEs3Qm0yL1N0MnNZMy9xUWhsbVZSTWg4eU9sZk9OVDc0WlRJSlFvZDljVwpZOHdqMGY4dmx5VVFreGd6OHZyTVpSV3kvNHhhazViTWw0NkE2SEk4SWJ6eldXaEUwTVdPWkprR1MxMHo1dVdHCkNMYyswdHJVcHprNWFoNXU5QVZZQXhYNUlKeDIxdVBYUnUydmZ6VDBYOE9kNkF1SXd3djFLUUxpSFBNWG9sTysKdjhKejNlZEhVMDBlajFPeGN3OGkzbVNyUDVKNVlONkQrdUFhVWtWNTZzMlk0SlNiME41a0kyT2tRNjMwbGRZUApROGNxQVBRczFwODRuK2xveVVrWnZsSUdkNVVYSTZuWXFNTFQ4dGZoVGFzQVNuOW4zREtGRGJ3VE85eG01bldWCjlrZk1HVWdHNWVoLzFVZmxQWlA4UmhkVTlVbjZob1dla3doMkMzTnZTUFhZL1l0ZHVKK295ZjJ2QTdQMXdHSzMKdjJVRDIwL09YUnZxd2dTUlBVOHVtK3NxU0Rab0NKeWxFZXZ4aHFmZXFzUk5vdDAwNGJPY2ZjQlUydnpnR0wwPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
+        service:
+          name: webhook-service
+          namespace: activemq-artemis-operator
+          path: /convert
+      conversionReviewVersions:
+      - v1beta1
+  group: broker.amq.io
+  names:
+    kind: ActiveMQArtemisAddress
+    listKind: ActiveMQArtemisAddressList
+    plural: activemqartemisaddresses
+    singular: activemqartemisaddress
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: ActiveMQArtemisAddress is the Schema for the activemqartemisaddresses API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ActiveMQArtemisAddressSpec defines the desired state of ActiveMQArtemisAddress
+            properties:
+              addressName:
+                description: Address Name
+                type: string
+              applyToCrNames:
+                description: Apply to the broker crs in the current namespace. A value of * or empty string means applying to all broker crs. Default apply to all broker crs
+                items:
+                  type: string
+                type: array
+              password:
+                description: The user's password
+                type: string
+              queueConfiguration:
+                properties:
+                  autoCreateAddress:
+                    description: Whether auto create address
+                    type: boolean
+                  autoDelete:
+                    description: Auto-delete the queue
+                    type: boolean
+                  autoDeleteDelay:
+                    description: Delay (Milliseconds) before auto-delete the queue
+                    format: int64
+                    type: integer
+                  autoDeleteMessageCount:
+                    description: Message count of the queue to allow auto delete
+                    format: int64
+                    type: integer
+                  configurationManaged:
+                    description: ' If the queue is configuration managed'
+                    type: boolean
+                  consumerPriority:
+                    description: Consumer Priority
+                    format: int32
+                    type: integer
+                  consumersBeforeDispatch:
+                    description: Number of consumers required before dispatching messages
+                    format: int32
+                    type: integer
+                  delayBeforeDispatch:
+                    description: Milliseconds to wait for `consumers-before-dispatch` to be met before dispatching messages anyway
+                    format: int64
+                    type: integer
+                  durable:
+                    description: If the queue is durable or not
+                    type: boolean
+                  enabled:
+                    description: If the queue is enabled
+                    type: boolean
+                  exclusive:
+                    description: If the queue is exclusive
+                    type: boolean
+                  filterString:
+                    description: The filter string for the queue
+                    type: string
+                  groupBuckets:
+                    description: Number of messaging group buckets
+                    format: int32
+                    type: integer
+                  groupFirstKey:
+                    description: Header set on the first group message
+                    type: string
+                  groupRebalance:
+                    description: If rebalance the message group
+                    type: boolean
+                  groupRebalancePauseDispatch:
+                    description: If pause message dispatch when rebalancing groups
+                    type: boolean
+                  ignoreIfExists:
+                    description: If ignore if the target queue already exists
+                    type: boolean
+                  lastValue:
+                    description: If it is a last value queue
+                    type: boolean
+                  lastValueKey:
+                    description: The property used for last value queue to identify last values
+                    type: string
+                  maxConsumers:
+                    description: Max number of consumers allowed on this queue
+                    format: int32
+                    type: integer
+                  nonDestructive:
+                    description: If force non-destructive consumers on the queue
+                    type: boolean
+                  purgeOnNoConsumers:
+                    description: Whether to delete all messages when no consumers connected to the queue
+                    type: boolean
+                  ringSize:
+                    description: The size the queue should maintain according to ring semantics
+                    format: int64
+                    type: integer
+                  routingType:
+                    description: The routing type of the queue
+                    type: string
+                  temporary:
+                    description: If the queue is temporary
+                    type: boolean
+                  user:
+                    description: The user associated with the queue
+                    type: string
+                required:
+                - maxConsumers
+                - purgeOnNoConsumers
+                type: object
+              queueName:
+                description: Queue Name
+                type: string
+              removeFromBrokerOnDelete:
+                description: Whether or not delete the queue from broker when CR is undeployed(default false)
+                type: boolean
+              routingType:
+                description: The Routing Type
+                type: string
+              user:
+                description: User name for creating the queue or address
+                type: string
+            type: object
+          status:
+            description: ActiveMQArtemisAddressStatus defines the observed state of ActiveMQArtemisAddress
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - name: v2alpha1
+    schema:
+      openAPIV3Schema:
+        description: ActiveMQArtemisAddress is the Schema for the activemqartemisaddresses API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ActiveMQArtemisAddressSpec defines the desired state of ActiveMQArtemisAddress
+            properties:
+              addressName:
+                type: string
+              queueName:
+                type: string
+              routingType:
+                type: string
+            required:
+            - addressName
+            - queueName
+            - routingType
+            type: object
+          status:
+            description: ActiveMQArtemisAddressStatus defines the observed state of ActiveMQArtemisAddress
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v2alpha2
+    schema:
+      openAPIV3Schema:
+        description: ActiveMQArtemisAddress is the Schema for the activemqartemisaddresses API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ActiveMQArtemisAddressSpec defines the desired state of ActiveMQArtemisAddress
+            properties:
+              addressName:
+                type: string
+              queueName:
+                type: string
+              removeFromBrokerOnDelete:
+                type: boolean
+              routingType:
+                type: string
+            required:
+            - addressName
+            - queueName
+            - removeFromBrokerOnDelete
+            - routingType
+            type: object
+          status:
+            description: ActiveMQArtemisAddressStatus defines the observed state of ActiveMQArtemisAddress
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v2alpha3
+    schema:
+      openAPIV3Schema:
+        description: ActiveMQArtemisAddress is the Schema for the activemqartemisaddresses API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ActiveMQArtemisAddressSpec defines the desired state of ActiveMQArtemisAddress
+            properties:
+              addressName:
+                type: string
+              applyToCrNames:
+                items:
+                  type: string
+                type: array
+              password:
+                type: string
+              queueConfiguration:
+                properties:
+                  autoCreateAddress:
+                    type: boolean
+                  autoDelete:
+                    type: boolean
+                  autoDeleteDelay:
+                    format: int64
+                    type: integer
+                  autoDeleteMessageCount:
+                    format: int64
+                    type: integer
+                  configurationManaged:
+                    type: boolean
+                  consumerPriority:
+                    format: int32
+                    type: integer
+                  consumersBeforeDispatch:
+                    format: int32
+                    type: integer
+                  delayBeforeDispatch:
+                    format: int64
+                    type: integer
+                  durable:
+                    type: boolean
+                  enabled:
+                    type: boolean
+                  exclusive:
+                    type: boolean
+                  filterString:
+                    type: string
+                  groupBuckets:
+                    format: int32
+                    type: integer
+                  groupFirstKey:
+                    type: string
+                  groupRebalance:
+                    type: boolean
+                  groupRebalancePauseDispatch:
+                    type: boolean
+                  ignoreIfExists:
+                    type: boolean
+                  lastValue:
+                    type: boolean
+                  lastValueKey:
+                    type: string
+                  maxConsumers:
+                    format: int32
+                    type: integer
+                  nonDestructive:
+                    type: boolean
+                  purgeOnNoConsumers:
+                    type: boolean
+                  ringSize:
+                    format: int64
+                    type: integer
+                  routingType:
+                    type: string
+                  temporary:
+                    type: boolean
+                  user:
+                    type: string
+                required:
+                - maxConsumers
+                - purgeOnNoConsumers
+                type: object
+              queueName:
+                type: string
+              removeFromBrokerOnDelete:
+                type: boolean
+              routingType:
+                type: string
+              user:
+                type: string
+            type: object
+          status:
+            description: ActiveMQArtemisAddressStatus defines the observed state of ActiveMQArtemisAddress
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/deploy/crds/broker_activemqartemisscaledown_crd.yaml
+++ b/deploy/crds/broker_activemqartemisscaledown_crd.yaml
@@ -1,0 +1,114 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.7.0
+  name: activemqartemisscaledowns.broker.amq.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUdpekNDQkhPZ0F3SUJBZ0lVWXh6UkpyemJuUnFBUDhqQ1pETnA5QlRFMW5Zd0RRWUpLb1pJaHZjTkFRRUwKQlFBd2dhc3hDekFKQmdOVkJBWVRBbFZUTVJNd0VRWURWUVFJREFwRFlXeHBabTl5Ym1saE1SUXdFZ1lEVlFRSApEQXRNYjNNZ1FXNW5aV3hsY3pFVk1CTUdBMVVFQ2d3TVFYSjBaVzFwYzBOc2IzVmtNUkV3RHdZRFZRUUxEQWhQCmNHVnlZWFJ2Y2pGSE1FVUdBMVVFQXd3K1lXTjBhWFpsYlhFdFlYSjBaVzFwY3kxM1pXSm9iMjlyTFhObGNuWnAKWTJVdVlXTjBhWFpsYlhFdFlYSjBaVzFwY3kxdmNHVnlZWFJ2Y2k1emRtTXdIaGNOTWpFeE1qSTBNVE0xTXpBegpXaGNOTXpFeE1qSXlNVE0xTXpBeldqQ0JxekVMTUFrR0ExVUVCaE1DVlZNeEV6QVJCZ05WQkFnTUNrTmhiR2xtCmIzSnVhV0V4RkRBU0JnTlZCQWNNQzB4dmN5QkJibWRsYkdWek1SVXdFd1lEVlFRS0RBeEJjblJsYldselEyeHYKZFdReEVUQVBCZ05WQkFzTUNFOXdaWEpoZEc5eU1VY3dSUVlEVlFRRERENWhZM1JwZG1WdGNTMWhjblJsYldsegpMWGRsWW1odmIyc3RjMlZ5ZG1salpTNWhZM1JwZG1WdGNTMWhjblJsYldsekxXOXdaWEpoZEc5eUxuTjJZekNDCkFpSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnSVBBRENDQWdvQ2dnSUJBS3VRT0Y0aHdLK0xRejJnRGZ3aENQczAKeTJVVXp3SmN5SVhWY1VDeElXNDhMeWw1NXdvZkZhWmk1MHRyRisxUzM0OVAvNHFieDZQQVlmbk53Z0gvZmxKNQpXaFZoTG5DTFVrUjZYS3N0WWZIVjZBcW5BSlNXYWZPR2lGb2JHWVI4L1ZrdytKK3dCZHlGamRRc3NDNHczL0J1Cms2U3dLOFVEOFFFa1BKMGpyWHdPNkxvZnRxcVloWmd6N2poTEQxcXkyTDJmTFV6TVh0bEtReHI1Z2FNMzQwZ0cKaU9oNS96SGE1WmNsNXNMSzlRMlRtSk4vMVZGQjNNK2RzOEEreG1oS0pOSVNYaHMzRkpha2FYM05kQ2R4SVdYRQorOUtVU1BteXFKMmFaVEVlUHY2cXpCcVJOSlB6TjFhWURNZitFS2wwZ09hOG9NUzNVQVc3azRyZ2pNVWJ5dVFMCkExb0poVEdQcThiZWEwYUNGK1VaUCtEWFQ1YVJ3UWI4WCt1dWdqSFV4WGkrVndpUnJ1bXFFNWJlZ1kyK0h2Z1EKQWRNM0tSaTBVYVR2UXA4ajJUUG5pMVRCK0FYdmxlNjZwMFp3NE5HcWpaQTdVZGdTZlNBQzkxT1B5bnE0T0QvdQowYnloZVFFTjUvVmtJVzE4UVV6TkMxMVBFWmhFOXhXQ0JvdnEvSytEMjRNcllEb3MrQm84blFSY3c5UjN4ZW8vCmJpd3o2dXlVamJSUEgreStzVlJXeXhsdUNnRnVMdFVuMFlyZTE3Q1FQZnp3aXRNaStZWjhBb3ZYeHZZSlhFSm0KSE9nbzdqOFpFWVlTWDNCNS9GOVoyei9hSlJtc3dTUHVrT0RtZ0REZEJDWURZNk1ya1BYVTZocS8rYmtQcGZJbQp0N05sSHB3N0RuOEYzRzNDdjRBWEFnTUJBQUdqZ2FRd2dhRXdDd1lEVlIwUEJBUURBZ1F3TUJNR0ExVWRKUVFNCk1Bb0dDQ3NHQVFVRkJ3TUJNSDBHQTFVZEVRUjJNSFNDUG1GamRHbDJaVzF4TFdGeWRHVnRhWE10ZDJWaWFHOXYKYXkxelpYSjJhV05sTG1GamRHbDJaVzF4TFdGeWRHVnRhWE10YjNCbGNtRjBiM0l1YzNaamdqSmhiWEV0WW5KdgphMlZ5TFhkbFltaHZiMnN0YzJWeWRtbGpaUzVoYlhFdFluSnZhMlZ5TFc5d1pYSmhkRzl5TG5OMll6QU5CZ2txCmhraUc5dzBCQVFzRkFBT0NBZ0VBU0ZqT1NyMWVaVzh5dlpXTkx0L0hXaU1TK0E3MlNTODkySnhlTlZCTTNEVWUKMEVrSllnaXk1QzJqaWN6WFdLWXl4ZUo2TDdIVWwzNmZRbFptOC9Ea1NETUlrOTByd1dFWE45RUdIRUpIdEN0WAo0L0l4elJsTVJYK1Ric3FJZFF3SjlpNkFtVjBqaUdlcFpEOStpTi9nL2pYT2NSSFAza3dFVWkxcG9Uc3E5ZkZ0ClRtYU9HYjRZeXN5dWx4S1VtcTlDU1NpbkpNeW01S2o0cUFJSEVDS2RaaTg4b2JUeHl6b1VvY1RNeWw5ZXdTU0UKZDQrakRiWTBQWEc5OXpCZ0FKbjVSSEs3Qm0yL1N0MnNZMy9xUWhsbVZSTWg4eU9sZk9OVDc0WlRJSlFvZDljVwpZOHdqMGY4dmx5VVFreGd6OHZyTVpSV3kvNHhhazViTWw0NkE2SEk4SWJ6eldXaEUwTVdPWkprR1MxMHo1dVdHCkNMYyswdHJVcHprNWFoNXU5QVZZQXhYNUlKeDIxdVBYUnUydmZ6VDBYOE9kNkF1SXd3djFLUUxpSFBNWG9sTysKdjhKejNlZEhVMDBlajFPeGN3OGkzbVNyUDVKNVlONkQrdUFhVWtWNTZzMlk0SlNiME41a0kyT2tRNjMwbGRZUApROGNxQVBRczFwODRuK2xveVVrWnZsSUdkNVVYSTZuWXFNTFQ4dGZoVGFzQVNuOW4zREtGRGJ3VE85eG01bldWCjlrZk1HVWdHNWVoLzFVZmxQWlA4UmhkVTlVbjZob1dla3doMkMzTnZTUFhZL1l0ZHVKK295ZjJ2QTdQMXdHSzMKdjJVRDIwL09YUnZxd2dTUlBVOHVtK3NxU0Rab0NKeWxFZXZ4aHFmZXFzUk5vdDAwNGJPY2ZjQlUydnpnR0wwPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
+        service:
+          name: webhook-service
+          namespace: activemq-artemis-operator
+          path: /convert
+      conversionReviewVersions:
+      - v1beta1
+  group: broker.amq.io
+  names:
+    kind: ActiveMQArtemisScaledown
+    listKind: ActiveMQArtemisScaledownList
+    plural: activemqartemisscaledowns
+    singular: activemqartemisscaledown
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: ActiveMQArtemisScaledown is the Schema for the activemqartemisscaledowns API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ActiveMQArtemisScaledownSpec defines the desired state of ActiveMQArtemisScaledown
+            properties:
+              localOnly:
+                description: Triggered by main ActiveMQArtemis CRD messageMigration entry
+                type: boolean
+              resources:
+                description: ResourceRequirements describes the compute resource requirements.
+                properties:
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    type: object
+                type: object
+            required:
+            - localOnly
+            type: object
+          status:
+            description: ActiveMQArtemisScaledownStatus defines the observed state of ActiveMQArtemisScaledown
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - name: v2alpha1
+    schema:
+      openAPIV3Schema:
+        description: ActiveMQArtemisScaledown is the Schema for the activemqartemisscaledowns API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ActiveMQArtemisScaledownSpec defines the desired state of ActiveMQArtemisScaledown
+            properties:
+              localOnly:
+                description: Triggered by main ActiveMQArtemis CRD messageMigration entry
+                type: boolean
+            required:
+            - localOnly
+            type: object
+          status:
+            description: ActiveMQArtemisScaledownStatus defines the observed state of ActiveMQArtemisScaledown
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/deploy/crds/broker_activemqartemissecurity_crd.yaml
+++ b/deploy/crds/broker_activemqartemissecurity_crd.yaml
@@ -1,0 +1,776 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.7.0
+  name: activemqartemissecurities.broker.amq.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUdpekNDQkhPZ0F3SUJBZ0lVWXh6UkpyemJuUnFBUDhqQ1pETnA5QlRFMW5Zd0RRWUpLb1pJaHZjTkFRRUwKQlFBd2dhc3hDekFKQmdOVkJBWVRBbFZUTVJNd0VRWURWUVFJREFwRFlXeHBabTl5Ym1saE1SUXdFZ1lEVlFRSApEQXRNYjNNZ1FXNW5aV3hsY3pFVk1CTUdBMVVFQ2d3TVFYSjBaVzFwYzBOc2IzVmtNUkV3RHdZRFZRUUxEQWhQCmNHVnlZWFJ2Y2pGSE1FVUdBMVVFQXd3K1lXTjBhWFpsYlhFdFlYSjBaVzFwY3kxM1pXSm9iMjlyTFhObGNuWnAKWTJVdVlXTjBhWFpsYlhFdFlYSjBaVzFwY3kxdmNHVnlZWFJ2Y2k1emRtTXdIaGNOTWpFeE1qSTBNVE0xTXpBegpXaGNOTXpFeE1qSXlNVE0xTXpBeldqQ0JxekVMTUFrR0ExVUVCaE1DVlZNeEV6QVJCZ05WQkFnTUNrTmhiR2xtCmIzSnVhV0V4RkRBU0JnTlZCQWNNQzB4dmN5QkJibWRsYkdWek1SVXdFd1lEVlFRS0RBeEJjblJsYldselEyeHYKZFdReEVUQVBCZ05WQkFzTUNFOXdaWEpoZEc5eU1VY3dSUVlEVlFRRERENWhZM1JwZG1WdGNTMWhjblJsYldsegpMWGRsWW1odmIyc3RjMlZ5ZG1salpTNWhZM1JwZG1WdGNTMWhjblJsYldsekxXOXdaWEpoZEc5eUxuTjJZekNDCkFpSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnSVBBRENDQWdvQ2dnSUJBS3VRT0Y0aHdLK0xRejJnRGZ3aENQczAKeTJVVXp3SmN5SVhWY1VDeElXNDhMeWw1NXdvZkZhWmk1MHRyRisxUzM0OVAvNHFieDZQQVlmbk53Z0gvZmxKNQpXaFZoTG5DTFVrUjZYS3N0WWZIVjZBcW5BSlNXYWZPR2lGb2JHWVI4L1ZrdytKK3dCZHlGamRRc3NDNHczL0J1Cms2U3dLOFVEOFFFa1BKMGpyWHdPNkxvZnRxcVloWmd6N2poTEQxcXkyTDJmTFV6TVh0bEtReHI1Z2FNMzQwZ0cKaU9oNS96SGE1WmNsNXNMSzlRMlRtSk4vMVZGQjNNK2RzOEEreG1oS0pOSVNYaHMzRkpha2FYM05kQ2R4SVdYRQorOUtVU1BteXFKMmFaVEVlUHY2cXpCcVJOSlB6TjFhWURNZitFS2wwZ09hOG9NUzNVQVc3azRyZ2pNVWJ5dVFMCkExb0poVEdQcThiZWEwYUNGK1VaUCtEWFQ1YVJ3UWI4WCt1dWdqSFV4WGkrVndpUnJ1bXFFNWJlZ1kyK0h2Z1EKQWRNM0tSaTBVYVR2UXA4ajJUUG5pMVRCK0FYdmxlNjZwMFp3NE5HcWpaQTdVZGdTZlNBQzkxT1B5bnE0T0QvdQowYnloZVFFTjUvVmtJVzE4UVV6TkMxMVBFWmhFOXhXQ0JvdnEvSytEMjRNcllEb3MrQm84blFSY3c5UjN4ZW8vCmJpd3o2dXlVamJSUEgreStzVlJXeXhsdUNnRnVMdFVuMFlyZTE3Q1FQZnp3aXRNaStZWjhBb3ZYeHZZSlhFSm0KSE9nbzdqOFpFWVlTWDNCNS9GOVoyei9hSlJtc3dTUHVrT0RtZ0REZEJDWURZNk1ya1BYVTZocS8rYmtQcGZJbQp0N05sSHB3N0RuOEYzRzNDdjRBWEFnTUJBQUdqZ2FRd2dhRXdDd1lEVlIwUEJBUURBZ1F3TUJNR0ExVWRKUVFNCk1Bb0dDQ3NHQVFVRkJ3TUJNSDBHQTFVZEVRUjJNSFNDUG1GamRHbDJaVzF4TFdGeWRHVnRhWE10ZDJWaWFHOXYKYXkxelpYSjJhV05sTG1GamRHbDJaVzF4TFdGeWRHVnRhWE10YjNCbGNtRjBiM0l1YzNaamdqSmhiWEV0WW5KdgphMlZ5TFhkbFltaHZiMnN0YzJWeWRtbGpaUzVoYlhFdFluSnZhMlZ5TFc5d1pYSmhkRzl5TG5OMll6QU5CZ2txCmhraUc5dzBCQVFzRkFBT0NBZ0VBU0ZqT1NyMWVaVzh5dlpXTkx0L0hXaU1TK0E3MlNTODkySnhlTlZCTTNEVWUKMEVrSllnaXk1QzJqaWN6WFdLWXl4ZUo2TDdIVWwzNmZRbFptOC9Ea1NETUlrOTByd1dFWE45RUdIRUpIdEN0WAo0L0l4elJsTVJYK1Ric3FJZFF3SjlpNkFtVjBqaUdlcFpEOStpTi9nL2pYT2NSSFAza3dFVWkxcG9Uc3E5ZkZ0ClRtYU9HYjRZeXN5dWx4S1VtcTlDU1NpbkpNeW01S2o0cUFJSEVDS2RaaTg4b2JUeHl6b1VvY1RNeWw5ZXdTU0UKZDQrakRiWTBQWEc5OXpCZ0FKbjVSSEs3Qm0yL1N0MnNZMy9xUWhsbVZSTWg4eU9sZk9OVDc0WlRJSlFvZDljVwpZOHdqMGY4dmx5VVFreGd6OHZyTVpSV3kvNHhhazViTWw0NkE2SEk4SWJ6eldXaEUwTVdPWkprR1MxMHo1dVdHCkNMYyswdHJVcHprNWFoNXU5QVZZQXhYNUlKeDIxdVBYUnUydmZ6VDBYOE9kNkF1SXd3djFLUUxpSFBNWG9sTysKdjhKejNlZEhVMDBlajFPeGN3OGkzbVNyUDVKNVlONkQrdUFhVWtWNTZzMlk0SlNiME41a0kyT2tRNjMwbGRZUApROGNxQVBRczFwODRuK2xveVVrWnZsSUdkNVVYSTZuWXFNTFQ4dGZoVGFzQVNuOW4zREtGRGJ3VE85eG01bldWCjlrZk1HVWdHNWVoLzFVZmxQWlA4UmhkVTlVbjZob1dla3doMkMzTnZTUFhZL1l0ZHVKK295ZjJ2QTdQMXdHSzMKdjJVRDIwL09YUnZxd2dTUlBVOHVtK3NxU0Rab0NKeWxFZXZ4aHFmZXFzUk5vdDAwNGJPY2ZjQlUydnpnR0wwPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
+        service:
+          name: webhook-service
+          namespace: activemq-artemis-operator
+          path: /convert
+      conversionReviewVersions:
+      - v1beta1
+  group: broker.amq.io
+  names:
+    kind: ActiveMQArtemisSecurity
+    listKind: ActiveMQArtemisSecurityList
+    plural: activemqartemissecurities
+    singular: activemqartemissecurity
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ActiveMQArtemisSecurity is the Schema for the activemqartemissecurities API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ActiveMQArtemisSecuritySpec defines the desired state of ActiveMQArtemisSecurity
+            properties:
+              applyToCrNames:
+                items:
+                  type: string
+                type: array
+              loginModules:
+                properties:
+                  guestLoginModules:
+                    items:
+                      properties:
+                        guestRole:
+                          type: string
+                        guestUser:
+                          type: string
+                        name:
+                          type: string
+                      type: object
+                    type: array
+                  keycloakLoginModules:
+                    items:
+                      properties:
+                        configuration:
+                          properties:
+                            allowAnyHostName:
+                              type: boolean
+                            alwaysRefreshToken:
+                              type: boolean
+                            authServerUrl:
+                              type: string
+                            autoDetectBearerOnly:
+                              type: boolean
+                            bearerOnly:
+                              type: boolean
+                            clientKeyPassword:
+                              type: string
+                            clientKeyStore:
+                              type: string
+                            clientKeyStorePassword:
+                              type: string
+                            confidentialPort:
+                              format: int32
+                              type: integer
+                            connectionPoolSize:
+                              format: int64
+                              type: integer
+                            corsAllowedHeaders:
+                              type: string
+                            corsAllowedMethods:
+                              type: string
+                            corsExposedHeaders:
+                              type: string
+                            corsMaxAge:
+                              format: int64
+                              type: integer
+                            credentials:
+                              items:
+                                properties:
+                                  key:
+                                    type: string
+                                  value:
+                                    type: string
+                                type: object
+                              type: array
+                            disableTrustManager:
+                              type: boolean
+                            enableBasicAuth:
+                              type: boolean
+                            enableCors:
+                              type: boolean
+                            exposeToken:
+                              type: boolean
+                            ignoreOauthQueryParameter:
+                              type: boolean
+                            minTimeBetweenJwksRequests:
+                              format: int64
+                              type: integer
+                            principalAttribute:
+                              type: string
+                            proxyUrl:
+                              type: string
+                            publicClient:
+                              type: boolean
+                            publicKeyCacheTtl:
+                              format: int64
+                              type: integer
+                            realm:
+                              type: string
+                            realmPublicKey:
+                              type: string
+                            redirectRewriteRules:
+                              items:
+                                properties:
+                                  key:
+                                    type: string
+                                  value:
+                                    type: string
+                                type: object
+                              type: array
+                            registerNodeAtStartup:
+                              type: boolean
+                            registerNodePeriod:
+                              format: int64
+                              type: integer
+                            resource:
+                              type: string
+                            scope:
+                              type: string
+                            sslRequired:
+                              type: string
+                            tokenCookiePath:
+                              type: string
+                            tokenMinimumTimeToLive:
+                              format: int64
+                              type: integer
+                            tokenStore:
+                              type: string
+                            trustStore:
+                              type: string
+                            trustStorePassword:
+                              type: string
+                            turnOffChangeSessionIdOnLogin:
+                              type: boolean
+                            useResourceRoleMappings:
+                              type: boolean
+                            verifyTokenAudience:
+                              type: boolean
+                          required:
+                          - enableBasicAuth
+                          type: object
+                        moduleType:
+                          type: string
+                        name:
+                          type: string
+                      type: object
+                    type: array
+                  propertiesLoginModules:
+                    items:
+                      properties:
+                        name:
+                          type: string
+                        users:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                              password:
+                                type: string
+                              roles:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          type: array
+                      type: object
+                    type: array
+                type: object
+              securityDomains:
+                properties:
+                  brokerDomain:
+                    properties:
+                      loginModules:
+                        items:
+                          properties:
+                            debug:
+                              type: boolean
+                            flag:
+                              type: string
+                            name:
+                              type: string
+                            reload:
+                              type: boolean
+                          type: object
+                        type: array
+                      name:
+                        type: string
+                    type: object
+                  consoleDomain:
+                    properties:
+                      loginModules:
+                        items:
+                          properties:
+                            debug:
+                              type: boolean
+                            flag:
+                              type: string
+                            name:
+                              type: string
+                            reload:
+                              type: boolean
+                          type: object
+                        type: array
+                      name:
+                        type: string
+                    type: object
+                type: object
+              securitySettings:
+                properties:
+                  broker:
+                    items:
+                      properties:
+                        match:
+                          type: string
+                        permissions:
+                          items:
+                            properties:
+                              operationType:
+                                type: string
+                              roles:
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - operationType
+                            type: object
+                          type: array
+                      type: object
+                    type: array
+                  management:
+                    properties:
+                      authorisation:
+                        properties:
+                          allowedList:
+                            items:
+                              properties:
+                                domain:
+                                  type: string
+                                key:
+                                  type: string
+                              type: object
+                            type: array
+                          defaultAccess:
+                            items:
+                              properties:
+                                method:
+                                  type: string
+                                roles:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            type: array
+                          roleAccess:
+                            items:
+                              properties:
+                                accessList:
+                                  items:
+                                    properties:
+                                      method:
+                                        type: string
+                                      roles:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  type: array
+                                domain:
+                                  type: string
+                                key:
+                                  type: string
+                              type: object
+                            type: array
+                        type: object
+                      connector:
+                        properties:
+                          authenticatorType:
+                            type: string
+                          host:
+                            type: string
+                          jmxRealm:
+                            type: string
+                          keyStorePassword:
+                            type: string
+                          keyStorePath:
+                            type: string
+                          keyStoreProvider:
+                            type: string
+                          objectName:
+                            type: string
+                          passwordCodec:
+                            type: string
+                          port:
+                            format: int32
+                            type: integer
+                          rmiRegistryPort:
+                            format: int32
+                            type: integer
+                          secured:
+                            type: boolean
+                          trustStorePassword:
+                            type: string
+                          trustStorePath:
+                            type: string
+                          trustStoreProvider:
+                            type: string
+                        type: object
+                      hawtioRoles:
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                type: object
+            type: object
+          status:
+            description: ActiveMQArtemisSecurityStatus defines the observed state of ActiveMQArtemisSecurity
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: ActiveMQArtemisSecurity is the Schema for the activemqartemissecurities API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ActiveMQArtemisSecuritySpec defines the desired state of ActiveMQArtemisSecurity
+            properties:
+              applyToCrNames:
+                description: Apply this security config to the broker crs in the current namespace. A value of * or empty string means applying to all broker crs. Default apply to all broker crs
+                items:
+                  type: string
+                type: array
+              loginModules:
+                properties:
+                  guestLoginModules:
+                    items:
+                      properties:
+                        guestRole:
+                          description: The guest user role
+                          type: string
+                        guestUser:
+                          description: The guest user name
+                          type: string
+                        name:
+                          description: Name for GuestLoginModule
+                          type: string
+                      type: object
+                    type: array
+                  keycloakLoginModules:
+                    items:
+                      properties:
+                        configuration:
+                          properties:
+                            allowAnyHostName:
+                              description: If to allow any host name
+                              type: boolean
+                            alwaysRefreshToken:
+                              description: If always refresh token
+                              type: boolean
+                            authServerUrl:
+                              description: URL of the keycloak authentication server
+                              type: string
+                            autoDetectBearerOnly:
+                              description: If auto-detect bearer token only
+                              type: boolean
+                            bearerOnly:
+                              description: If only verify bearer token
+                              type: boolean
+                            clientKeyPassword:
+                              description: Client key password
+                              type: string
+                            clientKeyStore:
+                              description: Path of a client keystore
+                              type: string
+                            clientKeyStorePassword:
+                              description: Client keystore password
+                              type: string
+                            confidentialPort:
+                              description: The confidential port used by the Keycloak server for secure connections over SSL/TLS
+                              format: int32
+                              type: integer
+                            connectionPoolSize:
+                              description: Size of the connection pool
+                              format: int64
+                              type: integer
+                            corsAllowedHeaders:
+                              description: CORS allowed headers
+                              type: string
+                            corsAllowedMethods:
+                              description: CORS allowed methods
+                              type: string
+                            corsExposedHeaders:
+                              description: CORS exposed headers
+                              type: string
+                            corsMaxAge:
+                              description: CORS max age
+                              format: int64
+                              type: integer
+                            credentials:
+                              items:
+                                properties:
+                                  key:
+                                    description: The credentials key
+                                    type: string
+                                  value:
+                                    description: The credentials value
+                                    type: string
+                                type: object
+                              type: array
+                            disableTrustManager:
+                              description: If to disable trust manager
+                              type: boolean
+                            enableBasicAuth:
+                              description: Whether to support basic authentication
+                              type: boolean
+                            enableCors:
+                              description: If to enable CORS
+                              type: boolean
+                            exposeToken:
+                              description: If to expose access token
+                              type: boolean
+                            ignoreOauthQueryParameter:
+                              description: Whether to turn off processing of the access_token query parameter for bearer token processing
+                              type: boolean
+                            minTimeBetweenJwksRequests:
+                              description: Minimum interval between two requests to Keycloak to retrieve new public keys
+                              format: int64
+                              type: integer
+                            principalAttribute:
+                              description: OpenID Connect ID Token attribute to populate the UserPrincipal name with
+                              type: string
+                            proxyUrl:
+                              description: The proxy URL
+                              type: string
+                            publicClient:
+                              description: If it is public client
+                              type: boolean
+                            publicKeyCacheTtl:
+                              description: Maximum interval between two requests to Keycloak to retrieve new public keys
+                              format: int64
+                              type: integer
+                            realm:
+                              description: Realm for KeycloakLoginModule
+                              type: string
+                            realmPublicKey:
+                              description: Public key for the realm
+                              type: string
+                            redirectRewriteRules:
+                              description: The regular expression to which the Redirect URI is to be matched value is the replacement String
+                              items:
+                                properties:
+                                  key:
+                                    description: The credentials key
+                                    type: string
+                                  value:
+                                    description: The credentials value
+                                    type: string
+                                type: object
+                              type: array
+                            registerNodeAtStartup:
+                              description: If register node at startup
+                              type: boolean
+                            registerNodePeriod:
+                              description: Period for re-registering node
+                              format: int64
+                              type: integer
+                            resource:
+                              description: Resource Name
+                              type: string
+                            scope:
+                              description: The OAuth2 scope parameter for DirectAccessGrantsLoginModule
+                              type: string
+                            sslRequired:
+                              description: How SSL is required
+                              type: string
+                            tokenCookiePath:
+                              description: Cookie path for a cookie store
+                              type: string
+                            tokenMinimumTimeToLive:
+                              description: Minimum time to refresh an active access token
+                              format: int64
+                              type: integer
+                            tokenStore:
+                              description: Type of token store. session or cookie
+                              type: string
+                            trustStore:
+                              description: Path of a trust store
+                              type: string
+                            trustStorePassword:
+                              description: Truststore password
+                              type: string
+                            turnOffChangeSessionIdOnLogin:
+                              description: If not to change session id on a successful login
+                              type: boolean
+                            useResourceRoleMappings:
+                              description: If to use resource role mappings
+                              type: boolean
+                            verifyTokenAudience:
+                              description: Verify whether the token contains this client name (resource) as an audience
+                              type: boolean
+                          required:
+                          - enableBasicAuth
+                          type: object
+                        moduleType:
+                          description: Type of KeycloakLoginModule directAccess or bearerToken
+                          type: string
+                        name:
+                          description: Name for KeycloakLoginModule
+                          type: string
+                      type: object
+                    type: array
+                  propertiesLoginModules:
+                    items:
+                      properties:
+                        name:
+                          description: Name for PropertiesLoginModule
+                          type: string
+                        users:
+                          items:
+                            properties:
+                              name:
+                                description: User name to be defined in properties login module
+                                type: string
+                              password:
+                                description: Password to be defined in properties login module
+                                type: string
+                              roles:
+                                description: Roles to be defined in properties login module
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          type: array
+                      type: object
+                    type: array
+                type: object
+              securityDomains:
+                properties:
+                  brokerDomain:
+                    properties:
+                      loginModules:
+                        items:
+                          properties:
+                            debug:
+                              description: Debug option of login modules for broker/console domain
+                              type: boolean
+                            flag:
+                              description: Flag of login modules for broker/console domain
+                              type: string
+                            name:
+                              description: Name for login modules for broker/console domain
+                              type: string
+                            reload:
+                              description: Reload option of login modules for broker/console domain
+                              type: boolean
+                          type: object
+                        type: array
+                      name:
+                        description: Name for the broker/console domain
+                        type: string
+                    type: object
+                  consoleDomain:
+                    properties:
+                      loginModules:
+                        items:
+                          properties:
+                            debug:
+                              description: Debug option of login modules for broker/console domain
+                              type: boolean
+                            flag:
+                              description: Flag of login modules for broker/console domain
+                              type: string
+                            name:
+                              description: Name for login modules for broker/console domain
+                              type: string
+                            reload:
+                              description: Reload option of login modules for broker/console domain
+                              type: boolean
+                          type: object
+                        type: array
+                      name:
+                        description: Name for the broker/console domain
+                        type: string
+                    type: object
+                type: object
+              securitySettings:
+                properties:
+                  broker:
+                    items:
+                      properties:
+                        match:
+                          description: The address match pattern of a security setting
+                          type: string
+                        permissions:
+                          items:
+                            properties:
+                              operationType:
+                                description: The operation type of a security setting
+                                type: string
+                              roles:
+                                description: The roles of a security setting
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - operationType
+                            type: object
+                          type: array
+                      type: object
+                    type: array
+                  management:
+                    properties:
+                      authorisation:
+                        properties:
+                          allowedList:
+                            items:
+                              properties:
+                                domain:
+                                  description: The domain of allowedList
+                                  type: string
+                                key:
+                                  description: The key of allowedList
+                                  type: string
+                              type: object
+                            type: array
+                          defaultAccess:
+                            items:
+                              properties:
+                                method:
+                                  description: The method of defaultAccess/roleAccess List
+                                  type: string
+                                roles:
+                                  description: The roles of defaultAccess/roleAccess List
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            type: array
+                          roleAccess:
+                            items:
+                              properties:
+                                accessList:
+                                  items:
+                                    properties:
+                                      method:
+                                        description: The method of defaultAccess/roleAccess List
+                                        type: string
+                                      roles:
+                                        description: The roles of defaultAccess/roleAccess List
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  type: array
+                                domain:
+                                  description: The domain of roleAccess List
+                                  type: string
+                                key:
+                                  description: The key of roleAccess List
+                                  type: string
+                              type: object
+                            type: array
+                        type: object
+                      connector:
+                        properties:
+                          authenticatorType:
+                            description: The management authentication type
+                            type: string
+                          host:
+                            description: The connector host for connecting to management
+                            type: string
+                          jmxRealm:
+                            description: The JMX realm of management
+                            type: string
+                          keyStorePassword:
+                            description: The keystore password for management connector
+                            type: string
+                          keyStorePath:
+                            description: The keystore path for management connector
+                            type: string
+                          keyStoreProvider:
+                            description: The keystore provider for management connector
+                            type: string
+                          objectName:
+                            description: The JMX object name of management
+                            type: string
+                          passwordCodec:
+                            description: The password codec for management connector
+                            type: string
+                          port:
+                            description: The connector port for connecting to management
+                            format: int32
+                            type: integer
+                          rmiRegistryPort:
+                            description: The RMI registry port for management
+                            format: int32
+                            type: integer
+                          secured:
+                            description: Whether management connection is secured
+                            type: boolean
+                          trustStorePassword:
+                            description: The truststore password for management connector
+                            type: string
+                          trustStorePath:
+                            description: The truststore path for management connector
+                            type: string
+                          trustStoreProvider:
+                            description: The truststore provider for management connector
+                            type: string
+                        type: object
+                      hawtioRoles:
+                        description: The roles allowed to login hawtio
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                type: object
+            required:
+            - loginModules
+            - securityDomains
+            - securitySettings
+            type: object
+          status:
+            description: ActiveMQArtemisSecurityStatus defines the observed state of ActiveMQArtemisSecurity
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/deploy/election_role.yaml
+++ b/deploy/election_role.yaml
@@ -1,0 +1,36 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: activemq-artemis-leader-election-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch

--- a/deploy/election_role_binding.yaml
+++ b/deploy/election_role_binding.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: activemq-artemis-leader-election-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: activemq-artemis-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: activemq-artemis-controller-manager

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -1,0 +1,86 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: activemq-artemis-controller-manager
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        control-plane: controller-manager
+    spec:
+      containers:
+      - args:
+        - --zap-log-level=debug
+        - --zap-encoder=console
+        - --leader-elect
+        command:
+        - /home/activemq-artemis-operator/bin/entrypoint
+        env:
+        - name: OPERATOR_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['name']
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: WATCH_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: RELATED_IMAGE_ActiveMQ_Artemis_Broker_Init_2150
+          value: quay.io/artemiscloud/activemq-artemis-broker-init:0.2.2
+        - name: RELATED_IMAGE_ActiveMQ_Artemis_Broker_Init_2160
+          value: quay.io/artemiscloud/activemq-artemis-broker-init:0.2.4
+        - name: RELATED_IMAGE_ActiveMQ_Artemis_Broker_Init_2180
+          value: quay.io/artemiscloud/activemq-artemis-broker-init:0.2.10
+        - name: RELATED_IMAGE_ActiveMQ_Artemis_Broker_Init_2200
+          value: quay.io/artemiscloud/activemq-artemis-broker-init:0.2.12
+        - name: RELATED_IMAGE_ActiveMQ_Artemis_Broker_Kubernetes_2150
+          value: quay.io/artemiscloud/activemq-artemis-broker-kubernetes:0.2.0
+        - name: RELATED_IMAGE_ActiveMQ_Artemis_Broker_Kubernetes_2160
+          value: quay.io/artemiscloud/activemq-artemis-broker-kubernetes:0.2.1
+        - name: RELATED_IMAGE_ActiveMQ_Artemis_Broker_Kubernetes_2180
+          value: quay.io/artemiscloud/activemq-artemis-broker-kubernetes:0.2.7
+        - name: RELATED_IMAGE_ActiveMQ_Artemis_Broker_Kubernetes_2200
+          value: quay.io/artemiscloud/activemq-artemis-broker-kubernetes:0.2.9
+        - name: ENABLE_WEBHOOKS
+          value: "false"
+        image: quay.io/artemiscloud/activemq-artemis-operator:1.0.0
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: manager
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 200m
+            memory: 100Mi
+          requests:
+            cpu: 100m
+            memory: 20Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+      securityContext:
+        runAsNonRoot: true
+      serviceAccountName: activemq-artemis-controller-manager
+      terminationGracePeriodSeconds: 10

--- a/deploy/operator_config.yaml
+++ b/deploy/operator_config.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+data:
+  controller_manager_config.yaml: |
+    apiVersion: controller-runtime.sigs.k8s.io/v1alpha1
+    kind: ControllerManagerConfig
+    health:
+      healthProbeBindAddress: :8081
+    metrics:
+      bindAddress: 127.0.0.1:8080
+    webhook:
+      port: 9443
+    leaderElection:
+      leaderElect: true
+      resourceName: d864aab0.amq.io
+kind: ConfigMap
+metadata:
+  name: activemq-artemis-manager-config

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -1,0 +1,89 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: activemq-artemis-operator
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - configmaps
+  - secrets
+  - routes
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - broker.amq.io
+  resources:
+  - '*'
+  - activemqartemisaddresses
+  - activemqartemisscaledowns
+  - activemqartemis
+  - activemqartemissecurities
+  verbs:
+  - '*'
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  - routes/custom-host
+  - routes/status
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - update
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - apps
+  resources:
+  - deployments/finalizers
+  verbs:
+  - update

--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -1,0 +1,11 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: activemq-artemis-operator
+subjects:
+- kind: ServiceAccount
+  name: activemq-artemis-controller-manager
+roleRef:
+  kind: Role
+  name: activemq-artemis-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy/service_account.yaml
+++ b/deploy/service_account.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: activemq-artemis-controller-manager

--- a/hack/static_manifest_gen.sh
+++ b/hack/static_manifest_gen.sh
@@ -1,0 +1,143 @@
+#!/bin/bash
+
+# service accounts, role/rolebinding, operator resources
+mkdir -p $1
+# crds
+mkdir -p $1/crds
+
+destdir=$1
+crdsdir=$1/crds
+file=()
+resource_kind=""
+resource_name=""
+
+# write a single yaml.
+# it takes one parameter:
+# 1 array that contains total lines of the yaml
+function writeFile() {
+  array_name=$1[@]
+  lines=("${!array_name}")
+
+  case $resource_kind in
+
+    CustomResourceDefinition)
+      if [[ ${resource_name} =~ (activemqartemises) ]]; then
+        file_path="$crdsdir/broker_activemqartemis_crd.yaml"
+      elif [[ ${resource_name} =~ (activemqartemissecurities) ]]; then
+        file_path="$crdsdir/broker_activemqartemissecurity_crd.yaml"
+      elif [[ ${resource_name} =~ (activemqartemisaddresses) ]]; then
+        file_path="$crdsdir/broker_activemqartemisaddress_crd.yaml"
+      elif [[ ${resource_name} =~ (activemqartemisscaledowns) ]]; then
+        file_path="$crdsdir/broker_activemqartemisscaledown_crd.yaml"
+      else
+        file_path="$crdsdir/${resource_name}.yaml"
+      fi
+      ;;
+
+    Deployment)
+      file_path="$destdir/operator.yaml"
+      ;;
+
+    ClusterRoleBinding)
+      file_path="$destdir/cluster_role_binding.yaml"
+      ;;
+
+    ClusterRole)
+      file_path="$destdir/cluster_role.yaml"
+      ;;
+
+    ServiceAccount)
+      file_path="$destdir/service_account.yaml"
+      ;;
+
+    ConfigMap)
+      file_path="$destdir/operator_config.yaml"
+      ;;
+
+    Role)
+      file_path="$destdir/election_role.yaml"
+      ;;
+
+    RoleBinding)
+      file_path="$destdir/election_role_binding.yaml"
+      ;;
+
+    Namespace)
+      file_path="skip_this_file"
+      ;;
+    
+    *)
+      file_path="$destdir/${resource_kind}_${resource_name}.yaml"
+      ;;
+    esac
+
+  if [[ ${file_path} != "skip_this_file" ]]; then
+    rm -rf ${file_path}
+    for value in "${file[@]}"
+      do
+        printf "%s\n" "${value}" >> ${file_path}
+      done
+  fi
+}
+
+function beginFile() {
+  if [[ ${#file[@]} > 0 ]]
+  then
+    # it gathered a single file now
+    writeFile file
+  fi
+  file=()
+}
+
+function appendFile() {
+  file+=("$1")
+}
+
+IFS=''
+while read -r line
+do
+  if [[ $line =~ ^---$ ]]
+  then
+    beginFile
+    resource_kind=""
+    resource_name=""
+    meta_start="false"
+  else
+    to_append="true"
+
+    if [[ $resource_kind == "" && $line =~ ^(kind: ) ]]
+    then
+      resource_kind=$(echo $line | cut -b 7-)
+    fi
+
+    if [[ $line =~ ^(metadata:) ]]
+    then
+      meta_start="true"
+    elif [[ ! $line =~ ^("  ") ]]; then
+      meta_start="false"
+    elif [[ ${meta_start} == "true" ]]; then
+      if [[ $line =~ ^(  name: ) ]]; then
+        resource_name=$(echo $line | cut -b 9-)
+      elif [[ $line =~ ^(  namespace: ) ]]; then
+        to_append="false"
+      fi
+    fi
+
+    if [[ $resource_kind == "RoleBinding" ]]; then
+      if [[ $line =~ ^(subjects:) ]]; then
+        rb_subjects="true"
+      elif [[ ${rb_subjects} == "true" ]]; then
+        if [[ $line =~ ^(  namespace: ) ]]; then
+          to_append="false"
+        fi
+      fi
+    fi
+
+    if [[ $to_append == "true" ]]; then
+      appendFile "$line"
+    fi
+  fi
+done
+# check the last one
+beginFile
+

--- a/pkg/draincontroller/controller.go
+++ b/pkg/draincontroller/controller.go
@@ -19,7 +19,9 @@ package draincontroller
 import (
 	"context"
 	"fmt"
+
 	brokerv1beta1 "github.com/artemiscloud/activemq-artemis-operator/api/v1beta1"
+
 	//"github.com/artemiscloud/activemq-artemis-operator/pkg/client/clientset/versioned/typed/broker/v1beta1"
 	"os"
 	"time"
@@ -118,6 +120,11 @@ type Controller struct {
 	client client.Client
 }
 
+func eventLog(format string, args ...interface{}) {
+	formatted := fmt.Sprintf(format, args...)
+	dlog.Info(formatted)
+}
+
 // NewController returns a new sample controller
 func NewController(
 	// controller name is the target namespace
@@ -140,7 +147,7 @@ func NewController(
 	// logged for statefulset-drain-controller types.
 	dlog.V(4).Info("Creating event broadcaster")
 	eventBroadcaster := record.NewBroadcaster()
-	eventBroadcaster.StartLogging(dlog.Info)
+	eventBroadcaster.StartLogging(eventLog)
 	eventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: kubeclientset.CoreV1().Events(namespace)})
 	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: controllerAgentName})
 	itemExponentialFailureRateLimiter := workqueue.NewItemExponentialFailureRateLimiter(5*time.Second, 300*time.Second)


### PR DESCRIPTION
Also:
added missing permissions for doing scaledown cluster wide
added eventLog function to drainer controller to handle the event log
instead of using log.Info() which requires keys to always be string type