### PR TITLE
JaaS authentication configmap

### DIFF
--- a/api/v1beta1/activemqartemis_types.go
+++ b/api/v1beta1/activemqartemis_types.go
@@ -422,8 +422,6 @@ const (
 	DeployedConditionZeroSizeReason  = "ZeroSizeDeployment"
 	DeployedConditionZeroSizeMessage = "Pods not scheduled. Deployment size is 0"
 
-	ValidConditionType                      = "Valid"
-	ValidConditionSuccessReason             = "ValidationSucceeded"
 	ValidConditionFailedReservedLabelReason = "ReservedLabelReference"
 
 	ConfigAppliedConditionType                            = "BrokerPropertiesApplied"

--- a/controllers/activemqartemis_controller.go
+++ b/controllers/activemqartemis_controller.go
@@ -18,11 +18,14 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -149,15 +152,23 @@ func (r *ActiveMQArtemisReconciler) Reconcile(ctx context.Context, request ctrl.
 	namer := MakeNamers(customResource)
 	reconciler := ActiveMQArtemisReconcilerImpl{}
 
-	reconciler.Process(customResource, *namer, r.Client, r.Scheme)
+	result := ctrl.Result{}
 
-	err = UpdatePodStatus(customResource, r.Client, request.NamespacedName)
-	if err != nil {
-		reqLogger.Error(err, "unable to update pod status", "Request Namespace", request.Namespace, "Request Name", request.Name)
-		return ctrl.Result{RequeueAfter: common.GetReconcileResyncPeriod()}, err
+	if hasValidationErrors, err := validate(customResource, r.Client, r.Scheme); !hasValidationErrors && err == nil {
+		requeue := reconciler.Process(customResource, *namer, r.Client, r.Scheme)
+
+		err = UpdatePodStatus(customResource, r.Client, request.NamespacedName)
+		if err != nil {
+			reqLogger.Error(err, "unable to update pod status", "Request Namespace", request.Namespace, "Request Name", request.Name)
+			return ctrl.Result{RequeueAfter: common.GetReconcileResyncPeriod()}, err
+		}
+
+		result = UpdateBrokerPropertiesStatus(customResource, r.Client, r.Scheme)
+		if requeue {
+			result = ctrl.Result{RequeueAfter: common.GetReconcileResyncPeriod()}
+		}
 	}
 
-	result := UpdateBrokerPropertiesStatus(customResource, r.Client, r.Scheme)
 	err = UpdateCRStatus(customResource, r.Client, request.NamespacedName)
 
 	if err != nil {
@@ -171,6 +182,69 @@ func (r *ActiveMQArtemisReconciler) Reconcile(ctx context.Context, request ctrl.
 		reqLogger.Info("requeue resource")
 	}
 	return result, err
+}
+
+func validate(customResource *brokerv1beta1.ActiveMQArtemis, client rtclient.Client, scheme *runtime.Scheme) (bool, error) {
+	// Do additional validation here
+	validationCondition := metav1.Condition{
+		Type:   common.ValidConditionType,
+		Status: metav1.ConditionTrue,
+		Reason: common.ValidConditionSuccessReason,
+	}
+	condition, err := validateExtraMounts(customResource, client, scheme)
+	if err != nil {
+		return false, err
+	}
+	if condition != nil {
+		validationCondition = *condition
+	}
+
+	meta.SetStatusCondition(&customResource.Status.Conditions, validationCondition)
+	return false, nil
+}
+
+func validateExtraMounts(customResource *brokerv1beta1.ActiveMQArtemis, client rtclient.Client, scheme *runtime.Scheme) (*metav1.Condition, error) {
+	for _, cm := range customResource.Spec.DeploymentPlan.ExtraMounts.ConfigMaps {
+		found, err := validateExtraMount(cm, customResource.Namespace, &corev1.ConfigMap{}, client, scheme)
+		if err != nil {
+			return nil, err
+		}
+		if !found {
+			return &metav1.Condition{
+				Type:    common.ValidConditionType,
+				Status:  metav1.ConditionFalse,
+				Reason:  common.ValidConditionMissingResourcesReason,
+				Message: fmt.Sprintf("Missing required configMap %v", cm),
+			}, nil
+		}
+	}
+	for _, s := range customResource.Spec.DeploymentPlan.ExtraMounts.Secrets {
+		found, err := validateExtraMount(s, customResource.Namespace, &corev1.Secret{}, client, scheme)
+		if err != nil {
+			return nil, err
+		}
+		if !found {
+			return &metav1.Condition{
+				Type:    common.ValidConditionType,
+				Status:  metav1.ConditionFalse,
+				Reason:  common.ValidConditionMissingResourcesReason,
+				Message: fmt.Sprintf("Missing required secret %v", s),
+			}, nil
+		}
+	}
+	return nil, nil
+}
+
+func validateExtraMount(name, namespace string, obj rtclient.Object, client rtclient.Client, scheme *runtime.Scheme) (bool, error) {
+	err := client.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: namespace}, obj)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		} else {
+			return false, err
+		}
+	}
+	return true, nil
 }
 
 type Namers struct {

--- a/controllers/activemqartemis_controller_test.go
+++ b/controllers/activemqartemis_controller_test.go
@@ -424,7 +424,6 @@ var _ = Describe("artemis controller", func() {
 
 			hasMatch, matchErr = MatchCapturedLog("ERROR")
 			Expect(matchErr).To(BeNil())
-			fmt.Printf("logBuffer: %v\n", logBuffer)
 			Expect(hasMatch).To(BeFalse())
 
 			// cleanup
@@ -1797,7 +1796,7 @@ var _ = Describe("artemis controller", func() {
 					g.Expect(len(createdCrd.Status.PodStatus.Ready)).Should(BeEquivalentTo(1))
 					g.Expect(meta.IsStatusConditionTrue(createdCrd.Status.Conditions, brokerv1beta1.DeployedConditionType)).Should(BeTrue())
 					g.Expect(meta.IsStatusConditionTrue(createdCrd.Status.Conditions, common.ReadyConditionType)).Should(BeTrue())
-					g.Expect(meta.IsStatusConditionTrue(createdCrd.Status.Conditions, brokerv1beta1.ValidConditionType)).Should(BeTrue())
+					g.Expect(meta.IsStatusConditionTrue(createdCrd.Status.Conditions, common.ValidConditionType)).Should(BeTrue())
 				}, timeout*2, interval).Should(Succeed())
 
 				By("applying taints to node")
@@ -2572,7 +2571,7 @@ var _ = Describe("artemis controller", func() {
 					Message: brokerv1beta1.DeployedConditionZeroSizeMessage,
 				})).Should(BeTrue())
 				g.Expect(meta.IsStatusConditionFalse(createdCrd.Status.Conditions, common.ReadyConditionType)).Should(BeTrue())
-				g.Expect(meta.IsStatusConditionTrue(createdCrd.Status.Conditions, brokerv1beta1.ValidConditionType)).Should(BeTrue())
+				g.Expect(meta.IsStatusConditionTrue(createdCrd.Status.Conditions, common.ValidConditionType)).Should(BeTrue())
 
 			}, timeout, interval).Should(Succeed())
 
@@ -3160,7 +3159,7 @@ var _ = Describe("artemis controller", func() {
 				g.Expect(deployedCrd.Name).Should(Equal(validCrd.ObjectMeta.Name))
 				g.Expect(len(deployedCrd.Status.PodStatus.Stopped)).Should(Equal(1))
 				g.Expect(deployedCrd.Status.PodStatus.Stopped[0]).Should(Equal(namer.CrToSS(validCrd.Name)))
-				g.Expect(meta.IsStatusConditionTrue(deployedCrd.Status.Conditions, brokerv1beta1.ValidConditionType)).Should(BeTrue())
+				g.Expect(meta.IsStatusConditionTrue(deployedCrd.Status.Conditions, common.ValidConditionType)).Should(BeTrue())
 			}, timeout, interval).Should(Succeed())
 
 			By("checking deployed resources of valid CR")
@@ -3186,9 +3185,9 @@ var _ = Describe("artemis controller", func() {
 			By("verify status valid false")
 			Eventually(func(g Gomega) {
 				g.Expect(k8sClient.Get(ctx, deployedCrdKey, &deployedCrd)).Should(Succeed())
-				g.Expect(meta.IsStatusConditionFalse(deployedCrd.Status.Conditions, brokerv1beta1.ValidConditionType)).Should(BeTrue())
-				g.Expect(meta.FindStatusCondition(deployedCrd.Status.Conditions, brokerv1beta1.ValidConditionType).Reason).Should(Equal(brokerv1beta1.ValidConditionFailedReservedLabelReason))
-				g.Expect(meta.FindStatusCondition(deployedCrd.Status.Conditions, brokerv1beta1.ValidConditionType).Message).Should(ContainSubstring("application"))
+				g.Expect(meta.IsStatusConditionFalse(deployedCrd.Status.Conditions, common.ValidConditionType)).Should(BeTrue())
+				g.Expect(meta.FindStatusCondition(deployedCrd.Status.Conditions, common.ValidConditionType).Reason).Should(Equal(brokerv1beta1.ValidConditionFailedReservedLabelReason))
+				g.Expect(meta.FindStatusCondition(deployedCrd.Status.Conditions, common.ValidConditionType).Message).Should(ContainSubstring("application"))
 				g.Expect(meta.IsStatusConditionFalse(deployedCrd.Status.Conditions, common.ReadyConditionType)).Should(BeTrue())
 			}, timeout, interval).Should(Succeed())
 
@@ -3209,8 +3208,8 @@ var _ = Describe("artemis controller", func() {
 				g.Expect(len(deployedCrd.Status.PodStatus.Stopped)).Should(Equal(1))
 				g.Expect(deployedCrd.Status.PodStatus.Stopped[0]).Should(Equal(namer.CrToSS(invalidCrd.Name)))
 				By("verify status valid true")
-				g.Expect(meta.IsStatusConditionTrue(deployedCrd.Status.Conditions, brokerv1beta1.ValidConditionType)).Should(BeTrue())
-				g.Expect(meta.FindStatusCondition(deployedCrd.Status.Conditions, brokerv1beta1.ValidConditionType).Reason).Should(Equal(brokerv1beta1.ValidConditionSuccessReason))
+				g.Expect(meta.IsStatusConditionTrue(deployedCrd.Status.Conditions, common.ValidConditionType)).Should(BeTrue())
+				g.Expect(meta.FindStatusCondition(deployedCrd.Status.Conditions, common.ValidConditionType).Reason).Should(Equal(common.ValidConditionSuccessReason))
 			}, timeout, interval).Should(Succeed())
 
 			By("checking deployed resources of updated invalid CR")

--- a/controllers/activemqartemis_reconciler.go
+++ b/controllers/activemqartemis_reconciler.go
@@ -66,6 +66,7 @@ const (
 	ImageNamePrefix                  = "RELATED_IMAGE_ActiveMQ_Artemis_Broker_"
 	defaultLivenessProbeInitialDelay = 5
 	TCPLivenessPort                  = 8161
+	jaasConfigSuffix                 = "-jaas-config"
 )
 
 var defaultMessageMigration bool = true
@@ -1501,7 +1502,7 @@ func (reconciler *ActiveMQArtemisReconcilerImpl) NewPodTemplateSpecForCR(customR
 			if key == selectors.LabelAppKey || key == selectors.LabelResourceKey {
 
 				meta.SetStatusCondition(&customResource.Status.Conditions, metav1.Condition{
-					Type:    brokerv1beta1.ValidConditionType,
+					Type:    common.ValidConditionType,
 					Status:  metav1.ConditionFalse,
 					Reason:  brokerv1beta1.ValidConditionFailedReservedLabelReason,
 					Message: fmt.Sprintf("'%s' is a reserved label, it is not allowed in Spec.DeploymentPlan.Labels", key),
@@ -1514,9 +1515,9 @@ func (reconciler *ActiveMQArtemisReconcilerImpl) NewPodTemplateSpecForCR(customR
 	}
 	// validation success
 	meta.SetStatusCondition(&customResource.Status.Conditions, metav1.Condition{
-		Type:   brokerv1beta1.ValidConditionType,
+		Type:   common.ValidConditionType,
 		Status: metav1.ConditionTrue,
-		Reason: brokerv1beta1.ValidConditionSuccessReason,
+		Reason: common.ValidConditionSuccessReason,
 	})
 
 	pts := pods.MakePodTemplateSpec(current, namespacedName, labels)
@@ -1601,6 +1602,15 @@ func (reconciler *ActiveMQArtemisReconcilerImpl) NewPodTemplateSpecForCR(customR
 		Value: brokerConfigRoot,
 	}
 	environments.Create(podSpec.Containers, &envBrokerCustomInstanceDir)
+
+	// JAAS Config
+	if jaasConfigPath, found := getJaasConfigExtraMountPath(customResource); found {
+		debugArgs := corev1.EnvVar{
+			Name:  "DEBUG_ARGS",
+			Value: fmt.Sprintf("-Djava.security.auth.login.config=%v", jaasConfigPath),
+		}
+		environments.CreateOrAppend(podSpec.Containers, &debugArgs)
+	}
 
 	//add empty-dir volume and volumeMounts to main container
 	volumeForCfg := volumes.MakeVolumeForCfg(cfgVolumeName)
@@ -1793,6 +1803,27 @@ func (reconciler *ActiveMQArtemisReconcilerImpl) NewPodTemplateSpecForCR(customR
 	pts.Spec = *podSpec
 
 	return pts, nil
+}
+
+func getJaasConfigExtraMountPath(customResource *brokerv1beta1.ActiveMQArtemis) (string, bool) {
+	if t, name, found := getJaasConfigExtraMount(customResource); found {
+		return fmt.Sprintf("/amq/extra/%v/%v/login.config", t, name), true
+	}
+	return "", false
+}
+
+func getJaasConfigExtraMount(customResource *brokerv1beta1.ActiveMQArtemis) (string, string, bool) {
+	for _, cm := range customResource.Spec.DeploymentPlan.ExtraMounts.ConfigMaps {
+		if strings.HasSuffix(cm, jaasConfigSuffix) {
+			return "configmaps", cm, true
+		}
+	}
+	for _, s := range customResource.Spec.DeploymentPlan.ExtraMounts.Secrets {
+		if strings.HasSuffix(s, jaasConfigSuffix) {
+			return "secrets", s, true
+		}
+	}
+	return "", "", false
 }
 
 func configureLivenessProbe(container *corev1.Container, probeFromCR *corev1.Probe) *corev1.Probe {
@@ -2263,13 +2294,13 @@ func UpdatePodStatus(cr *brokerv1beta1.ActiveMQArtemis, client rtclient.Client, 
 func getValidCondition(cr *brokerv1beta1.ActiveMQArtemis) metav1.Condition {
 	// add valid true if none exists
 	for _, c := range cr.Status.Conditions {
-		if c.Type == brokerv1beta1.ValidConditionType {
+		if c.Type == common.ValidConditionType {
 			return c
 		}
 	}
 	return metav1.Condition{
-		Type:   brokerv1beta1.ValidConditionType,
-		Reason: brokerv1beta1.ValidConditionSuccessReason,
+		Type:   common.ValidConditionType,
+		Reason: common.ValidConditionSuccessReason,
 		Status: metav1.ConditionTrue,
 	}
 }

--- a/pkg/utils/common/conditions.go
+++ b/pkg/utils/common/conditions.go
@@ -23,6 +23,11 @@ const (
 	ReadyConditionReason     = "ResourceReady"
 	NotReadyConditionReason  = "WaitingForAllConditions"
 	NotReadyConditionMessage = "Some conditions are not met"
+
+	ValidConditionType                   = "Validation"
+	ValidConditionSuccessReason          = "ValidationSucceded"
+	ValidConditionMissingResourcesReason = "MissingDependentResources"
+	ValidConditionFailedReason           = "UnableToPerformValidation"
 )
 
 func SetReadyCondition(conditions *[]metav1.Condition) {


### PR DESCRIPTION
Fix #345 

If an extraMount is present with the suffix `-jaas-config` it will be used instead of the generated jaas configuration files.
The secret or configMap must contain the login.config file and may or may not contain the additional user/roles properties files. They might be part of a different mount.

This allows automatic reloading of the authentication configuration and users/roles without a restart

```
spec:
  deploymentPlan:
    extraMounts:
      configMaps:
        - ex-aao-jaas-config 
  env:
    - name: JDK_JAVA_OPTIONS
      value: -XshowSettings:system
    - name: AMQ_USER
      value: ruben
    - name: AMQ_PASSWORD
      value: ruben01!
```

In this case I added the env vars for the user/pwd the controller will use by default to connect to the broker.

The configMap can look like this:

```
apiVersion: v1
kind: ConfigMap
metadata:
  name: ex-aao-jaas-config
  namespace: activemq-artemis-operator
data:
  login.config: |-
    activemq {
       org.apache.activemq.artemis.spi.core.security.jaas.PropertiesLoginModule required
           debug=false
           reload=true
           org.apache.activemq.jaas.properties.user="other-users.properties"
           org.apache.activemq.jaas.properties.role="other-roles.properties";
    };
  other-roles.properties: admin=ruben
  other-users.properties: ruben=ruben01!
```