### PR TITLE
[#839] Fix error installing setup-envtest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -264,7 +264,9 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+## The latest envtest version of envtest doesn't work with go 1.20 because of https://github.com/kubernetes-sigs/controller-runtime/issues/2720
+## Use the command `TZ=UTC git --no-pager show --quiet --abbrev=12 --date='format-local:%Y%m%d%H%M%S' --format="%cd-%h"` to get a pseudo-version
+	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20240215143116-d0396a3d6f9f
 
 .PHONY: bundle
 bundle: manifests operator-sdk kustomize ## Generate bundle manifests and metadata, then validate generated files.


### PR DESCRIPTION
The latest envtest version of envtest doesn't work with go 1.20 because of https://github.com/kubernetes-sigs/controller-runtime/issues/2720