### PR TITLE
#239 Addresses are not created in all the deployed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,10 @@ test: manifests generate fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test  ./... $(TEST_ARGS) -coverprofile cover.out
 
 test-mk: manifests generate fmt vet envtest ## Run tests.
-	USE_EXISTING_CLUSTER=true ENABLE_WEBHOOKS=false go test  ./... $(TEST_ARGS) -coverprofile cover.out
+	USE_EXISTING_CLUSTER=true ENABLE_WEBHOOKS=false go test  ./... $(TEST_ARGS)
+
+test-mk-do: manifests generate fmt vet envtest ## Run tests with operator deployed
+	DEPLOY_OPERATOR=true USE_EXISTING_CLUSTER=true ENABLE_WEBHOOKS=false go test  ./controllers/... -ginkgo.focus \"Address controller\" -ginkgo.v
 
 ##@ Build
 
@@ -128,6 +131,9 @@ docker-build-debug: test generate-deploy ## Build debug version of docker image 
 
 docker-push: ## Push docker image with the manager.
 	docker push ${IMG}
+
+podman-remote-build: build generate-deploy
+	podman-remote build -t ${IMG} .
 
 ##@ Deployment
 

--- a/controllers/activemqartemis_reconciler.go
+++ b/controllers/activemqartemis_reconciler.go
@@ -2355,8 +2355,8 @@ func GetPodStatus(cr *brokerv1beta1.ActiveMQArtemis, client rtclient.Client, nam
 	reqLogger.V(1).Info("status.Ready len is " + fmt.Sprint(len(status.Ready)))
 	if len(status.Ready) > len(lastStatus.Ready) {
 		// More pods ready, let the address controller know
-		newPodCount := len(status.Ready) - len(lastStatus.Ready)
-		for i := newPodCount - 1; i < len(status.Ready); i++ {
+		for i := len(lastStatus.Ready); i < len(status.Ready); i++ {
+			reqLogger.V(1).Info("Notifying address controller", "new ready", i)
 			channels.AddressListeningCh <- types.NamespacedName{namespacedName.Namespace, status.Ready[i]}
 		}
 	}

--- a/controllers/activemqartemisaddress_controller_test.go
+++ b/controllers/activemqartemisaddress_controller_test.go
@@ -1,0 +1,246 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+// +kubebuilder:docs-gen:collapse=Apache License
+
+/*
+As usual, we start with the necessary imports. We also define some utility variables.
+*/
+package controllers
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+
+	brokerv1beta1 "github.com/artemiscloud/activemq-artemis-operator/api/v1beta1"
+	"github.com/artemiscloud/activemq-artemis-operator/pkg/utils/namer"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/remotecommand"
+)
+
+// To run this test using the following command
+// export OPERATOR_IMAGE="<the test operator image>";export DEPLOY_OPERATOR="true";export TEST_ARGS="-ginkgo.focus \"Address controller\" -ginkgo.v"; make -e test-mk
+// if OPERATOR_IMAGE is not defined the test will use the latest dev tag
+var _ = Describe("Address controller", func() {
+
+	const (
+		namespace               = "default"
+		existingClusterTimeout  = time.Second * 180
+		existingClusterInterval = time.Second * 10
+		verobse                 = false
+	)
+
+	Context("Address test", func() {
+		It("Deploy CR with size 5 (pods)", func() {
+
+			ctx := context.Background()
+
+			brokerCrd := generateArtemisSpec(namespace)
+
+			brokerName := "ex-aao-broker"
+
+			brokerCrd.Name = brokerName
+
+			brokerCrd.Spec.DeploymentPlan.Size = 5
+
+			brokerCrd.Spec.DeploymentPlan.ReadinessProbe = &corev1.Probe{
+				InitialDelaySeconds: 1,
+				PeriodSeconds:       5,
+			}
+			Expect(k8sClient.Create(ctx, &brokerCrd)).Should(Succeed())
+
+			createdBrokerCrd := &brokerv1beta1.ActiveMQArtemis{}
+
+			if os.Getenv("USE_EXISTING_CLUSTER") == "true" && os.Getenv("DEPLOY_OPERATOR") == "true" {
+
+				By("Waiting for all pods to be started and ready")
+				Eventually(func(g Gomega) {
+
+					getPersistedVersionedCrd(brokerCrd.ObjectMeta.Name, defaultNamespace, createdBrokerCrd)
+					g.Expect(len(createdBrokerCrd.Status.PodStatus.Ready)).Should(BeEquivalentTo(5))
+
+				}, existingClusterTimeout, existingClusterInterval).Should(Succeed())
+
+				By("creating 5 queue resources and 1 security")
+				addressCrs := make([]*brokerv1beta1.ActiveMQArtemisAddress, 5)
+				for i := 0; i < 5; i++ {
+					ordinal := strconv.FormatInt(int64(i), 10)
+					addressCrs[i] = generateAddressSpec("ex-aaoaddress"+ordinal, namespace, "myAddress"+ordinal, "myQueue"+ordinal, true, true)
+				}
+
+				// This may trigger another issue where some secrets are deleted during pod restart
+				propLoginModules := make([]brokerv1beta1.PropertiesLoginModuleType, 1)
+				pwd := "geezrick"
+				moduleName := "prop-module"
+				flag := "sufficient"
+				propLoginModules[0] = brokerv1beta1.PropertiesLoginModuleType{
+					Name: moduleName,
+					Users: []brokerv1beta1.UserType{
+						{Name: "morty",
+							Password: &pwd,
+							Roles:    []string{"admin", "random"}},
+					},
+				}
+
+				brokerDomainName := "activemq"
+				loginModules := make([]brokerv1beta1.LoginModuleReferenceType, 1)
+				loginModules[0] = brokerv1beta1.LoginModuleReferenceType{
+					Name: &moduleName,
+					Flag: &flag,
+				}
+				brokerDomain := brokerv1beta1.BrokerDomainType{
+					Name:         &brokerDomainName,
+					LoginModules: loginModules,
+				}
+
+				By("Deploying all resources at once")
+				_, deployedSecCrd := DeploySecurity("ex-proper", namespace, func(secCrdToDeploy *brokerv1beta1.ActiveMQArtemisSecurity) {
+					secCrdToDeploy.Spec.LoginModules.PropertiesLoginModules = propLoginModules
+					secCrdToDeploy.Spec.SecurityDomains.BrokerDomain = brokerDomain
+				})
+
+				for _, addr := range addressCrs {
+					DeployAddress(addr)
+				}
+
+				By("Waiting for all pods to be restarted and ready")
+				Eventually(func(g Gomega) {
+
+					getPersistedVersionedCrd(brokerCrd.ObjectMeta.Name, defaultNamespace, createdBrokerCrd)
+					g.Expect(len(createdBrokerCrd.Status.PodStatus.Ready)).Should(BeEquivalentTo(5))
+
+				}, existingClusterTimeout, existingClusterInterval).Should(Succeed())
+
+				By("Checking all addresses are created on all pods")
+
+				gvk := schema.GroupVersionKind{
+					Group:   "",
+					Version: "v1",
+					Kind:    "Pod",
+				}
+				restClient, err := apiutil.RESTClientForGVK(gvk, false, restConfig, serializer.NewCodecFactory(scheme.Scheme))
+				Expect(err).To(BeNil())
+
+				for ipod := 4; ipod >= 0; ipod-- {
+					podOrdinal := strconv.FormatInt(int64(ipod), 10)
+					podName := namer.CrToSS(brokerCrd.Name) + "-" + podOrdinal
+
+					Eventually(func(g Gomega) {
+						fmt.Println("Checking pod " + podName)
+						execReq := restClient.
+							Post().
+							Namespace(namespace).
+							Resource("pods").
+							Name(podName).
+							SubResource("exec").
+							VersionedParams(&corev1.PodExecOptions{
+								Container: brokerName + "-container",
+								Command:   []string{"amq-broker/bin/artemis", "queue", "stat", "--user", "morty", "--password", "geezrick", "--url", "tcp://" + podName + ":61616"},
+								Stdin:     true,
+								Stdout:    true,
+								Stderr:    true,
+							}, runtime.NewParameterCodec(scheme.Scheme))
+
+						exec, err := remotecommand.NewSPDYExecutor(restConfig, "POST", execReq.URL())
+
+						if err != nil {
+							fmt.Printf("error while creating remote command executor: %v", err)
+						}
+						Expect(err).To(BeNil())
+						var capturedOut bytes.Buffer
+
+						err = exec.Stream(remotecommand.StreamOptions{
+							Stdin:  os.Stdin,
+							Stdout: &capturedOut,
+							Stderr: os.Stderr,
+							Tty:    false,
+						})
+						g.Expect(err).To(BeNil())
+
+						By("Checking for output pod")
+						g.Expect(capturedOut.Len() > 0)
+						content := capturedOut.String()
+						fmt.Println("out: " + content)
+						g.Expect(content).Should(ContainSubstring("myQueue0"))
+						g.Expect(content).Should(ContainSubstring("myQueue1"))
+						g.Expect(content).Should(ContainSubstring("myQueue2"))
+						g.Expect(content).Should(ContainSubstring("myQueue3"))
+						g.Expect(content).Should(ContainSubstring("myQueue4"))
+					}, existingClusterTimeout, existingClusterInterval).Should(Succeed())
+				}
+
+				//clean up all resources
+				Expect(k8sClient.Delete(ctx, createdBrokerCrd)).Should(Succeed())
+				Expect(k8sClient.Delete(ctx, deployedSecCrd)).Should(Succeed())
+				for _, addr := range addressCrs {
+					Expect(k8sClient.Delete(ctx, addr)).Should((Succeed()))
+				}
+			}
+		})
+	})
+})
+
+func generateAddressSpec(name string, ns string, address string, queue string, isMulticast bool, autoDelete bool) *brokerv1beta1.ActiveMQArtemisAddress {
+
+	spec := brokerv1beta1.ActiveMQArtemisAddressSpec{}
+
+	spec.AddressName = address
+	spec.QueueName = &queue
+
+	routingType := "anycast"
+	if isMulticast {
+		routingType = "multicast"
+	}
+	spec.RoutingType = &routingType
+
+	toCreate := &brokerv1beta1.ActiveMQArtemisAddress{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ActiveMQArtemisAddress",
+			APIVersion: brokerv1beta1.GroupVersion.Identifier(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+		},
+		Spec: spec,
+	}
+
+	return toCreate
+}
+
+func DeployAddress(candidate *brokerv1beta1.ActiveMQArtemisAddress) {
+	ctx := context.Background()
+
+	Expect(k8sClient.Create(ctx, candidate)).Should(Succeed())
+
+	createdAddressCrd := &brokerv1beta1.ActiveMQArtemisAddress{}
+
+	Eventually(func() bool {
+		return getPersistedVersionedCrd(candidate.ObjectMeta.Name, candidate.Namespace, createdAddressCrd)
+	}, timeout, interval).Should(BeTrue())
+	Expect(createdAddressCrd.Name).Should(Equal(candidate.ObjectMeta.Name))
+}

--- a/controllers/activemqartemissecurity_controller_test.go
+++ b/controllers/activemqartemissecurity_controller_test.go
@@ -24,8 +24,6 @@ import (
 	"os"
 	"strings"
 
-	"time"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -37,15 +35,6 @@ import (
 	"github.com/artemiscloud/activemq-artemis-operator/pkg/utils/namer"
 	appsv1 "k8s.io/api/apps/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
-)
-
-// Define utility constants for object names and testing timeouts/durations and intervals.
-const (
-	defaultNamespace = "default"
-	timeout          = time.Second * 15
-	duration         = time.Second * 10
-	interval         = time.Millisecond * 250
-	verobse          = false
 )
 
 var _ = Describe("security controller", func() {
@@ -484,7 +473,7 @@ func DeploySecurity(secName string, targetNamespace string, customFunc func(cand
 	Eventually(func() bool {
 		return getPersistedVersionedCrd(secCrd.ObjectMeta.Name, targetNamespace, createdSecCrd)
 	}, timeout, interval).Should(BeTrue())
-	Expect(createdSecCrd.Name).Should(Equal(createdSecCrd.ObjectMeta.Name))
+	Expect(createdSecCrd.Name).Should(Equal(secCrd.ObjectMeta.Name))
 
 	return secCrd, createdSecCrd
 }

--- a/controllers/address_observer.go
+++ b/controllers/address_observer.go
@@ -119,11 +119,12 @@ func (c *AddressObserver) checkCRsForNewPod(newPod *corev1.Pod, labels map[strin
 		targetCrNamespacedNames := createTargetCrNamespacedNames(newPod.Namespace, a.Spec.ApplyToCrNames)
 		//e.g. ex-aao-ss
 		podSSName, statefulset := c.getSSNameForPod(newPod)
-		olog.Info("Got pod's ss name", "value", *podSSName)
 		if podSSName == nil {
 			olog.Info("Can't find pod's statefulset name", "pod", newPod.Name)
 			continue
 		}
+		olog.Info("Got pod's ss name", "value", *podSSName)
+
 		podCrName := namer.SSToCr(*podSSName)
 		olog.Info("got pod's CR name", "value", podCrName)
 		//if the new pod is a target for this address cr, create
@@ -157,7 +158,11 @@ func (c *AddressObserver) checkCRsForNewPod(newPod *corev1.Pod, labels map[strin
 
 			olog.Info("New Jolokia with ", "User: ", jolokiaUser, "Protocol: ", jolokiaProtocol)
 			artemis := mgmt.GetArtemis(newPod.Status.PodIP, "8161", "amq-broker", jolokiaUser, jolokiaPassword, jolokiaProtocol)
-			createAddressResource(artemis, &a)
+			jk := JkInfo{
+				Artemis: artemis,
+				IP:      newPod.Status.PodIP,
+			}
+			createAddressResource(&jk, &a)
 		}
 	}
 }

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -233,17 +233,14 @@ func waitForOperator() error {
 	opts := &client.ListOptions{
 		Namespace: defaultNamespace,
 	}
-	Eventually(func() bool {
-		err := k8sClient.List(ctx, podList, opts)
-		if err != nil {
-			return false
-		}
-		if len(podList.Items) != 1 {
-			return false
-		}
+	Eventually(func(g Gomega) {
+		g.Expect(k8sClient.List(ctx, podList, opts)).Should(Succeed())
+
+		g.Expect(len(podList.Items)).Should(BeEquivalentTo(1))
 		oprPod := podList.Items[0]
-		return oprPod.Status.ContainerStatuses[0].Ready
-	}, operatorTimeout, operatorInterval).Should(Equal(true))
+		g.Expect(len(oprPod.Status.ContainerStatuses)).Should(BeEquivalentTo(1))
+		g.Expect(oprPod.Status.ContainerStatuses[0].Ready).Should(BeTrue())
+	}, operatorTimeout, operatorInterval).Should(Succeed())
 	return nil
 }
 

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -18,7 +18,9 @@ package controllers
 
 import (
 	"context"
+	"io/ioutil"
 	"os"
+	"time"
 
 	routev1 "github.com/openshift/api/route/v1"
 
@@ -28,7 +30,9 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -45,21 +49,48 @@ import (
 
 	nsoptions "github.com/artemiscloud/activemq-artemis-operator/pkg/resources/namespaces"
 	"github.com/artemiscloud/activemq-artemis-operator/pkg/utils/common"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
+// Define utility constants for object names and testing timeouts/durations and intervals.
+const (
+	defaultNamespace = "default"
+	timeout          = time.Second * 15
+	duration         = time.Second * 10
+	interval         = time.Millisecond * 250
+	verobse          = false
+	operatorTimeout  = time.Second * 120
+	operatorInterval = time.Second
+)
+
+var currentDir string
 var k8sClient client.Client
+var restConfig *rest.Config
 var testEnv *envtest.Environment
 var ctx context.Context
 var cancel context.CancelFunc
 var stateManager *common.StateManager
-var autodetect *common.AutoDetector
 
 var brokerReconciler *ActiveMQArtemisReconciler
 var securityReconciler *ActiveMQArtemisSecurityReconciler
+
+var oprRes = []string{
+	"../deploy/service_account.yaml",
+	"../deploy/role.yaml",
+	"../deploy/role_binding.yaml",
+	"../deploy/election_role.yaml",
+	"../deploy/election_role_binding.yaml",
+	"../deploy/operator_config.yaml",
+	"../deploy/operator.yaml",
+}
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -69,15 +100,7 @@ func TestAPIs(t *testing.T) {
 		[]Reporter{printer.NewlineReporter{}})
 }
 
-var _ = BeforeSuite(func() {
-	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
-
-	ctx, cancel = context.WithCancel(context.TODO())
-
-	// force isLocalOnly=false check from artemis reconciler such that scale down controller will create
-	// role binding to service account for the drainer pod
-	os.Setenv("OPERATOR_WATCH_NAMESPACE", "SomeValueToCauesEqualitytoFailInIsLocalSoDrainControllerSortsCreds")
-
+func setUpEnvTest() {
 	// for run in ide
 	// os.Setenv("KUBEBUILDER_ASSETS", " .. <path from makefile> /kubebuilder-envtest/k8s/1.22.1-linux-amd64")
 	By("bootstrapping test environment")
@@ -86,39 +109,15 @@ var _ = BeforeSuite(func() {
 		ErrorIfCRDPathMissing: true,
 	}
 
-	cfg, err := testEnv.Start()
+	var err error
+	restConfig, err = testEnv.Start()
 	Expect(err).NotTo(HaveOccurred())
-	Expect(cfg).NotTo(BeNil())
+	Expect(restConfig).NotTo(BeNil())
 
-	err = routev1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = brokerv2alpha5.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = brokerv2alpha4.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = brokerv2alpha3.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = brokerv2alpha1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = brokerv1alpha1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = brokerv1beta1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	//+kubebuilder:scaffold:scheme
-
-	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
-	Expect(err).NotTo(HaveOccurred())
-	Expect(k8sClient).NotTo(BeNil())
+	setUpK8sClient()
 
 	// start our controler
-	k8Manager, err := ctrl.NewManager(cfg, ctrl.Options{
+	k8Manager, err := ctrl.NewManager(restConfig, ctrl.Options{
 		Scheme: scheme.Scheme,
 	})
 	Expect(err).ToNot(HaveOccurred())
@@ -176,13 +175,213 @@ var _ = BeforeSuite(func() {
 		err = k8Manager.Start(ctx)
 		Expect(err).ToNot(HaveOccurred(), "failed to run manager")
 	}()
+}
 
+func setUpRealOperator() {
+	var err error
+	restConfig, err = config.GetConfig()
+	Expect(err).ShouldNot(HaveOccurred(), "failed to get the config")
+
+	setUpK8sClient()
+
+	logf.Log.Info("Installing CRDs")
+	crds := []string{"../deploy/crds"}
+	options := envtest.CRDInstallOptions{
+		Paths:              crds,
+		ErrorIfPathMissing: false,
+	}
+	_, err = envtest.InstallCRDs(restConfig, options)
+	Expect(err).To(Succeed())
+
+	err = installOperator()
+	Expect(err).To(Succeed(), "failed to install operator")
+}
+
+//Deploy operator resources
+//TODO: provide 'watch all namespaces' option
+func installOperator() error {
+	logf.Log.Info("#### Installing Operator ####")
+	for _, res := range oprRes {
+		if err := installYamlResource(res); err != nil {
+			return err
+		}
+	}
+
+	return waitForOperator()
+}
+
+func uninstallOperator() error {
+	logf.Log.Info("#### Uninstalling Operator ####")
+	for _, res := range oprRes {
+		if err := uninstallYamlResource(res); err != nil {
+			return err
+		}
+	}
+
+	//uninstall CRDs
+	logf.Log.Info("Uninstalling CRDs")
+	crds := []string{"../deploy/crds"}
+	options := envtest.CRDInstallOptions{
+		Paths:              crds,
+		ErrorIfPathMissing: false,
+	}
+	return envtest.UninstallCRDs(restConfig, options)
+}
+
+func waitForOperator() error {
+	podList := &corev1.PodList{}
+	opts := &client.ListOptions{
+		Namespace: defaultNamespace,
+	}
+	Eventually(func() bool {
+		err := k8sClient.List(ctx, podList, opts)
+		if err != nil {
+			return false
+		}
+		if len(podList.Items) != 1 {
+			return false
+		}
+		oprPod := podList.Items[0]
+		return oprPod.Status.ContainerStatuses[0].Ready
+	}, operatorTimeout, operatorInterval).Should(Equal(true))
+	return nil
+}
+
+func loadYamlResource(yamlFile string) (runtime.Object, *schema.GroupVersionKind, error) {
+	var info os.FileInfo
+	var err error
+	var filePath string
+
+	// Return the error if ErrorIfPathMissing exists
+	if info, err = os.Stat(yamlFile); os.IsNotExist(err) {
+		return nil, nil, err
+	}
+	filePath = filepath.Dir(yamlFile)
+
+	var b []byte
+	b, err = ioutil.ReadFile(filepath.Join(filePath, info.Name()))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	decode := scheme.Codecs.UniversalDeserializer().Decode
+	robj, gKV, _ := decode(b, nil, nil)
+	logf.Log.Info("Loaded resource", "kind", gKV.Kind)
+	return robj, gKV, nil
+}
+
+func uninstallYamlResource(resPath string) error {
+	logf.Log.Info("Uninstalling yaml resource", "yaml", resPath)
+	robj, _, err := loadYamlResource(resPath)
+	if err != nil {
+		return err
+	}
+	cobj := robj.(client.Object)
+	cobj.SetNamespace(defaultNamespace)
+
+	err = k8sClient.Delete(ctx, cobj)
+	if err != nil {
+		return err
+	}
+
+	logf.Log.Info("Successfully uninstalled", "yaml", resPath)
+	return nil
+}
+
+func installYamlResource(resPath string) error {
+	logf.Log.Info("Installing yaml resource", "yaml", resPath)
+	robj, gkv, err := loadYamlResource(resPath)
+	if err != nil {
+		return err
+	}
+	cobj := robj.(client.Object)
+	cobj.SetNamespace(defaultNamespace)
+
+	if oprImg := os.Getenv("OPERATOR_IMAGE"); oprImg != "" {
+		if gkv.Kind == "Deployment" {
+			logf.Log.Info("Using custom operator image", "url", oprImg)
+			oprObj := cobj.(*appsv1.Deployment)
+			oprObj.Spec.Template.Spec.Containers[0].Image = oprImg
+		}
+	}
+
+	err = k8sClient.Create(ctx, cobj)
+	if err != nil {
+		return err
+	}
+
+	//make sure the create ok
+	Eventually(func() bool {
+		key := types.NamespacedName{Name: cobj.GetName(), Namespace: defaultNamespace}
+		err := k8sClient.Get(ctx, key, cobj)
+		return err == nil
+	}, timeout, interval).Should(Equal(true))
+
+	logf.Log.Info("Successfully installed", "yaml", resPath)
+	return nil
+}
+
+func setUpK8sClient() {
+
+	logf.Log.Info("Setting up k8s client")
+
+	err := routev1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = brokerv2alpha5.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = brokerv2alpha4.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = brokerv2alpha3.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = brokerv2alpha1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = brokerv1alpha1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = brokerv1beta1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	//+kubebuilder:scaffold:scheme
+
+	k8sClient, err = client.New(restConfig, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+	ctx, cancel = context.WithCancel(context.TODO())
+	// force isLocalOnly=false check from artemis reconciler such that scale down controller will create
+	// role binding to service account for the drainer pod
+	os.Setenv("OPERATOR_WATCH_NAMESPACE", "SomeValueToCauesEqualitytoFailInIsLocalSoDrainControllerSortsCreds")
+
+	var err error
+	currentDir, err = os.Getwd()
+	Expect(err).To(Succeed())
+	logf.Log.Info("#### Starting test ####", "working dir", currentDir)
+	if os.Getenv("DEPLOY_OPERATOR") == "true" {
+		logf.Log.Info("#### Setting up a real operator ####")
+		setUpRealOperator()
+	} else {
+		logf.Log.Info("#### Setting up EnvTest ####")
+		setUpEnvTest()
+	}
 }, 60)
 
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 
 	os.Unsetenv("OPERATOR_WATCH_NAMESPACE")
+
+	if os.Getenv("DEPLOY_OPERATOR") == "true" {
+		err := uninstallOperator()
+		Expect(err).NotTo(HaveOccurred())
+	}
 
 	cancel()
 	if stateManager != nil {
@@ -192,6 +391,9 @@ var _ = AfterSuite(func() {
 	for _, drainController := range controllers {
 		close(*drainController.GetStopCh())
 	}
-	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
+
+	if os.Getenv("DEPLOY_OPERATOR") != "true" {
+		err := testEnv.Stop()
+		Expect(err).NotTo(HaveOccurred())
+	}
 })


### PR DESCRIPTION
broker pods if the address crs are deployed at the
same time with security

Added a test option "DEPLOY_OPERATOR" to test-mk
to allow tests run against operator deployed
in existing cluster