### PR TITLE
[#266] use WATCH_NAMESPACE instead of OPERATOR_WATCH_NAMESPACE

### DIFF
--- a/controllers/activemqartemis_reconciler.go
+++ b/controllers/activemqartemis_reconciler.go
@@ -546,7 +546,7 @@ func (r *ActiveMQArtemisReconcilerImpl) syncMessageMigration(customResource *bro
 
 func isLocalOnly() bool {
 	oprNamespace := os.Getenv("OPERATOR_NAMESPACE")
-	watchNamespace := os.Getenv("OPERATOR_WATCH_NAMESPACE")
+	watchNamespace := os.Getenv("WATCH_NAMESPACE")
 	return oprNamespace == watchNamespace
 }
 

--- a/controllers/activemqartemisscaledown_controller_test.go
+++ b/controllers/activemqartemisscaledown_controller_test.go
@@ -52,7 +52,7 @@ var _ = Describe("Scale down controller", func() {
 
 			// note: we force a non local scaledown cr to exercise creds generation
 			// hense only valid with DEPLOY_OPERATOR = false
-			// 	see suite_test.go: os.Setenv("OPERATOR_WATCH_NAMESPACE", "SomeValueToCauesEqualitytoFailInIsLocalSoDrainControllerSortsCreds")
+			// 	see suite_test.go: os.Setenv("WATCH_NAMESPACE", "SomeValueToCauesEqualitytoFailInIsLocalSoDrainControllerSortsCreds")
 			if os.Getenv("USE_EXISTING_CLUSTER") == "true" {
 
 				brokerName := NextSpecResourceName()

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -729,7 +729,7 @@ var _ = BeforeSuite(func() {
 
 	// force isLocalOnly=false check from artemis reconciler such that scale down controller will create
 	// role binding to service account for the drainer pod
-	os.Setenv("OPERATOR_WATCH_NAMESPACE", "SomeValueToCauesEqualitytoFailInIsLocalSoDrainControllerSortsCreds")
+	os.Setenv("WATCH_NAMESPACE", "SomeValueToCauesEqualitytoFailInIsLocalSoDrainControllerSortsCreds")
 
 	var err error
 	currentDir, err = os.Getwd()
@@ -761,7 +761,7 @@ var _ = AfterSuite(func() {
 		cleanUpTestProxy()
 	}
 
-	os.Unsetenv("OPERATOR_WATCH_NAMESPACE")
+	os.Unsetenv("WATCH_NAMESPACE")
 
 	if os.Getenv("DEPLOY_OPERATOR") == "true" {
 		err := uninstallOperator(true, defaultNamespace)

--- a/main.go
+++ b/main.go
@@ -157,7 +157,7 @@ func main() {
 	if err := os.Setenv("OPERATOR_NAMESPACE", oprNamespace); err != nil {
 		setupLog.Error(err, "failed to set operator's namespace to env")
 	}
-	if err := os.Setenv("OPERATOR_WATCH_NAMESPACE", watchNamespace); err != nil {
+	if err := os.Setenv("WATCH_NAMESPACE", watchNamespace); err != nil {
 		setupLog.Error(err, "failed to set operator's watch namespace to env")
 	}
 


### PR DESCRIPTION
Replace the custom env variable OPERATOR_WATCH_NAMESPACE with WATCH_NAMESPACE.

@gtully I'm wondering though if that's what you had in mind in the issue or if you meant to remove all the code related to `OPERATOR_WATCH_NAMESPACE`. If it's the later, then we'll have to also rethink the `isLocalOnly` function. Let me know your thoughts on this.