### PR TITLE
[#614] Support custom ingress hosts

### DIFF
--- a/api/v1beta1/activemqartemis_types.go
+++ b/api/v1beta1/activemqartemis_types.go
@@ -476,6 +476,9 @@ type AcceptorType struct {
 	// Provider used for the truststore; "SUN", "SunJCE", etc. Default in broker is null
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="TrustStore Provider",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	TrustStoreProvider string `json:"trustStoreProvider,omitempty"`
+	// Host for Ingress and Route resources of the acceptor. It supports the following variables: $(CR_NAME), $(CR_NAMESPACE), $(BROKER_ORDINAL), $(ITEM_NAME), $(RES_NAME) and $(INGRESS_DOMAIN). Default is $(CR_NAME)-$(ITEM_NAME)-$(BROKER_ORDINAL)-svc-$(RES_TYPE).$(INGRESS_DOMAIN)
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Ingress Host",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	IngressHost string `json:"ingressHost,omitempty"`
 }
 
 type ConnectorType struct {
@@ -530,9 +533,15 @@ type ConnectorType struct {
 	// Provider used for the truststore; "SUN", "SunJCE", etc. Default in broker is null
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="TrustStore Provider",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	TrustStoreProvider string `json:"trustStoreProvider,omitempty"`
+	// Host for Ingress and Route resources of the acceptor. It supports the following variables: $(CR_NAME), $(CR_NAMESPACE), $(BROKER_ORDINAL), $(ITEM_NAME), $(RES_NAME) and $(INGRESS_DOMAIN). Default is $(CR_NAME)-$(ITEM_NAME)-$(BROKER_ORDINAL)-svc-$(RES_TYPE).$(INGRESS_DOMAIN)
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Ingress Host",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	IngressHost string `json:"ingressHost,omitempty"`
 }
 
 type ConsoleType struct {
+	// The name of the console. Default is wconsj.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Name",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	Name string `json:"name,omitempty"`
 	// Whether or not to expose this port
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Expose",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
 	Expose bool `json:"expose,omitempty"`
@@ -545,6 +554,9 @@ type ConsoleType struct {
 	// If the embedded server requires client authentication
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Use Client Auth",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
 	UseClientAuth bool `json:"useClientAuth,omitempty"`
+	// Host for Ingress and Route resources of the acceptor. It supports the following variables: $(CR_NAME), $(CR_NAMESPACE), $(BROKER_ORDINAL), $(ITEM_NAME), $(RES_NAME) and $(INGRESS_DOMAIN). Default is $(CR_NAME)-$(ITEM_NAME)-$(BROKER_ORDINAL)-svc-$(RES_TYPE).$(INGRESS_DOMAIN)
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Ingress Host",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	IngressHost string `json:"ingressHost,omitempty"`
 }
 
 // ActiveMQArtemis App product upgrade flags, this is deprecated in v1beta1, specifying the Version is sufficient

--- a/bundle/manifests/activemq-artemis-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/activemq-artemis-operator.clusterserviceversion.yaml
@@ -494,6 +494,13 @@ spec:
         path: acceptors[0].expose
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: 'Host for Ingress and Route resources of the acceptor. It supports
+          the following variables: $(CR_NAME), $(CR_NAMESPACE), $(BROKER_ORDINAL),
+          $(ITEM_NAME), $(RES_NAME) and $(INGRESS_DOMAIN). Default is $(CR_NAME)-$(ITEM_NAME)-$(BROKER_ORDINAL)-svc-$(RES_TYPE).$(INGRESS_DOMAIN)'
+        displayName: Ingress Host
+        path: acceptors[0].ingressHost
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
       - description: Provider used for the keystore; "SUN", "SunJCE", etc. Default
           is null
         displayName: KeyStore Provider
@@ -1011,6 +1018,13 @@ spec:
         path: connectors[0].host
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: 'Host for Ingress and Route resources of the acceptor. It supports
+          the following variables: $(CR_NAME), $(CR_NAMESPACE), $(BROKER_ORDINAL),
+          $(ITEM_NAME), $(RES_NAME) and $(INGRESS_DOMAIN). Default is $(CR_NAME)-$(ITEM_NAME)-$(BROKER_ORDINAL)-svc-$(RES_TYPE).$(INGRESS_DOMAIN)'
+        displayName: Ingress Host
+        path: connectors[0].ingressHost
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
       - description: Provider used for the keystore; "SUN", "SunJCE", etc. Default
           is null
         displayName: KeyStore Provider
@@ -1093,6 +1107,18 @@ spec:
         path: console.expose
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: 'Host for Ingress and Route resources of the acceptor. It supports
+          the following variables: $(CR_NAME), $(CR_NAMESPACE), $(BROKER_ORDINAL),
+          $(ITEM_NAME), $(RES_NAME) and $(INGRESS_DOMAIN). Default is $(CR_NAME)-$(ITEM_NAME)-$(BROKER_ORDINAL)-svc-$(RES_TYPE).$(INGRESS_DOMAIN)'
+        displayName: Ingress Host
+        path: console.ingressHost
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The name of the console. Default is wconsj.
+        displayName: Name
+        path: console.name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
       - description: Whether or not to enable SSL on this port
         displayName: SSL Enabled
         path: console.sslEnabled

--- a/bundle/manifests/broker.amq.io_activemqartemises.yaml
+++ b/bundle/manifests/broker.amq.io_activemqartemises.yaml
@@ -62,6 +62,12 @@ spec:
                     expose:
                       description: Whether or not to expose this acceptor
                       type: boolean
+                    ingressHost:
+                      description: 'Host for Ingress and Route resources of the acceptor.
+                        It supports the following variables: $(CR_NAME), $(CR_NAMESPACE),
+                        $(BROKER_ORDINAL), $(ITEM_NAME), $(RES_NAME) and $(INGRESS_DOMAIN).
+                        Default is $(CR_NAME)-$(ITEM_NAME)-$(BROKER_ORDINAL)-svc-$(RES_TYPE).$(INGRESS_DOMAIN)'
+                      type: string
                     keyStoreProvider:
                       description: Provider used for the keystore; "SUN", "SunJCE",
                         etc. Default is null
@@ -472,6 +478,12 @@ spec:
                     host:
                       description: Hostname or IP to connect to
                       type: string
+                    ingressHost:
+                      description: 'Host for Ingress and Route resources of the acceptor.
+                        It supports the following variables: $(CR_NAME), $(CR_NAMESPACE),
+                        $(BROKER_ORDINAL), $(ITEM_NAME), $(RES_NAME) and $(INGRESS_DOMAIN).
+                        Default is $(CR_NAME)-$(ITEM_NAME)-$(BROKER_ORDINAL)-svc-$(RES_TYPE).$(INGRESS_DOMAIN)'
+                      type: string
                     keyStoreProvider:
                       description: Provider used for the keystore; "SUN", "SunJCE",
                         etc. Default is null
@@ -535,6 +547,15 @@ spec:
                   expose:
                     description: Whether or not to expose this port
                     type: boolean
+                  ingressHost:
+                    description: 'Host for Ingress and Route resources of the acceptor.
+                      It supports the following variables: $(CR_NAME), $(CR_NAMESPACE),
+                      $(BROKER_ORDINAL), $(ITEM_NAME), $(RES_NAME) and $(INGRESS_DOMAIN).
+                      Default is $(CR_NAME)-$(ITEM_NAME)-$(BROKER_ORDINAL)-svc-$(RES_TYPE).$(INGRESS_DOMAIN)'
+                    type: string
+                  name:
+                    description: The name of the console. Default is wconsj.
+                    type: string
                   sslEnabled:
                     description: Whether or not to enable SSL on this port
                     type: boolean

--- a/config/crd/bases/broker.amq.io_activemqartemises.yaml
+++ b/config/crd/bases/broker.amq.io_activemqartemises.yaml
@@ -63,6 +63,12 @@ spec:
                     expose:
                       description: Whether or not to expose this acceptor
                       type: boolean
+                    ingressHost:
+                      description: 'Host for Ingress and Route resources of the acceptor.
+                        It supports the following variables: $(CR_NAME), $(CR_NAMESPACE),
+                        $(BROKER_ORDINAL), $(ITEM_NAME), $(RES_NAME) and $(INGRESS_DOMAIN).
+                        Default is $(CR_NAME)-$(ITEM_NAME)-$(BROKER_ORDINAL)-svc-$(RES_TYPE).$(INGRESS_DOMAIN)'
+                      type: string
                     keyStoreProvider:
                       description: Provider used for the keystore; "SUN", "SunJCE",
                         etc. Default is null
@@ -473,6 +479,12 @@ spec:
                     host:
                       description: Hostname or IP to connect to
                       type: string
+                    ingressHost:
+                      description: 'Host for Ingress and Route resources of the acceptor.
+                        It supports the following variables: $(CR_NAME), $(CR_NAMESPACE),
+                        $(BROKER_ORDINAL), $(ITEM_NAME), $(RES_NAME) and $(INGRESS_DOMAIN).
+                        Default is $(CR_NAME)-$(ITEM_NAME)-$(BROKER_ORDINAL)-svc-$(RES_TYPE).$(INGRESS_DOMAIN)'
+                      type: string
                     keyStoreProvider:
                       description: Provider used for the keystore; "SUN", "SunJCE",
                         etc. Default is null
@@ -536,6 +548,15 @@ spec:
                   expose:
                     description: Whether or not to expose this port
                     type: boolean
+                  ingressHost:
+                    description: 'Host for Ingress and Route resources of the acceptor.
+                      It supports the following variables: $(CR_NAME), $(CR_NAMESPACE),
+                      $(BROKER_ORDINAL), $(ITEM_NAME), $(RES_NAME) and $(INGRESS_DOMAIN).
+                      Default is $(CR_NAME)-$(ITEM_NAME)-$(BROKER_ORDINAL)-svc-$(RES_TYPE).$(INGRESS_DOMAIN)'
+                    type: string
+                  name:
+                    description: The name of the console. Default is wconsj.
+                    type: string
                   sslEnabled:
                     description: Whether or not to enable SSL on this port
                     type: boolean

--- a/config/manifests/bases/activemq-artemis-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/activemq-artemis-operator.clusterserviceversion.yaml
@@ -268,6 +268,13 @@ spec:
         path: acceptors[0].expose
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: 'Host for Ingress and Route resources of the acceptor. It supports
+          the following variables: $(CR_NAME), $(CR_NAMESPACE), $(BROKER_ORDINAL),
+          $(ITEM_NAME), $(RES_NAME) and $(INGRESS_DOMAIN). Default is $(CR_NAME)-$(ITEM_NAME)-$(BROKER_ORDINAL)-svc-$(RES_TYPE).$(INGRESS_DOMAIN)'
+        displayName: Ingress Host
+        path: acceptors[0].ingressHost
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
       - description: Provider used for the keystore; "SUN", "SunJCE", etc. Default
           is null
         displayName: KeyStore Provider
@@ -785,6 +792,13 @@ spec:
         path: connectors[0].host
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: 'Host for Ingress and Route resources of the acceptor. It supports
+          the following variables: $(CR_NAME), $(CR_NAMESPACE), $(BROKER_ORDINAL),
+          $(ITEM_NAME), $(RES_NAME) and $(INGRESS_DOMAIN). Default is $(CR_NAME)-$(ITEM_NAME)-$(BROKER_ORDINAL)-svc-$(RES_TYPE).$(INGRESS_DOMAIN)'
+        displayName: Ingress Host
+        path: connectors[0].ingressHost
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
       - description: Provider used for the keystore; "SUN", "SunJCE", etc. Default
           is null
         displayName: KeyStore Provider
@@ -867,6 +881,18 @@ spec:
         path: console.expose
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: 'Host for Ingress and Route resources of the acceptor. It supports
+          the following variables: $(CR_NAME), $(CR_NAMESPACE), $(BROKER_ORDINAL),
+          $(ITEM_NAME), $(RES_NAME) and $(INGRESS_DOMAIN). Default is $(CR_NAME)-$(ITEM_NAME)-$(BROKER_ORDINAL)-svc-$(RES_TYPE).$(INGRESS_DOMAIN)'
+        displayName: Ingress Host
+        path: console.ingressHost
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The name of the console. Default is wconsj.
+        displayName: Name
+        path: console.name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
       - description: Whether or not to enable SSL on this port
         displayName: SSL Enabled
         path: console.sslEnabled

--- a/controllers/activemqartemis_controller_test.go
+++ b/controllers/activemqartemis_controller_test.go
@@ -1829,6 +1829,199 @@ var _ = Describe("artemis controller", func() {
 			}
 		})
 
+		It("Exposing secured broker with custom ingress hosts", Label("console-expose-ssl"), func() {
+			//we need to use existing cluster to differentiate testing
+			//between openshift and k8s, also need it to check pod status
+			if os.Getenv("USE_EXISTING_CLUSTER") == "true" {
+
+				crd := generateArtemisSpec(defaultNamespace)
+
+				isOpenshift, err := environments.DetectOpenshift()
+				Expect(err).To(BeNil())
+
+				By("deploying ssl secret")
+				sslSecretName := crd.Name + "-ssl-secret"
+				sslSecret, err := CreateTlsSecret(sslSecretName, defaultNamespace, defaultPassword, defaultSanDnsNames)
+				Expect(err).To(BeNil())
+				Expect(k8sClient.Create(ctx, sslSecret)).Should(Succeed())
+
+				createdSecret := corev1.Secret{}
+				secretKey := types.NamespacedName{
+					Name:      sslSecretName,
+					Namespace: defaultNamespace,
+				}
+				Eventually(func(g Gomega) {
+					g.Expect(k8sClient.Get(ctx, secretKey, &createdSecret)).To(Succeed())
+				}, existingClusterTimeout, existingClusterInterval).Should(Succeed())
+
+				specIngressHost := "$(CR_NAME)-$(ITEM_NAME)-$(BROKER_ORDINAL).$(INGRESS_DOMAIN)"
+
+				crd.Spec.DeploymentPlan.ReadinessProbe = &corev1.Probe{
+					InitialDelaySeconds: 1,
+					PeriodSeconds:       1,
+					TimeoutSeconds:      5,
+				}
+
+				crd.Spec.Acceptors = []brokerv1beta1.AcceptorType{
+					{
+						Name:        "my-acceptor",
+						Port:        61626,
+						Expose:      true,
+						SSLEnabled:  true,
+						SSLSecret:   sslSecretName,
+						IngressHost: specIngressHost,
+					},
+				}
+
+				crd.Spec.Connectors = []brokerv1beta1.ConnectorType{
+					{
+						Name:        "my-connector",
+						Port:        61626,
+						Expose:      true,
+						SSLEnabled:  true,
+						SSLSecret:   sslSecretName,
+						IngressHost: specIngressHost,
+					},
+				}
+
+				crd.Spec.Console = brokerv1beta1.ConsoleType{
+					Name:        "my-console",
+					Expose:      true,
+					SSLEnabled:  true,
+					SSLSecret:   sslSecretName,
+					IngressHost: specIngressHost,
+				}
+
+				crd.Spec.IngressDomain = "tests.artemiscloud.io"
+
+				By("deploying broker" + crd.Name)
+				Expect(k8sClient.Create(ctx, &crd)).Should(Succeed())
+
+				brokerKey := types.NamespacedName{Name: crd.Name, Namespace: crd.Namespace}
+				deployedCrd := &brokerv1beta1.ActiveMQArtemis{}
+
+				Eventually(func(g Gomega) {
+					g.Expect(k8sClient.Get(ctx, brokerKey, deployedCrd)).Should(Succeed())
+				}, existingClusterTimeout, existingClusterInterval).Should(Succeed())
+
+				ssKey := types.NamespacedName{
+					Name:      namer.CrToSS(crd.Name),
+					Namespace: defaultNamespace,
+				}
+				currentSS := &appsv1.StatefulSet{}
+				Eventually(func(g Gomega) {
+					g.Expect(k8sClient.Get(ctx, ssKey, currentSS)).Should(Succeed())
+				}, existingClusterTimeout, existingClusterInterval).Should(Succeed())
+
+				By("verify pod is up")
+				podKey := types.NamespacedName{Name: namer.CrToSS(crd.Name) + "-0", Namespace: defaultNamespace}
+				Eventually(func(g Gomega) {
+					pod := &corev1.Pod{}
+					g.Expect(k8sClient.Get(ctx, podKey, pod)).Should(Succeed())
+					g.Expect(pod.Status.ContainerStatuses).Should(HaveLen(1))
+					g.Expect(pod.Status.ContainerStatuses[0].State.Running).Should(Not(BeNil()))
+				}, existingClusterTimeout, existingClusterInterval).Should(Succeed())
+
+				if isOpenshift {
+					By("check console acceptor is created")
+					acceptorHost := crd.Name + "-my-acceptor-0." + crd.Spec.IngressDomain
+					acceptorRouteKey := types.NamespacedName{
+						Name:      crd.Name + "-my-acceptor-0-svc-rte",
+						Namespace: defaultNamespace,
+					}
+					acceptorRoute := routev1.Route{}
+					Eventually(func(g Gomega) {
+						g.Expect(k8sClient.Get(ctx, acceptorRouteKey, &acceptorRoute)).To(Succeed())
+
+						g.Expect(acceptorRoute.Spec.Host).To(Equal(acceptorHost))
+					}).Should(Succeed())
+
+					By("check console connector is created")
+					connectorHost := crd.Name + "-my-connector-0." + crd.Spec.IngressDomain
+					connectorRouteKey := types.NamespacedName{
+						Name:      crd.Name + "-my-connector-0-svc-rte",
+						Namespace: defaultNamespace,
+					}
+					connectorRoute := routev1.Route{}
+					Eventually(func(g Gomega) {
+						g.Expect(k8sClient.Get(ctx, connectorRouteKey, &connectorRoute)).To(Succeed())
+
+						g.Expect(acceptorRoute.Spec.Host).To(Equal(connectorHost))
+					}).Should(Succeed())
+
+					By("check console route is created")
+					consoleHost := crd.Name + "-my-console-0." + crd.Spec.IngressDomain
+					consoleRouteKey := types.NamespacedName{
+						Name:      crd.Name + "-my-console-0-svc-rte",
+						Namespace: defaultNamespace,
+					}
+					consoleRoute := routev1.Route{}
+					Eventually(func(g Gomega) {
+						g.Expect(k8sClient.Get(ctx, consoleRouteKey, &consoleRoute)).To(Succeed())
+
+						g.Expect(consoleRoute.Spec.Host).To(Equal(consoleHost))
+					}).Should(Succeed())
+				} else {
+					By("check acceptor ingress is created")
+					acceptorHost := crd.Name + "-my-acceptor-0." + crd.Spec.IngressDomain
+					acceptorIngKey := types.NamespacedName{
+						Name:      crd.Name + "-my-acceptor-0-svc-ing",
+						Namespace: defaultNamespace,
+					}
+					acceptorIngress := netv1.Ingress{}
+					Eventually(func(g Gomega) {
+						g.Expect(k8sClient.Get(ctx, acceptorIngKey, &acceptorIngress)).To(Succeed())
+
+						g.Expect(acceptorIngress.Spec.Rules).To(HaveLen(1))
+						g.Expect(acceptorIngress.Spec.Rules[0].Host).To(Equal(acceptorHost))
+
+						g.Expect(acceptorIngress.Spec.TLS).To(HaveLen(1))
+						g.Expect(acceptorIngress.Spec.TLS[0].Hosts).To(HaveLen(1))
+						g.Expect(acceptorIngress.Spec.TLS[0].Hosts[0]).To(Equal(acceptorHost))
+					}, existingClusterTimeout, existingClusterInterval).Should(Succeed())
+
+					By("check connector ingress is created")
+					connectorHost := crd.Name + "-my-connector-0." + crd.Spec.IngressDomain
+					connectorIngKey := types.NamespacedName{
+						Name:      crd.Name + "-my-connector-0-svc-ing",
+						Namespace: defaultNamespace,
+					}
+					connectorIngress := netv1.Ingress{}
+					Eventually(func(g Gomega) {
+						g.Expect(k8sClient.Get(ctx, connectorIngKey, &connectorIngress)).To(Succeed())
+
+						g.Expect(connectorIngress.Spec.Rules).To(HaveLen(1))
+						g.Expect(connectorIngress.Spec.Rules[0].Host).To(Equal(connectorHost))
+
+						g.Expect(connectorIngress.Spec.TLS).To(HaveLen(1))
+						g.Expect(connectorIngress.Spec.TLS[0].Hosts).To(HaveLen(1))
+						g.Expect(connectorIngress.Spec.TLS[0].Hosts[0]).To(Equal(connectorHost))
+					}, existingClusterTimeout, existingClusterInterval).Should(Succeed())
+
+					By("check console ingress is created")
+					consoleHost := crd.Name + "-my-console-0." + crd.Spec.IngressDomain
+					consoleIngKey := types.NamespacedName{
+						Name:      crd.Name + "-my-console-0-svc-ing",
+						Namespace: defaultNamespace,
+					}
+					consoleIngress := netv1.Ingress{}
+					Eventually(func(g Gomega) {
+						g.Expect(k8sClient.Get(ctx, consoleIngKey, &consoleIngress)).To(Succeed())
+
+						g.Expect(consoleIngress.Spec.Rules).To(HaveLen(1))
+						g.Expect(consoleIngress.Spec.Rules[0].Host).To(Equal(consoleHost))
+
+						g.Expect(consoleIngress.Spec.TLS).To(HaveLen(1))
+						g.Expect(consoleIngress.Spec.TLS[0].Hosts).To(HaveLen(1))
+						g.Expect(consoleIngress.Spec.TLS[0].Hosts[0]).To(Equal(consoleHost))
+					}, existingClusterTimeout, existingClusterInterval).Should(Succeed())
+				}
+
+				CleanResource(&crd, crd.Name, defaultNamespace)
+				CleanResource(sslSecret, sslSecret.Name, defaultNamespace)
+			}
+		})
+
 		It("Exposing secured console with user specified secret", Label("console-expose-ssl-no-default-secret"), func() {
 			if os.Getenv("USE_EXISTING_CLUSTER") == "true" {
 

--- a/controllers/activemqartemis_reconciler_test.go
+++ b/controllers/activemqartemis_reconciler_test.go
@@ -711,3 +711,27 @@ func TestStatusMarshall(t *testing.T) {
 	assert.True(t, strings.Contains(string(v), ":false"))
 
 }
+
+func TestGetBrokerHost(t *testing.T) {
+	cr := brokerv1beta1.ActiveMQArtemis{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "test-ns",
+			Name:      "test",
+		},
+		Spec: brokerv1beta1.ActiveMQArtemisSpec{
+			IngressDomain: "my-domain.com",
+		},
+	}
+
+	var ingressHost string
+	specIngressHost := "$(CR_NAME)-$(CR_NAMESPACE)-$(ITEM_NAME)-$(BROKER_ORDINAL)-$(RES_TYPE).$(INGRESS_DOMAIN)"
+
+	ingressHost = formatIngressHost(&cr, specIngressHost, "0", "my-acceptor", "ing")
+	assert.Equal(t, "test-test-ns-my-acceptor-0-ing.my-domain.com", ingressHost)
+
+	ingressHost = formatIngressHost(&cr, specIngressHost, "1", "my-connector", "rte")
+	assert.Equal(t, "test-test-ns-my-connector-1-rte.my-domain.com", ingressHost)
+
+	ingressHost = formatIngressHost(&cr, specIngressHost, "2", "my-console", "abc")
+	assert.Equal(t, "test-test-ns-my-console-2-abc.my-domain.com", ingressHost)
+}

--- a/deploy/crds/broker_activemqartemis_crd.yaml
+++ b/deploy/crds/broker_activemqartemis_crd.yaml
@@ -56,6 +56,9 @@ spec:
                     expose:
                       description: Whether or not to expose this acceptor
                       type: boolean
+                    ingressHost:
+                      description: 'Host for Ingress and Route resources of the acceptor. It supports the following variables: $(CR_NAME), $(CR_NAMESPACE), $(BROKER_ORDINAL), $(ITEM_NAME), $(RES_NAME) and $(INGRESS_DOMAIN). Default is $(CR_NAME)-$(ITEM_NAME)-$(BROKER_ORDINAL)-svc-$(RES_TYPE).$(INGRESS_DOMAIN)'
+                      type: string
                     keyStoreProvider:
                       description: Provider used for the keystore; "SUN", "SunJCE", etc. Default is null
                       type: string
@@ -369,6 +372,9 @@ spec:
                     host:
                       description: Hostname or IP to connect to
                       type: string
+                    ingressHost:
+                      description: 'Host for Ingress and Route resources of the acceptor. It supports the following variables: $(CR_NAME), $(CR_NAMESPACE), $(BROKER_ORDINAL), $(ITEM_NAME), $(RES_NAME) and $(INGRESS_DOMAIN). Default is $(CR_NAME)-$(ITEM_NAME)-$(BROKER_ORDINAL)-svc-$(RES_TYPE).$(INGRESS_DOMAIN)'
+                      type: string
                     keyStoreProvider:
                       description: Provider used for the keystore; "SUN", "SunJCE", etc. Default is null
                       type: string
@@ -421,6 +427,12 @@ spec:
                   expose:
                     description: Whether or not to expose this port
                     type: boolean
+                  ingressHost:
+                    description: 'Host for Ingress and Route resources of the acceptor. It supports the following variables: $(CR_NAME), $(CR_NAMESPACE), $(BROKER_ORDINAL), $(ITEM_NAME), $(RES_NAME) and $(INGRESS_DOMAIN). Default is $(CR_NAME)-$(ITEM_NAME)-$(BROKER_ORDINAL)-svc-$(RES_TYPE).$(INGRESS_DOMAIN)'
+                    type: string
+                  name:
+                    description: The name of the console. Default is wconsj.
+                    type: string
                   sslEnabled:
                     description: Whether or not to enable SSL on this port
                     type: boolean

--- a/pkg/resources/ingresses/ingress.go
+++ b/pkg/resources/ingresses/ingress.go
@@ -11,7 +11,7 @@ import (
 
 const defaultIngressDomain string = "apps.artemiscloud.io"
 
-func NewIngressForCRWithSSL(existing *netv1.Ingress, namespacedName types.NamespacedName, labels map[string]string, targetServiceName string, targetPortName string, sslEnabled bool, domain string) *netv1.Ingress {
+func NewIngressForCRWithSSL(existing *netv1.Ingress, namespacedName types.NamespacedName, labels map[string]string, targetServiceName string, targetPortName string, sslEnabled bool, domain string, brokerHost string) *netv1.Ingress {
 
 	pathType := netv1.PathTypePrefix
 
@@ -75,6 +75,11 @@ func NewIngressForCRWithSSL(existing *netv1.Ingress, namespacedName types.Namesp
 	}
 
 	host := desired.GetObjectMeta().GetName() + "." + domain
+
+	if brokerHost != "" {
+		host = brokerHost
+	}
+
 	desired.Spec.Rules[0].Host = host
 	if sslEnabled {
 		desired.Annotations = map[string]string{"nginx.ingress.kubernetes.io/ssl-passthrough": "true"}

--- a/pkg/resources/routes/route.go
+++ b/pkg/resources/routes/route.go
@@ -7,7 +7,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func NewRouteDefinitionForCR(existing *routev1.Route, namespacedName types.NamespacedName, labels map[string]string, targetServiceName string, targetPortName string, passthroughTLS bool, domain string) *routev1.Route {
+func NewRouteDefinitionForCR(existing *routev1.Route, namespacedName types.NamespacedName, labels map[string]string, targetServiceName string, targetPortName string, passthroughTLS bool, domain string, brokerHost string) *routev1.Route {
 
 	var desired *routev1.Route = nil
 	if existing == nil {
@@ -39,7 +39,9 @@ func NewRouteDefinitionForCR(existing *routev1.Route, namespacedName types.Names
 		}
 	}
 
-	if domain != "" {
+	if brokerHost != "" {
+		desired.Spec.Host = brokerHost
+	} else if domain != "" {
 		desired.Spec.Host = desired.GetObjectMeta().GetName() + "." + domain
 	}
 


### PR DESCRIPTION
Add the field `spec.ingressHost` to customize the host for Ingress and Route resources of the broker. The field `spec.ingressHost` also supports the following variables:
- $(CR_NAME) - the name of the custom resource
- $(CR_NAMESPACE) - the namespace of the custom resource
- $(BROKER_ORDINAL) - the StatefulSet ordinal index of the broker pod
- $(ITEM_NAME) - the name of the item (acceptor's name, connector's name or console)
- $(RES_TYPE) - the type of the resource (ing for Ingress and rte for Route)
- $(INGRESS_DOMAIN) - the value of the field `spec.ingressDomain`

The following ActiveMQArtemis CR generates the following acceptor, connector and console Ingress resources:
```
apiVersion: broker.amq.io/v1beta1
kind: ActiveMQArtemis
metadata: 
  name: ex-aoo
spec: 
  deploymentPlan: 
    size: 2
  acceptors: 
  - name: my-acceptor
    port: 61617
    sslEnabled: true
    expose: true
    ingressHost: $(CR_NAME)-$(ITEM_NAME)-$(BROKER_ORDINAL).$(INGRESS_DOMAIN)
  connectors: 
  - name: my-connector
    port: 61617
    sslEnabled: true
    expose: true
    ingressHost: $(CR_NAME)-$(ITEM_NAME)-$(BROKER_ORDINAL).$(INGRESS_DOMAIN)
  console: 
    name: my-console
    sslEnabled: true
    expose: true
    ingressHost: $(CR_NAME)-$(ITEM_NAME)-$(BROKER_ORDINAL).$(INGRESS_DOMAIN)
  ingressDomain: my-domain.com
```
```
ex-aoo-my-acceptor-0.my-domain.com
ex-aoo-my-acceptor-1.my-domain.com
```
```
ex-aoo-my-connector-0.my-domain.com
ex-aoo-my-connector-1.my-domain.com
```
```
ex-aoo-my-console-0.my-domain.com
ex-aoo-my-console-1.my-domain.com
```