### PR TITLE
[NO-ISSUE] Fix script issue with deploy/cluster_wide_install_opr.sh

### DIFF
--- a/deploy/cluster_wide_install_opr.sh
+++ b/deploy/cluster_wide_install_opr.sh
@@ -18,9 +18,9 @@ fi
 $KUBE_CLI create -f $DEPLOY_PATH/crds
 $KUBE_CLI create -f $DEPLOY_PATH/service_account.yaml
 $KUBE_CLI create -f $DEPLOY_PATH/cluster_role.yaml
-SERVICE_ACCOUNT_NS="$(kubectl get -f $DEPLOY_PATH/service_account.yaml -o jsonpath='{.metadata.namespace}')"
-sed "s/namespace:.*/namespace: ${SERVICE_ACCOUNT_NS}/" $DEPLOY_PATH/cluster_role_binding.yaml | kubectl apply -f -
+SERVICE_ACCOUNT_NS="$($KUBE_CLI get -f $DEPLOY_PATH/service_account.yaml -o jsonpath='{.metadata.namespace}')"
+sed "s/namespace:.*/namespace: ${SERVICE_ACCOUNT_NS}/" $DEPLOY_PATH/cluster_role_binding.yaml | $KUBE_CLI apply -f -
 $KUBE_CLI create -f $DEPLOY_PATH/election_role.yaml
 $KUBE_CLI create -f $DEPLOY_PATH/election_role_binding.yaml
 $KUBE_CLI create -f $DEPLOY_PATH/operator_config.yaml
-sed -e "/WATCH_NAMESPACE/,/- name/ { /WATCH_NAMESPACE/b; /valueFrom:/bx; /- name/b; d; :x s/valueFrom:/value: '${WATCH_NAMESPACE}'/}" $DEPLOY_PATH/operator.yaml | kubectl apply -f -
+sed -e "/WATCH_NAMESPACE/,/- name/ { /WATCH_NAMESPACE/b; /valueFrom:/bx; /- name/b; d; :x s/valueFrom:/value: '${WATCH_NAMESPACE}'/}" $DEPLOY_PATH/operator.yaml | $KUBE_CLI apply -f -


### PR DESCRIPTION
The script uses KUBE_CLI for client tool (oc or kubectl). However there are several places where the kubectl is used directly instead of using $KUBE_CLI