### PR TITLE
[#811] Allow updates to ingresses

### DIFF
--- a/bundle/manifests/activemq-artemis-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/activemq-artemis-operator.clusterserviceversion.yaml
@@ -2938,6 +2938,7 @@ spec:
           - delete
           - get
           - list
+          - update
           - watch
         - apiGroups:
           - policy

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -167,6 +167,7 @@ rules:
   - delete
   - get
   - list
+  - update
   - watch
 - apiGroups:
   - policy

--- a/controllers/activemqartemis_controller.go
+++ b/controllers/activemqartemis_controller.go
@@ -125,7 +125,7 @@ func NewActiveMQArtemisReconciler(client rtclient.Client, scheme *runtime.Scheme
 //+kubebuilder:rbac:groups="",namespace=activemq-artemis-operator,resources=pods;services;endpoints;persistentvolumeclaims;events;configmaps;secrets;routes;serviceaccounts,verbs=*
 //+kubebuilder:rbac:groups="",namespace=activemq-artemis-operator,resources=namespaces,verbs=get
 //+kubebuilder:rbac:groups=apps,namespace=activemq-artemis-operator,resources=deployments;daemonsets;replicasets;statefulsets,verbs=*
-//+kubebuilder:rbac:groups=networking.k8s.io,namespace=activemq-artemis-operator,resources=ingresses,verbs=get;list;watch;create;delete
+//+kubebuilder:rbac:groups=networking.k8s.io,namespace=activemq-artemis-operator,resources=ingresses,verbs=get;list;watch;create;delete;update
 //+kubebuilder:rbac:groups=route.openshift.io,namespace=activemq-artemis-operator,resources=routes;routes/custom-host;routes/status,verbs=get;list;watch;create;delete;update
 //+kubebuilder:rbac:groups=monitoring.coreos.com,namespace=activemq-artemis-operator,resources=servicemonitors,verbs=get;create
 //+kubebuilder:rbac:groups=apps,namespace=activemq-artemis-operator,resources=deployments/finalizers,verbs=update

--- a/deploy/activemq-artemis-operator.yaml
+++ b/deploy/activemq-artemis-operator.yaml
@@ -5009,6 +5009,7 @@ rules:
   - delete
   - get
   - list
+  - update
   - watch
 - apiGroups:
   - policy

--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -165,6 +165,7 @@ rules:
   - delete
   - get
   - list
+  - update
   - watch
 - apiGroups:
   - policy

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -165,6 +165,7 @@ rules:
   - delete
   - get
   - list
+  - update
   - watch
 - apiGroups:
   - policy


### PR DESCRIPTION
At some point the default (or our configuration) changed for the web console ingress hostname and the operator is attempting to update it and failing with the following error:
```
ingresses.networking.k8s.io "cluster-artemis-wconsj-0-svc-ing" is forbidden:
User "system:serviceaccount:artemis:activemq-artemis-controller-manager" cannot update
resource "ingresses" in API group "networking.k8s.io" in the namespace "artemis"
```

Adding the `update` verb for `ingresses`

Closes https://github.com/artemiscloud/activemq-artemis-operator/issues/811