### PR TITLE
Update the bundle manifests to include additional annotations in the CSV file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -286,7 +286,8 @@ bundle: manifests operator-sdk kustomize ## Generate bundle manifests and metada
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle --package $(BUNDLE_PACKAGE) $(BUNDLE_GEN_FLAGS)
 	sed -i.bak '/creationTimestamp:/d' ./bundle/manifests/*.yaml && rm ./bundle/manifests/*.bak
-	sed -i.bak '/createdAt/d' ./bundle/manifests/*.yaml && rm ./bundle/manifests/*.bak
+	sed -i.bak "s/createdAt:.*/`grep -oP 'createdAt:.*' config/manifests/bases/$(BUNDLE_PACKAGE).clusterserviceversion.yaml`/" ./bundle/manifests/*.yaml && rm ./bundle/manifests/*.bak
+	sed -i.bak 's|containerImage: .*|containerImage: '${IMG}'|' ./bundle/manifests/*.yaml && rm ./bundle/manifests/*.bak
 	sed 's/annotations://' config/metadata/$(BUNDLE_PACKAGE).annotations.yaml >> bundle/metadata/annotations.yaml
 	sed -e 's/annotations://' -e 's/  /LABEL /g' -e 's/: /=/g'  config/metadata/$(BUNDLE_PACKAGE).annotations.yaml >> bundle.Dockerfile
 	sed -i.bak 's/operators.operatorframework.io.bundle.package.v1:.*/operators.operatorframework.io.bundle.package.v1: $(BUNDLE_ANNOTATION_PACKAGE)/' bundle/metadata/annotations.yaml && rm bundle/metadata/annotations.yaml.bak

--- a/bundle/manifests/activemq-artemis-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/activemq-artemis-operator.clusterserviceversion.yaml
@@ -271,6 +271,9 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     categories: Streaming & Messaging
+    containerImage: quay.io/arkmq-org/activemq-artemis-operator:2.0.2
+    createdAt: "2025-04-04 14:35:00"
+    description: An operator for managing the Apache ActiveMQ Artemis message broker
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
@@ -283,6 +286,8 @@ metadata:
     features.operators.openshift.io/token-auth-gcp: "false"
     operators.operatorframework.io/builder: operator-sdk-v1.28.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+    repository: https://github.com/arkmq-org/activemq-artemis-operator
+    support: arkmq-org
   name: activemq-artemis-operator.v2.0.2
   namespace: placeholder
 spec:

--- a/config/manifests/bases/activemq-artemis-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/activemq-artemis-operator.clusterserviceversion.yaml
@@ -5,6 +5,9 @@ metadata:
     alm-examples: '[]'
     capabilities: Seamless Upgrades
     categories: Streaming & Messaging
+    containerImage: ""
+    createdAt: "2025-04-04 14:35:00"
+    description: An operator for managing the Apache ActiveMQ Artemis message broker
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
@@ -15,6 +18,8 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
+    repository: https://github.com/arkmq-org/activemq-artemis-operator
+    support: arkmq-org
   name: activemq-artemis-operator.v0.0.0
   namespace: placeholder
 spec:


### PR DESCRIPTION
Updated the bundle manifest to include additional annotations in the CSV file by referring the [community-operators](https://github.com/operator-framework/community-operators/blob/master/docs/packaging-required-fields.md#packaging-required-fields-for-operatorhub) documentation from [operatorhub.io](https://operatorhub.io/)

fixes: [#659](https://github.com/arkmq-org/activemq-artemis-operator/issues/659)



