### PR TITLE
[#735] Fix apt-get in github workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,9 @@ jobs:
 
     steps:
       - name: Install prerequisites
-        run: sudo apt-get install pass
+        run: >
+          sudo apt-get update &&
+          sudo apt-get install pass
 
       - name: Checkout the repo
         uses: actions/checkout@v3


### PR DESCRIPTION
apt-get install may fail if it is used directly without update the mirror list with apt-get update

closes #735 