### PR TITLE
 [694] - Enable metrics to be scraped on operator

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -120,6 +120,9 @@ spec:
           initialDelaySeconds: 15
           periodSeconds: 20
         name: manager
+        ports:
+        - name: http-metrics
+          containerPort: 8383
         readinessProbe:
           httpGet:
             path: /readyz

--- a/docs/help/operator.md
+++ b/docs/help/operator.md
@@ -983,6 +983,24 @@ spec:
 ```
 For a complete example please refer to this [artemiscloud example](https://github.com/artemiscloud/artemiscloud-examples/tree/main/operator/prometheus).
 
+## Enabling Operator Metrics
+
+The operator exposes a port called **http-metrics** for Prometheus to monitor.
+The following is a sample Prometheus PodMonitor resource
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: activemq-artemis-controller-manager
+spec:
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  podMetricsEndpoints:
+  - port: http-metrics
+```
+
 ## Configuring PodDisruptionBudget for broker deployment
 
 The ActiveMQArtemis custom resource offers a PodDisruptionBudget option


### PR DESCRIPTION
Fixes [694](https://github.com/artemiscloud/activemq-artemis-operator/issues/694)

### Type of change
Enhancement

### Description
- Add service to expose metrics port
- Add Prometheus annotations
- Documentation updated  