### PR TITLE
[#968] Replace HTTP test proxy with SSH tunnels

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 
 require (
 	github.com/blang/semver/v4 v4.0.0
+	golang.org/x/crypto v0.21.0
 	k8s.io/apiextensions-apiserver v0.28.3
 	k8s.io/utils v0.0.0-20230726121419-3b25d923346b
 )
@@ -66,7 +67,6 @@ require (
 	github.com/prometheus/procfs v0.10.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	golang.org/x/crypto v0.21.0 // indirect
 	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e // indirect
 	golang.org/x/net v0.23.0 // indirect
 	golang.org/x/oauth2 v0.8.0 // indirect

--- a/pkg/utils/jolokia/jolokia.go
+++ b/pkg/utils/jolokia/jolokia.go
@@ -83,20 +83,20 @@ func (j *Jolokia) GetProtocol() string {
 }
 
 func (j *Jolokia) getClient() *http.Client {
+	httpClient := http.Client{
+		Transport: http.DefaultTransport,
+		Timeout:   time.Second * 2,
+	}
+
 	if j.protocol == "https" {
-		return &http.Client{
-			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{
-					InsecureSkipVerify: true,
-					ServerName:         j.ip,
-				},
-			},
-			Timeout: time.Second * 2, //Maximum of 2 seconds
+		httpClientTransport := httpClient.Transport.(*http.Transport)
+		httpClientTransport.TLSClientConfig = &tls.Config{
+			InsecureSkipVerify: true,
+			ServerName:         j.ip,
 		}
 	}
-	return &http.Client{
-		Timeout: time.Second * 2, // Maximum of 2 seconds
-	}
+
+	return &httpClient
 }
 
 func (j *Jolokia) Read(_path string) (*ResponseData, error) {


### PR DESCRIPTION
SSH tunnels support HTTPS and other tcp connections.