### PR TITLE
[#616] Restrict manager container security context

### DIFF
--- a/bundle/manifests/activemq-artemis-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/activemq-artemis-operator.clusterserviceversion.yaml
@@ -2060,6 +2060,11 @@ spec:
                 resources: {}
                 securityContext:
                   allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+                  seccompProfile:
+                    type: RuntimeDefault
               securityContext:
                 runAsNonRoot: true
               serviceAccountName: activemq-artemis-controller-manager

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -65,6 +65,11 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - "ALL"
+          seccompProfile:
+            type: RuntimeDefault
         livenessProbe:
           httpGet:
             path: /healthz

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -107,6 +107,11 @@ spec:
           periodSeconds: 10
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
       securityContext:
         runAsNonRoot: true
       serviceAccountName: activemq-artemis-controller-manager


### PR DESCRIPTION
Drop all cpabilities and set seccomp profile to RuntimeDefault to avoid the warning: would violate PodSecurity "restricted:v1.24"