### PR TITLE
[#503] support jgroup in headless services for istio

### DIFF
--- a/pkg/resources/serviceports/service_port.go
+++ b/pkg/resources/serviceports/service_port.go
@@ -7,10 +7,18 @@ import (
 )
 
 var appProtocolHTTP = "http"
+var appProtocolTCP = "tcp"
 
 func GetDefaultPorts() *[]corev1.ServicePort {
 
 	ports := []corev1.ServicePort{
+		{
+			Name:        "jgroups",
+			Protocol:    "TCP",
+			Port:        7800,
+			AppProtocol: &appProtocolTCP,
+			TargetPort:  intstr.FromInt(int(7800)),
+		},
 		{
 			Name:        "console-jolokia",
 			Protocol:    "TCP",


### PR DESCRIPTION
I added the JGroup Port 7800 to the headless service. It's used in a Cluster to communicate with other nodes. With a service mesh like istio, all used ports must be defined or else the port is blocked.