### PR TITLE
[#845] Make: check for go version compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,14 @@ GO_MODULE := github.com/artemiscloud/activemq-artemis-operator
 OS := $(shell go env GOOS)
 ARCH := $(shell go env GOARCH)
 
+# Check that the system's go version is compatible with the one stored in the
+# go.mod file.
+RUNTIME_GO_VERSION := $(shell go version)
+REQUIRED_GO_VERSION := $(subst go ,,$(shell grep -i -e '^go .*' go.mod))
+
+ifeq (,$(findstring $(REQUIRED_GO_VERSION),$(RUNTIME_GO_VERSION)))
+$(error The go version $(RUNTIME_GO_VERSION) the system is currently running is incompatible with the required one $(REQUIRED_GO_VERSION))
+endif
 
 # directory to hold static resources for deploying operator
 DEPLOY := ./deploy


### PR DESCRIPTION
Building with golang 1.21 requires changes to the go.mod file. This is most likely due to a change in behavior in golang's gomod (see https://go.dev/doc/modules/gomod-ref).

Since the migration to the newer version of go hasn't yet been made, and to help any user who might have a > 1.20 version of go on their system, the Makefile now brings in a new check to verify that the go version matches the one of the go.mod.