### PR TITLE
speed up scaledown test - exposed a missing exec on the broker proces…

### DIFF
--- a/controllers/activemqartemisscaledown_controller_test.go
+++ b/controllers/activemqartemisscaledown_controller_test.go
@@ -61,7 +61,10 @@ var _ = Describe("Scale down controller", func() {
 			brokerCrd.Spec.DeploymentPlan.Clustered = &clustered
 			brokerCrd.Spec.DeploymentPlan.Size = 2
 			brokerCrd.Spec.DeploymentPlan.PersistenceEnabled = true
-
+			brokerCrd.Spec.DeploymentPlan.ReadinessProbe = &corev1.Probe{
+				InitialDelaySeconds: 1,
+				PeriodSeconds:       5,
+			}
 			Expect(k8sClient.Create(ctx, brokerCrd)).Should(Succeed())
 
 			createdBrokerCrd := &brokerv1beta1.ActiveMQArtemis{}

--- a/pkg/resources/containers/container.go
+++ b/pkg/resources/containers/container.go
@@ -26,7 +26,7 @@ func MakeContainer(hostingPodSpec *corev1.PodSpec, customResourceName string, im
 	if container == nil {
 		container = &corev1.Container{
 			Name:    name,
-			Command: []string{"/bin/sh", "-c", "export STATEFUL_SET_ORDINAL=${HOSTNAME##*-};/opt/amq/bin/launch.sh", "start"},
+			Command: []string{"/bin/sh", "-c", "export STATEFUL_SET_ORDINAL=${HOSTNAME##*-};exec /opt/amq/bin/launch.sh", "start"},
 		}
 	}
 


### PR DESCRIPTION
…s, causing it to loose sigterm from #195 and delay for the hard coded terminationGracePeriodSeconds of 60s