### PR TITLE
Improve controllers test suite output

### DIFF
--- a/controllers/activemqartemis_controller_deploy_operator_test.go
+++ b/controllers/activemqartemis_controller_deploy_operator_test.go
@@ -34,6 +34,11 @@ import (
 )
 
 var _ = Describe("artemis controller", Label("do"), func() {
+
+	BeforeEach(func() {
+		BeforeEachSpec()
+	})
+
 	Context("operator logging config test", Label("do-operator-log"), func() {
 		It("test operator with env var", func() {
 			if os.Getenv("DEPLOY_OPERATOR") == "true" {

--- a/controllers/activemqartemis_controller_test.go
+++ b/controllers/activemqartemis_controller_test.go
@@ -87,6 +87,8 @@ var _ = Describe("artemis controller", func() {
 	wis := list.New()
 	BeforeEach(func() {
 
+		BeforeEachSpec()
+
 		if verbose {
 			fmt.Println("Time with MicroSeconds: ", time.Now().Format("2006-01-02 15:04:05.000000"), " test:", CurrentSpecReport())
 		}
@@ -1055,7 +1057,7 @@ var _ = Describe("artemis controller", func() {
 					APIVersion: v2alpha5.GroupVersion.Identifier(),
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      nameFromTest(),
+					Name:      NextSpecResourceName(),
 					Namespace: defaultNamespace,
 				},
 				Spec: v2alpha5.ActiveMQArtemisSpec{
@@ -1109,7 +1111,7 @@ var _ = Describe("artemis controller", func() {
 					APIVersion: brokerv1beta1.GroupVersion.Identifier(),
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      nameFromTest(),
+					Name:      NextSpecResourceName(),
 					Namespace: defaultNamespace,
 				},
 				Spec: brokerv1beta1.ActiveMQArtemisSpec{
@@ -5808,7 +5810,7 @@ var _ = Describe("artemis controller", func() {
 					APIVersion: brokerv2alpha4.GroupVersion.Identifier(),
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      nameFromTest(),
+					Name:      NextSpecResourceName(),
 					Namespace: defaultNamespace,
 				},
 				Spec: spec,
@@ -6091,7 +6093,7 @@ var _ = Describe("artemis controller", func() {
 
 		By("Creating broker with custom probe that relies on security")
 		ctx := context.Background()
-		randString := nameFromTest()
+		randString := NextSpecResourceName()
 		crd := generateOriginalArtemisSpec(defaultNamespace, "br-"+randString)
 
 		crd.Spec.DeploymentPlan.ReadinessProbe = nil
@@ -7134,7 +7136,7 @@ func generateArtemisSpec(namespace string) brokerv1beta1.ActiveMQArtemis {
 			APIVersion: brokerv1beta1.GroupVersion.Identifier(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      nameFromTest(),
+			Name:      NextSpecResourceName(),
 			Namespace: namespace,
 		},
 		Spec: newArtemisSpecWithFastProbes(),
@@ -7192,33 +7194,6 @@ func randStringWithPrefix(prefix string) string {
 	return b.String()
 }
 
-func nameFromTest() string {
-	name := strings.ToLower(strings.ReplaceAll(CurrentSpecReport().LeafNodeText, " ", ""))
-	name = strings.ReplaceAll(name, ",", "")
-	name = strings.ReplaceAll(name, ".", "")
-	name = strings.ReplaceAll(name, "(", "")
-	name = strings.ReplaceAll(name, ")", "")
-	name = strings.ReplaceAll(name, "/", "")
-	name = strings.ReplaceAll(name, "_", "")
-	name = strings.ReplaceAll(name, "-", "")
-
-	// track the test count as there may be many crs per test
-	testCount++
-	name += "-" + strconv.FormatInt(testCount, 10)
-
-	// 63 char limit on service names in kube - reduce to 30 by dropping chars
-	limit := 25
-	if len(name) > limit {
-		for _, letter := range chars {
-			name = strings.ReplaceAll(name, string(letter), "")
-			if len(name) <= limit {
-				break
-			}
-		}
-	}
-	return name
-}
-
 func randString() string {
 	return randStringWithPrefix("br-")
 }
@@ -7269,7 +7244,7 @@ func DeployCustomBroker(targetNamespace string, customFunc func(candidate *broke
 func DeploySecret(targetNamespace string, customFunc func(candidate *corev1.Secret)) (*corev1.Secret, *corev1.Secret) {
 	ctx := context.Background()
 
-	secretName := nameFromTest()
+	secretName := NextSpecResourceName()
 	secretDefinition := corev1.Secret{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",

--- a/controllers/activemqartemisaddress_controller_deploy_operator_test.go
+++ b/controllers/activemqartemisaddress_controller_deploy_operator_test.go
@@ -49,6 +49,10 @@ import (
 // The Deployeyed Operator (DO) watches a single NameSpace called "default"
 var _ = Describe("Address controller DO", Label("do"), func() {
 
+	BeforeEach(func() {
+		BeforeEachSpec()
+	})
+
 	Context("Address test", func() {
 
 		It("Deploy CR with size 5 (pods)", Label("slow"), func() {

--- a/controllers/activemqartemisaddress_controller_test.go
+++ b/controllers/activemqartemisaddress_controller_test.go
@@ -49,6 +49,10 @@ import (
 
 var _ = Describe("Address controller tests", func() {
 
+	BeforeEach(func() {
+		BeforeEachSpec()
+	})
+
 	Context("address queue config defaults", Label("queue-config-defaults"), func() {
 		if os.Getenv("USE_EXISTING_CLUSTER") == "true" {
 			queueName := "myqueue"
@@ -1054,7 +1058,7 @@ func DeployAddress(candidate *brokerv1beta1.ActiveMQArtemisAddress) {
 func DeployCustomAddress(targetNamespace string, customFunc func(candidate *brokerv1beta1.ActiveMQArtemisAddress)) (*brokerv1beta1.ActiveMQArtemisAddress, *brokerv1beta1.ActiveMQArtemisAddress) {
 
 	ctx := context.Background()
-	addressCr := GenerateAddressSpec(nameFromTest(), targetNamespace, "myAddress", "myQueue", false, true)
+	addressCr := GenerateAddressSpec(NextSpecResourceName(), targetNamespace, "myAddress", "myQueue", false, true)
 
 	if customFunc != nil {
 		customFunc(addressCr)

--- a/controllers/activemqartemisscaledown_controller_test.go
+++ b/controllers/activemqartemisscaledown_controller_test.go
@@ -43,6 +43,10 @@ import (
 
 var _ = Describe("Scale down controller", func() {
 
+	BeforeEach(func() {
+		BeforeEachSpec()
+	})
+
 	Context("Scale down test", func() {
 		It("deploy plan 2 clustered", func() {
 
@@ -51,7 +55,7 @@ var _ = Describe("Scale down controller", func() {
 			// 	see suite_test.go: os.Setenv("OPERATOR_WATCH_NAMESPACE", "SomeValueToCauesEqualitytoFailInIsLocalSoDrainControllerSortsCreds")
 			if os.Getenv("USE_EXISTING_CLUSTER") == "true" {
 
-				brokerName := nameFromTest()
+				brokerName := NextSpecResourceName()
 				ctx := context.Background()
 
 				brokerCrd := generateOriginalArtemisSpec(defaultNamespace, brokerName)

--- a/controllers/activemqartemissecurity_controller_test.go
+++ b/controllers/activemqartemissecurity_controller_test.go
@@ -54,6 +54,8 @@ var boolTrue = true
 var _ = Describe("security controller", func() {
 
 	BeforeEach(func() {
+		BeforeEachSpec()
+
 		if verbose {
 			fmt.Println("Time with MicroSeconds: ", time.Now().Format("2006-01-02 15:04:05.000000"), " test:", CurrentSpecReport())
 		}
@@ -67,7 +69,7 @@ var _ = Describe("security controller", func() {
 		It("security after recreating broker cr", func() {
 
 			By("deploy a security cr")
-			securityCr, createdSecurityCr := DeploySecurity(nameFromTest(), defaultNamespace, func(candidate *brokerv1beta1.ActiveMQArtemisSecurity) {
+			securityCr, createdSecurityCr := DeploySecurity(NextSpecResourceName(), defaultNamespace, func(candidate *brokerv1beta1.ActiveMQArtemisSecurity) {
 			})
 
 			By("deploy a broker cr")

--- a/controllers/controllermanager_test.go
+++ b/controllers/controllermanager_test.go
@@ -34,6 +34,10 @@ import (
 
 var _ = Describe("tests regarding controller manager", func() {
 
+	BeforeEach(func() {
+		BeforeEachSpec()
+	})
+
 	Context("operator namespaces test", func() {
 
 		It("test resolving watching namespace", func() {


### PR DESCRIPTION
```
$ make test-mk-v
...
Running Suite: Controller Suite - /home/dbruscin/Workspace/brusdev/artemiscloud/activemq-artemis-operator/controllers
=====================================================================================================================
Random Seed: 1675056097

Will run 116 of 124 specs

Running Spec 1: security controller broker with security custom resources security after recreating broker cr [aasecurity-controller69]
/home/dbruscin/Workspace/brusdev/artemiscloud/activemq-artemis-operator/controllers/activemqartemissecurity_controller_test.go:69
•
Running Spec 2: security controller Reconcile Test testing security applied after broker [aasecurity-controller142]
/home/dbruscin/Workspace/brusdev/artemiscloud/activemq-artemis-operator/controllers/activemqartemissecurity_controller_test.go:142
...
```