### PR TITLE
[#1088] Revert release tag prefix v

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           git fetch --tags --force
           HEAD_COMMIT="$(git rev-parse HEAD)"
-          RELEASE_TAG="$(grep -m 1 -oP '(?<=Version = ")[^"]+' version/version.go)"
+          RELEASE_TAG="v$(grep -m 1 -oP '(?<=Version = ")[^"]+' version/version.go)"
           RELEASE_TAG_COMMIT="$(git rev-list -n 1 ${RELEASE_TAG} || true)"
           if [ "$RELEASE_TAG_COMMIT" != "$HEAD_COMMIT" ]; then
             git config user.name 'arkmq-bot'


### PR DESCRIPTION
Each go module version starts with the letter v, followed by a semantic version. See https://go.dev/ref/mod