### PR TITLE
[#885] Add ready printer column to ActiveMQArtemis CRD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,13 +123,13 @@ ifeq ($(ENABLE_WEBHOOKS),true)
 ## v2alpha3, v2alpha4 and v2alpha3 requires allowDangerousTypes=true because they use float32 type
 	cd config/manager && $(KUSTOMIZE) edit add resource webhook_secret.yaml 
 	$(CONTROLLER_GEN) rbac:roleName=$(OPERATOR_CLUSTER_ROLE_NAME) crd:allowDangerousTypes=true webhook paths="./..." output:crd:artifacts:config=config/crd/bases
-	find config -type f -exec sed -i.bak -e '/creationTimestamp/d' {} \; -exec rm {}.bak \;
+	find config -type f -exec sed -i.bak -e '/creationTimestamp:/d' {} \; -exec rm {}.bak \;
 else
 ## Generate ClusterRole and CustomResourceDefinition objects.
 ## v2alpha3, v2alpha4 and v2alpha3 requires allowDangerousTypes=true because they use float32 type
 	cd config/manager && $(KUSTOMIZE) edit remove resource webhook_secret.yaml 
 	$(CONTROLLER_GEN) rbac:roleName=$(OPERATOR_CLUSTER_ROLE_NAME) crd:allowDangerousTypes=true paths="./..." output:crd:artifacts:config=config/crd/bases
-	find config -type f -exec sed -i.bak -e '/creationTimestamp/d' {} \; -exec rm {}.bak \;
+	find config -type f -exec sed -i.bak -e '/creationTimestamp:/d' {} \; -exec rm {}.bak \;
 endif
 
 .PHONY: generate
@@ -281,7 +281,7 @@ bundle: manifests operator-sdk kustomize ## Generate bundle manifests and metada
 	$(OPERATOR_SDK) generate kustomize manifests -q --package $(BUNDLE_PACKAGE)
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle --package $(BUNDLE_PACKAGE) $(BUNDLE_GEN_FLAGS)
-	sed -i.bak '/creationTimestamp/d' ./bundle/manifests/*.yaml && rm ./bundle/manifests/*.bak
+	sed -i.bak '/creationTimestamp:/d' ./bundle/manifests/*.yaml && rm ./bundle/manifests/*.bak
 	sed -i.bak '/createdAt/d' ./bundle/manifests/*.yaml && rm ./bundle/manifests/*.bak
 	sed 's/annotations://' config/metadata/$(BUNDLE_PACKAGE).annotations.yaml >> bundle/metadata/annotations.yaml
 	sed -e 's/annotations://' -e 's/  /LABEL /g' -e 's/: /=/g'  config/metadata/$(BUNDLE_PACKAGE).annotations.yaml >> bundle.Dockerfile

--- a/api/v1beta1/activemqartemis_types.go
+++ b/api/v1beta1/activemqartemis_types.go
@@ -760,6 +760,8 @@ type ExternalConfigStatus struct {
 //+kubebuilder:storageversion
 //+kubebuilder:resource:path=activemqartemises
 //+kubebuilder:resource:path=activemqartemises,shortName=aa
+//+kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status",description="The state of the resource"
+//+kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="The age of the resource"
 //+operator-sdk:csv:customresourcedefinitions:resources={{"Service", "v1"}}
 //+operator-sdk:csv:customresourcedefinitions:resources={{"Secret", "v1"}}
 //+operator-sdk:csv:customresourcedefinitions:resources={{"ConfigMap", "v1"}}

--- a/bundle/manifests/broker.amq.io_activemqartemises.yaml
+++ b/bundle/manifests/broker.amq.io_activemqartemises.yaml
@@ -15,7 +15,16 @@ spec:
     singular: activemqartemis
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - description: The state of the resource
+      jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
+    - description: The age of the resource
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: A stateful deployment of one or more brokers

--- a/config/crd/bases/broker.amq.io_activemqartemises.yaml
+++ b/config/crd/bases/broker.amq.io_activemqartemises.yaml
@@ -16,7 +16,16 @@ spec:
     singular: activemqartemis
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - description: The state of the resource
+      jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
+    - description: The age of the resource
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: A stateful deployment of one or more brokers

--- a/deploy/activemq-artemis-operator.yaml
+++ b/deploy/activemq-artemis-operator.yaml
@@ -546,7 +546,16 @@ spec:
     singular: activemqartemis
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - description: The state of the resource
+      jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
+    - description: The age of the resource
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: A stateful deployment of one or more brokers

--- a/deploy/crds/broker_activemqartemis_crd.yaml
+++ b/deploy/crds/broker_activemqartemis_crd.yaml
@@ -15,7 +15,16 @@ spec:
     singular: activemqartemis
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - description: The state of the resource
+      jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
+    - description: The age of the resource
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: A stateful deployment of one or more brokers


### PR DESCRIPTION
The kubectl tool relies on server-side output formatting. Your cluster's API server decides which columns are shown by the kubectl get command. You can customize these columns for a CustomResourceDefinition, see https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#additional-printer-columns

```
$ kubectl apply -f examples/artemis/artemis_single.yaml 
activemqartemis.broker.amq.io/artemis-broker created
```

```
$ kubectl get aa --watch
NAME             READY   AGE
artemis-broker   False   3s
artemis-broker   True    11s
```