### PR TITLE
Support running in FIPS compliant mode

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -77,7 +77,7 @@ jobs:
         if: ${{ inputs.update_base_image }}
         run: |
           if [ "${{ inputs.base_image }}" = "latest" ]; then
-            BASE_IMAGE="registry.access.redhat.com/ubi8-minimal:$(basename $(skopeo inspect docker://registry.access.redhat.com/ubi8-minimal:latest | jq -r '.Labels.url'))"
+            BASE_IMAGE="registry.access.redhat.com/ubi9-minimal:$(basename $(skopeo inspect docker://registry.access.redhat.com/ubi9-minimal:latest | jq -r '.Labels.version + "-" + .Labels.release'))"
           else
             BASE_IMAGE="${{ inputs.base_image }}"
           fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi8/go-toolset:1.21.11 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.21.11 as builder
 
 ARG TARGETOS
 ARG TARGETARCH
@@ -37,9 +37,11 @@ RUN cp -r $REMOTE_SOURCE_DIR/app/* .
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -ldflags="-X '${GO_MODULE}/version.BuildTimestamp=`date '+%Y-%m-%dT%H:%M:%S'`'" -o manager main.go
+# CGO_ENABLED is set to 1 for dynamic linking to OpenSSL to use FIPS validated cryptographic modules
+# when is executed on nodes that are booted into FIPS mode.
+RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -ldflags="-X '${GO_MODULE}/version.BuildTimestamp=`date '+%Y-%m-%dT%H:%M:%S'`'" -o manager main.go
 
-FROM registry.access.redhat.com/ubi8-minimal:8.10-1130 as base-env
+FROM registry.access.redhat.com/ubi9-minimal:9.5-1731593028 as base-env
 
 ENV BROKER_NAME=activemq-artemis
 ENV USER_UID=1000

--- a/bundle/manifests/activemq-artemis-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/activemq-artemis-operator.clusterserviceversion.yaml
@@ -275,7 +275,7 @@ metadata:
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
     features.operators.openshift.io/disconnected: "true"
-    features.operators.openshift.io/fips-compliant: "false"
+    features.operators.openshift.io/fips-compliant: "true"
     features.operators.openshift.io/proxy-aware: "false"
     features.operators.openshift.io/tls-profiles: "false"
     features.operators.openshift.io/token-auth-aws: "false"

--- a/config/manifests/bases/activemq-artemis-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/activemq-artemis-operator.clusterserviceversion.yaml
@@ -9,7 +9,7 @@ metadata:
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
     features.operators.openshift.io/disconnected: "true"
-    features.operators.openshift.io/fips-compliant: "false"
+    features.operators.openshift.io/fips-compliant: "true"
     features.operators.openshift.io/proxy-aware: "false"
     features.operators.openshift.io/tls-profiles: "false"
     features.operators.openshift.io/token-auth-aws: "false"

--- a/controllers/activemqartemis_controller_test.go
+++ b/controllers/activemqartemis_controller_test.go
@@ -10323,6 +10323,7 @@ var _ = Describe("artemis controller", func() {
 
 				crd.Spec.BrokerProperties = []string{
 					"connectorConfigurations.artemis.params.sslEnabled=true",
+					"connectorConfigurations.artemis.params.forceSSLParameters=true",
 					"connectorConfigurations.artemis.params.trustStorePath=/etc/" + tlsSecretName + "-volume/broker.ks",
 					"connectorConfigurations.artemis.params.trustStorePassword=" + defaultPassword,
 				}
@@ -10360,6 +10361,7 @@ var _ = Describe("artemis controller", func() {
 
 				crd.Spec.BrokerProperties = []string{
 					"connectorConfigurations.artemis.params.sslEnabled=true",
+					"connectorConfigurations.artemis.params.forceSSLParameters=true",
 					"connectorConfigurations.artemis.params.trustStorePath=/etc/" + tlsSecretName + "-volume/tls.crt",
 					"connectorConfigurations.artemis.params.trustStoreType=PEM",
 				}
@@ -10415,6 +10417,7 @@ var _ = Describe("artemis controller", func() {
 
 				crd.Spec.BrokerProperties = []string{
 					"connectorConfigurations.artemis.params.sslEnabled=true",
+					"connectorConfigurations.artemis.params.forceSSLParameters=true",
 					"connectorConfigurations.artemis.params.trustStorePath=/etc/" + tlsSecretName + "-volume/broker.ks",
 					"connectorConfigurations.artemis.params.trustStorePassword=" + defaultPassword,
 				}
@@ -10456,6 +10459,7 @@ var _ = Describe("artemis controller", func() {
 
 				crd.Spec.BrokerProperties = []string{
 					"connectorConfigurations.artemis.params.sslEnabled=true",
+					"connectorConfigurations.artemis.params.forceSSLParameters=true",
 					"connectorConfigurations.artemis.params.trustStorePath=/etc/" + tlsSecretName + "-volume/broker.ks",
 					"connectorConfigurations.artemis.params.trustStorePassword=" + defaultPassword,
 					"connectorConfigurations.artemis.params.verifyHost=false",

--- a/controllers/common_util_test.go
+++ b/controllers/common_util_test.go
@@ -700,7 +700,7 @@ func GenerateKeystore(password string, dnsNames []string) ([]byte, error) {
 		return nil, err
 	}
 
-	ksBytes, err := pkcs12.Encode(crand.Reader, caPrivKey, cert, []*x509.Certificate{}, password)
+	ksBytes, err := pkcs12.Modern.Encode(caPrivKey, cert, []*x509.Certificate{}, password)
 	if err != nil {
 		return nil, err
 	}
@@ -716,7 +716,7 @@ func GenerateTrustStoreFromKeyStore(ksBytes []byte, password string) ([]byte, er
 		return nil, err
 	}
 
-	pfxBytes, err := pkcs12.EncodeTrustStore(crand.Reader, []*x509.Certificate{cert}, password)
+	pfxBytes, err := pkcs12.Modern.EncodeTrustStore([]*x509.Certificate{cert}, password)
 
 	if err != nil {
 		return nil, err

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -143,6 +143,7 @@ var (
 
 	artemisGvk = schema.GroupVersionKind{Group: "broker", Version: "v1beta1", Kind: "ActiveMQArtemis"}
 
+	isFIPSEnabled                             = false
 	isOpenshift                               = false
 	isIngressSSLPassthroughEnabled            = false
 	verbose                                   = false
@@ -200,6 +201,15 @@ func setUpEnvTest() {
 
 	if isOpenshift {
 		kubeTool = "oc"
+	}
+
+	if isOpenshift {
+		clusterConfig := &corev1.ConfigMap{}
+		clusterConfigKey := types.NamespacedName{Name: "cluster-config-v1", Namespace: "kube-system"}
+		clusterConfigErr := k8sClient.Get(ctx, clusterConfigKey, clusterConfig)
+		if clusterConfigErr == nil {
+			isFIPSEnabled = strings.Contains(clusterConfig.Data["install-config"], "fips: true")
+		}
 	}
 
 	setUpIngress()

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	k8s.io/apimachinery v0.28.3
 	k8s.io/client-go v0.28.3
 	sigs.k8s.io/controller-runtime v0.16.3
-	software.sslmate.com/src/go-pkcs12 v0.2.1
+	software.sslmate.com/src/go-pkcs12 v0.5.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -340,5 +340,5 @@ sigs.k8s.io/structured-merge-diff/v4 v4.2.3 h1:PRbqxJClWWYMNV1dhaG4NsibJbArud9kF
 sigs.k8s.io/structured-merge-diff/v4 v4.2.3/go.mod h1:qjx8mGObPmV2aSZepjQjbmb2ihdVs8cGKBraizNC69E=
 sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=
 sigs.k8s.io/yaml v1.3.0/go.mod h1:GeOyir5tyXNByN85N/dRIT9es5UQNerPYEKK56eTBm8=
-software.sslmate.com/src/go-pkcs12 v0.2.1 h1:tbT1jjaeFOF230tzOIRJ6U5S1jNqpsSyNjzDd58H3J8=
-software.sslmate.com/src/go-pkcs12 v0.2.1/go.mod h1:Qiz0EyvDRJjjxGyUQa2cCNZn/wMyzrRJ/qcDXOQazLI=
+software.sslmate.com/src/go-pkcs12 v0.5.0 h1:EC6R394xgENTpZ4RltKydeDUjtlM5drOYIG9c6TVj2M=
+software.sslmate.com/src/go-pkcs12 v0.5.0/go.mod h1:Qiz0EyvDRJjjxGyUQa2cCNZn/wMyzrRJ/qcDXOQazLI=

--- a/pkg/utils/jolokia/jolokia.go
+++ b/pkg/utils/jolokia/jolokia.go
@@ -101,7 +101,9 @@ func (j *Jolokia) GetProtocol() string {
 func (j *Jolokia) getClient() *http.Client {
 	httpClient := http.Client{
 		Transport: http.DefaultTransport,
-		Timeout:   time.Second * 2,
+		// A timeout less than 3 seconds may cause connection issues when
+		// the server requires to change the chiper.
+		Timeout: time.Second * 3,
 	}
 
 	if j.protocol == "https" {


### PR DESCRIPTION
Describe the feature
The FIPS Publication 140 is a series of computer security standards developed by the National Institute of Standards and Technology (NIST) to ensure the quality of cryptographic modules. The FIPS 140 standard ensures that cryptographic tools implement their algorithms correctly. Red Hat UBI 9 comes with a FIPS validated OpenSSL version and the manager must be dynamically linked to OpenSSL to use FIPS validated cryptographic modules when is executed on nodes that are booted into FIPS mode.