### PR TITLE
[#1018] Fix conversion of ActiveMQArtemisAddress CRs from v1beta1 to previous versions

### DIFF
--- a/api/v2alpha1/activemqartemisaddress_types.go
+++ b/api/v2alpha1/activemqartemisaddress_types.go
@@ -28,9 +28,9 @@ type ActiveMQArtemisAddressSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
-	AddressName string `json:"addressName"`
-	QueueName   string `json:"queueName"`
-	RoutingType string `json:"routingType"`
+	AddressName string `json:"addressName,omitempty"`
+	QueueName   string `json:"queueName,omitempty"`
+	RoutingType string `json:"routingType,omitempty"`
 }
 
 // ActiveMQArtemisAddressStatus defines the observed state of ActiveMQArtemisAddress

--- a/api/v2alpha2/activemqartemisaddress_types.go
+++ b/api/v2alpha2/activemqartemisaddress_types.go
@@ -28,10 +28,10 @@ type ActiveMQArtemisAddressSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
-	AddressName              string `json:"addressName"`
-	QueueName                string `json:"queueName"`
-	RoutingType              string `json:"routingType"`
-	RemoveFromBrokerOnDelete bool   `json:"removeFromBrokerOnDelete"`
+	AddressName              string `json:"addressName,omitempty"`
+	QueueName                string `json:"queueName,omitempty"`
+	RoutingType              string `json:"routingType,omitempty"`
+	RemoveFromBrokerOnDelete bool   `json:"removeFromBrokerOnDelete,omitempty"`
 }
 
 // ActiveMQArtemisAddressStatus defines the observed state of ActiveMQArtemisAddress

--- a/api/v2alpha3/activemqartemisaddress_types.go
+++ b/api/v2alpha3/activemqartemisaddress_types.go
@@ -44,7 +44,7 @@ type QueueConfigurationType struct {
 	FilterString                *string `json:"filterString,omitempty"`
 	Durable                     *bool   `json:"durable,omitempty"`
 	User                        *string `json:"user,omitempty"`
-	MaxConsumers                *int32  `json:"maxConsumers"`
+	MaxConsumers                *int32  `json:"maxConsumers,omitempty"`
 	Exclusive                   *bool   `json:"exclusive,omitempty"`
 	GroupRebalance              *bool   `json:"groupRebalance,omitempty"`
 	GroupRebalancePauseDispatch *bool   `json:"groupRebalancePauseDispatch,omitempty"`
@@ -53,7 +53,7 @@ type QueueConfigurationType struct {
 	LastValue                   *bool   `json:"lastValue,omitempty"`
 	LastValueKey                *string `json:"lastValueKey,omitempty"`
 	NonDestructive              *bool   `json:"nonDestructive,omitempty"`
-	PurgeOnNoConsumers          *bool   `json:"purgeOnNoConsumers"`
+	PurgeOnNoConsumers          *bool   `json:"purgeOnNoConsumers,omitempty"`
 	Enabled                     *bool   `json:"enabled,omitempty"`
 	ConsumersBeforeDispatch     *int32  `json:"consumersBeforeDispatch,omitempty"`
 	DelayBeforeDispatch         *int64  `json:"delayBeforeDispatch,omitempty"`

--- a/bundle/manifests/broker.amq.io_activemqartemisaddresses.yaml
+++ b/bundle/manifests/broker.amq.io_activemqartemisaddresses.yaml
@@ -269,10 +269,6 @@ spec:
                 type: string
               routingType:
                 type: string
-            required:
-            - addressName
-            - queueName
-            - routingType
             type: object
           status:
             description: ActiveMQArtemisAddressStatus defines the observed state of
@@ -386,11 +382,6 @@ spec:
                 type: boolean
               routingType:
                 type: string
-            required:
-            - addressName
-            - queueName
-            - removeFromBrokerOnDelete
-            - routingType
             type: object
           status:
             description: ActiveMQArtemisAddressStatus defines the observed state of
@@ -566,9 +557,6 @@ spec:
                     type: boolean
                   user:
                     type: string
-                required:
-                - maxConsumers
-                - purgeOnNoConsumers
                 type: object
               queueName:
                 type: string

--- a/config/crd/bases/broker.amq.io_activemqartemisaddresses.yaml
+++ b/config/crd/bases/broker.amq.io_activemqartemisaddresses.yaml
@@ -270,10 +270,6 @@ spec:
                 type: string
               routingType:
                 type: string
-            required:
-            - addressName
-            - queueName
-            - routingType
             type: object
           status:
             description: ActiveMQArtemisAddressStatus defines the observed state of
@@ -387,11 +383,6 @@ spec:
                 type: boolean
               routingType:
                 type: string
-            required:
-            - addressName
-            - queueName
-            - removeFromBrokerOnDelete
-            - routingType
             type: object
           status:
             description: ActiveMQArtemisAddressStatus defines the observed state of
@@ -567,9 +558,6 @@ spec:
                     type: boolean
                   user:
                     type: string
-                required:
-                - maxConsumers
-                - purgeOnNoConsumers
                 type: object
               queueName:
                 type: string

--- a/controllers/activemqartemisaddress_controller_test.go
+++ b/controllers/activemqartemisaddress_controller_test.go
@@ -38,6 +38,9 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	brokerv1beta1 "github.com/artemiscloud/activemq-artemis-operator/api/v1beta1"
+	"github.com/artemiscloud/activemq-artemis-operator/api/v2alpha1"
+	"github.com/artemiscloud/activemq-artemis-operator/api/v2alpha2"
+	"github.com/artemiscloud/activemq-artemis-operator/api/v2alpha3"
 	"github.com/artemiscloud/activemq-artemis-operator/pkg/utils/common"
 	"github.com/artemiscloud/activemq-artemis-operator/pkg/utils/jolokia"
 	"github.com/artemiscloud/activemq-artemis-operator/pkg/utils/namer"
@@ -953,6 +956,47 @@ var _ = Describe("Address controller tests", func() {
 				CleanResource(crd2, crd2.Name, defaultNamespace)
 			}
 
+		})
+	})
+
+	Context("Address conversion test", Label("address-conversion-test"), func() {
+		It("convert empty address CR", func() {
+			v1beta1AddressCR := brokerv1beta1.ActiveMQArtemisAddress{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "ActiveMQArtemisAddress",
+					APIVersion: brokerv1beta1.GroupVersion.Identifier(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      NextSpecResourceName(),
+					Namespace: defaultNamespace,
+				},
+			}
+			Expect(k8sClient.Create(ctx, &v1beta1AddressCR)).Should(Succeed())
+
+			addressCRKey := types.NamespacedName{Name: v1beta1AddressCR.Name, Namespace: v1beta1AddressCR.Namespace}
+
+			Eventually(func(g Gomega) {
+				v1beta1CreatedAddressCR := &brokerv1beta1.ActiveMQArtemisAddress{}
+				g.Expect(k8sClient.Get(ctx, addressCRKey, v1beta1CreatedAddressCR)).Should(Succeed())
+			}, timeout, interval).Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				v2alpha3AddressCR := &v2alpha3.ActiveMQArtemisAddress{}
+				g.Expect(k8sClient.Get(ctx, addressCRKey, v2alpha3AddressCR)).Should(Succeed())
+				g.Expect(k8sClient.Update(ctx, v2alpha3AddressCR)).Should(Succeed())
+			}, timeout, interval).Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				v2alpha2AddressCR := &v2alpha2.ActiveMQArtemisAddress{}
+				g.Expect(k8sClient.Get(ctx, addressCRKey, v2alpha2AddressCR)).Should(Succeed())
+				g.Expect(k8sClient.Update(ctx, v2alpha2AddressCR)).Should(Succeed())
+			}, timeout, interval).Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				v2alpha1AddressCR := &v2alpha1.ActiveMQArtemisAddress{}
+				g.Expect(k8sClient.Get(ctx, addressCRKey, v2alpha1AddressCR)).Should(Succeed())
+				g.Expect(k8sClient.Update(ctx, v2alpha1AddressCR)).Should(Succeed())
+			}, timeout, interval).Should(Succeed())
 		})
 	})
 })

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -62,6 +62,7 @@ import (
 	brokerv1alpha1 "github.com/artemiscloud/activemq-artemis-operator/api/v1alpha1"
 	brokerv1beta1 "github.com/artemiscloud/activemq-artemis-operator/api/v1beta1"
 	brokerv2alpha1 "github.com/artemiscloud/activemq-artemis-operator/api/v2alpha1"
+	brokerv2alpha2 "github.com/artemiscloud/activemq-artemis-operator/api/v2alpha2"
 	brokerv2alpha3 "github.com/artemiscloud/activemq-artemis-operator/api/v2alpha3"
 	brokerv2alpha4 "github.com/artemiscloud/activemq-artemis-operator/api/v2alpha4"
 	brokerv2alpha5 "github.com/artemiscloud/activemq-artemis-operator/api/v2alpha5"
@@ -749,6 +750,9 @@ func setUpK8sClient() {
 	Expect(err).NotTo(HaveOccurred())
 
 	err = brokerv2alpha3.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = brokerv2alpha2.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	err = brokerv2alpha1.AddToScheme(scheme.Scheme)

--- a/deploy/activemq-artemis-operator.yaml
+++ b/deploy/activemq-artemis-operator.yaml
@@ -231,10 +231,6 @@ spec:
                 type: string
               routingType:
                 type: string
-            required:
-            - addressName
-            - queueName
-            - routingType
             type: object
           status:
             description: ActiveMQArtemisAddressStatus defines the observed state of ActiveMQArtemisAddress
@@ -315,11 +311,6 @@ spec:
                 type: boolean
               routingType:
                 type: string
-            required:
-            - addressName
-            - queueName
-            - removeFromBrokerOnDelete
-            - routingType
             type: object
           status:
             description: ActiveMQArtemisAddressStatus defines the observed state of ActiveMQArtemisAddress
@@ -462,9 +453,6 @@ spec:
                     type: boolean
                   user:
                     type: string
-                required:
-                - maxConsumers
-                - purgeOnNoConsumers
                 type: object
               queueName:
                 type: string

--- a/deploy/crds/broker_activemqartemisaddress_crd.yaml
+++ b/deploy/crds/broker_activemqartemisaddress_crd.yaml
@@ -224,10 +224,6 @@ spec:
                 type: string
               routingType:
                 type: string
-            required:
-            - addressName
-            - queueName
-            - routingType
             type: object
           status:
             description: ActiveMQArtemisAddressStatus defines the observed state of ActiveMQArtemisAddress
@@ -308,11 +304,6 @@ spec:
                 type: boolean
               routingType:
                 type: string
-            required:
-            - addressName
-            - queueName
-            - removeFromBrokerOnDelete
-            - routingType
             type: object
           status:
             description: ActiveMQArtemisAddressStatus defines the observed state of ActiveMQArtemisAddress
@@ -455,9 +446,6 @@ spec:
                     type: boolean
                   user:
                     type: string
-                required:
-                - maxConsumers
-                - purgeOnNoConsumers
                 type: object
               queueName:
                 type: string


### PR DESCRIPTION
The ActiveMQArtemisAddress CR v1beta1 has no required fields while the previous versions have the following required fields:
- AddressName
- QueueName
- RoutingType
- RemoveFromBrokerOnDelete
- MaxConsumers
- PurgeOnNoConsumers

Converting an ActiveMQArtemisAddress CR v1beta1 without the previous required fields to previous versions causes errors.