### PR TITLE
[#32] allow user to config logging for broker

### DIFF
--- a/controllers/activemqartemis_reconciler_test.go
+++ b/controllers/activemqartemis_reconciler_test.go
@@ -334,7 +334,7 @@ func TestNewPodTemplateSpecForCR_IncludesDebugArgs(t *testing.T) {
 		},
 	}
 
-	newSpec, err := reconciler.NewPodTemplateSpecForCR(cr, Namers{}, &v1.PodTemplateSpec{})
+	newSpec, err := reconciler.NewPodTemplateSpecForCR(cr, Namers{}, &v1.PodTemplateSpec{}, k8sClient)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, newSpec)
@@ -371,7 +371,7 @@ func TestNewPodTemplateSpecForCR_AppendsDebugArgs(t *testing.T) {
 		},
 	}
 
-	newSpec, err := reconciler.NewPodTemplateSpecForCR(cr, Namers{}, &v1.PodTemplateSpec{})
+	newSpec, err := reconciler.NewPodTemplateSpecForCR(cr, Namers{}, &v1.PodTemplateSpec{}, k8sClient)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, newSpec)

--- a/docs/help/operator.md
+++ b/docs/help/operator.md
@@ -690,3 +690,48 @@ spec:
 ```
 
 Note: you are configuring an array of [envVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#envvar-v1-core) which is a very powerfull concept. Proceed with care, taking due respect to any environment the operator may set and depend on. For full documentation see the [Kubernetes Documentation](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/)
+
+## Configuring Logging for Brokers
+
+By default the operator deploys a broker with a default logging configuration that comes with the [Artemis container image]
+(https://github.com/artemiscloud/activemq-artemis-broker-kubernetes-image). Broker logs its messages to console only.
+
+Users can change the broker logging configuration by providing their own in a configmap or secret. The name of the configmap
+or secret must have the suffix **-logging-config**. There must be one entry in the configmap or secret. The key of the entry
+must be **logging.properties** and the value must of the full content of the logging configuration. (The broker is using slf4j with
+log4j2 binding so the content should be log4j2's configuration in Java's properties file format).
+
+Then you need to give the name of the configmap or secret in the broker custom resource. For example
+
+`for configmap`
+```yaml
+apiVersion: broker.amq.io/v1beta1
+kind: ActiveMQArtemis
+metadata:
+  name: broker
+  namespace: activemq-artemis-operator
+spec:
+spec:
+  deploymentPlan:
+    size: 1
+    image: placeholder
+    extraMounts:
+      configMaps:
+      - "my-logging-config"
+```
+`for secret`
+```yaml
+apiVersion: broker.amq.io/v1beta1
+kind: ActiveMQArtemis
+metadata:
+  name: broker
+  namespace: activemq-artemis-operator
+spec:
+spec:
+  deploymentPlan:
+    size: 1
+    image: placeholder
+    extraMounts:
+      secrets:
+      - "my-logging-config"
+```

--- a/pkg/resources/configmaps/configmap.go
+++ b/pkg/resources/configmaps/configmap.go
@@ -1,0 +1,39 @@
+package configmaps
+
+import (
+	"github.com/artemiscloud/activemq-artemis-operator/pkg/resources"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func RetrieveConfigMap(namespace string, configMapName string, client client.Client) (*corev1.ConfigMap, error) {
+	data := make(map[string]string)
+	namespacedName := types.NamespacedName{
+		Name:      configMapName,
+		Namespace: namespace,
+	}
+	configMapDefinition := MakeConfigMap(namespace, configMapName, data)
+	if err := resources.Retrieve(namespacedName, client, configMapDefinition); err != nil {
+		return nil, err
+	}
+	return configMapDefinition, nil
+}
+
+func MakeConfigMap(namespace string, configMapName string, stringData map[string]string) *corev1.ConfigMap {
+
+	configMapDefinition := corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      configMapName,
+			Namespace: namespace,
+		},
+		Data: stringData,
+	}
+
+	return &configMapDefinition
+}


### PR DESCRIPTION
To use custom logging configuration for broker user has to make a configmap with the following rules:
1. The name of the configmap takes the form [cr-name]-logging-config
2. The configmap has one entry, the key name must be "logger.properties", the value is the whole content of the logging configuration (normally lines of key=value)
The operator doesn't care about the content of the configmap. It only finds the configmap and mounted to a location
/amq/extra/configmaps/<configmap name>/logger.properties
The operator then also export an env var LOGGER_PROPERTIES that points to the above mounted location.

When the broker image is launched it checks the env var LOGGER_PROPERTIES and creates a sym link to ${instanceDir}/etc/logging.properties. if the var is defined. Otherwise it takes the default logging.properties and changes all logging to console output (unless persistence is enabled)

If the configmap is created after the broker has been deployed, all the pods will be restarted to update the logging configuration.


