### PR TITLE
Allow -1 as valid amqpMinLargeMessage value

### DIFF
--- a/controllers/activemqartemis_reconciler.go
+++ b/controllers/activemqartemis_reconciler.go
@@ -651,7 +651,8 @@ func generateAcceptorsString(customResource *brokerv1beta1.ActiveMQArtemis, name
 		if acceptor.ConnectionsAllowed > 0 {
 			acceptorEntry = acceptorEntry + ";" + "connectionsAllowed=" + fmt.Sprintf("%d", acceptor.ConnectionsAllowed)
 		}
-		if acceptor.AMQPMinLargeMessageSize > 0 {
+		if (acceptor.AMQPMinLargeMessageSize > 0) ||
+			(acceptor.AMQPMinLargeMessageSize == -1) {
 			acceptorEntry = acceptorEntry + ";" + "amqpMinLargeMessageSize=" + fmt.Sprintf("%d", acceptor.AMQPMinLargeMessageSize)
 		}
 		if acceptor.SupportAdvisory != nil {


### PR DESCRIPTION
Extends `acceptor.AMQPMinLargeMessageSize` condition because `acceptor.AMQPMinLargeMessageSize > -1` is not valid condition, since if not `amqpMinLargeMessageSize` is set, then 0 is be the default value.

Ref #717 