### PR TITLE
[NO-ISSUE] Fix docker build warnings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi9/go-toolset:1.21.11 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.21.11 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH
@@ -41,7 +41,7 @@ RUN cp -r $REMOTE_SOURCE_DIR/app/* .
 # when is executed on nodes that are booted into FIPS mode.
 RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -ldflags="-X '${GO_MODULE}/version.BuildTimestamp=`date '+%Y-%m-%dT%H:%M:%S'`'" -o manager main.go
 
-FROM registry.access.redhat.com/ubi9-minimal:9.5-1736404155 as base-env
+FROM registry.access.redhat.com/ubi9-minimal:9.5-1736404155 AS base-env
 
 ENV BROKER_NAME=activemq-artemis
 ENV USER_UID=1000


### PR DESCRIPTION
When build docker image using `make docker-build` the recent docker command gives warnings as the cases of keywords are not consistent. example:
$ make docker-build
...

2 warnings found (use docker --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 2)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 44)