### PR TITLE
Update scorecard test image to latest version

### DIFF
--- a/api/v2alpha1/activemqartemis_types.go
+++ b/api/v2alpha1/activemqartemis_types.go
@@ -29,64 +29,156 @@ type ActiveMQArtemisSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
-	AdminUser      string             `json:"adminUser,omitempty"`
-	AdminPassword  string             `json:"adminPassword,omitempty"`
+	// User name for standard broker user. It is required for connecting to the broker and the web console. If left empty, it will be generated.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Admin User",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	AdminUser string `json:"adminUser,omitempty"`
+	// Password for standard broker user. It is required for connecting to the broker and the web console. If left empty, it will be generated.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Admin Password",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:password"}
+	AdminPassword string `json:"adminPassword,omitempty"`
+	// Specifies the deployment plan
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Deployment Plan"
 	DeploymentPlan DeploymentPlanType `json:"deploymentPlan,omitempty"`
-	Acceptors      []AcceptorType     `json:"acceptors,omitempty"`
-	Connectors     []ConnectorType    `json:"connectors,omitempty"`
-	Console        ConsoleType        `json:"console,omitempty"`
+	// Specifies the acceptor configuration
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Acceptors"
+	Acceptors []AcceptorType `json:"acceptors,omitempty"`
+	// Specifies connectors and connector configuration
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Connectors"
+	Connectors []ConnectorType `json:"connectors,omitempty"`
+	// Specifies the console configuration
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Console Configurations"
+	Console ConsoleType `json:"console,omitempty"`
 }
 
 type DeploymentPlanType struct {
-	Image              string `json:"image,omitempty"`
-	Size               int32  `json:"size,omitempty"`
-	RequireLogin       bool   `json:"requireLogin,omitempty"`
-	PersistenceEnabled bool   `json:"persistenceEnabled,omitempty"`
-	JournalType        string `json:"journalType,omitempty"`
-	MessageMigration   *bool  `json:"messageMigration,omitempty"`
+	//The image used for the broker, all upgrades are disabled. Needs a corresponding initImage
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Image",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	Image string `json:"image,omitempty"`
+	// The number of broker pods to deploy
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Size",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:podCount"}
+	Size int32 `json:"size,omitempty"`
+	// If true require user password login credentials for broker protocol ports
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Require Login",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	RequireLogin bool `json:"requireLogin,omitempty"`
+	// If true use persistent volume via persistent volume claim for journal storage
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Persistence Enabled",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	PersistenceEnabled bool `json:"persistenceEnabled,omitempty"`
+	// If aio use ASYNCIO, if nio use NIO for journal IO
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Journal Type",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	JournalType string `json:"journalType,omitempty"`
+	//If true migrate messages on scaledown
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Message Migration",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	MessageMigration *bool `json:"messageMigration,omitempty"`
 }
 
 type AcceptorType struct {
-	Name                string `json:"name"`
-	Port                int32  `json:"port,omitempty"`
-	Protocols           string `json:"protocols,omitempty"`
-	SSLEnabled          bool   `json:"sslEnabled,omitempty"`
-	SSLSecret           string `json:"sslSecret,omitempty"`
+	// The acceptor name
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Name",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	Name string `json:"name"`
+	// Port number
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Port",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	Port int32 `json:"port,omitempty"`
+	// The protocols to enable for this acceptor
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Protocols",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	Protocols string `json:"protocols,omitempty"`
+	// Whether or not to enable SSL on this port
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="SSL Enabled",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	SSLEnabled bool `json:"sslEnabled,omitempty"`
+	// Name of the secret to use for ssl information
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="SSL Secret",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	SSLSecret string `json:"sslSecret,omitempty"`
+	// Comma separated list of cipher suites used for SSL communication.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Enabled Cipher Suites",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	EnabledCipherSuites string `json:"enabledCipherSuites,omitempty"`
-	EnabledProtocols    string `json:"enabledProtocols,omitempty"`
-	NeedClientAuth      bool   `json:"needClientAuth,omitempty"`
-	WantClientAuth      bool   `json:"wantClientAuth,omitempty"`
-	VerifyHost          bool   `json:"verifyHost,omitempty"`
-	SSLProvider         string `json:"sslProvider,omitempty"`
-	SNIHost             string `json:"sniHost,omitempty"`
-	Expose              bool   `json:"expose,omitempty"`
-	AnycastPrefix       string `json:"anycastPrefix,omitempty"`
-	MulticastPrefix     string `json:"multicastPrefix,omitempty"`
-	ConnectionsAllowed  int    `json:"connectionsAllowed,omitempty"`
+	// Comma separated list of protocols used for SSL communication.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Enabled Protocols",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	EnabledProtocols string `json:"enabledProtocols,omitempty"`
+	// Tells a client connecting to this acceptor that 2-way SSL is required. This property takes precedence over wantClientAuth.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Need Client Auth",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	NeedClientAuth bool `json:"needClientAuth,omitempty"`
+	// Tells a client connecting to this acceptor that 2-way SSL is requested but not required. Overridden by needClientAuth.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Want Client Auth",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	WantClientAuth bool `json:"wantClientAuth,omitempty"`
+	// The CN of the connecting client's SSL certificate will be compared to its hostname to verify they match. This is useful only for 2-way SSL.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Verify Host",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	VerifyHost bool `json:"verifyHost,omitempty"`
+	// Used to change the SSL Provider between JDK and OPENSSL. The default is JDK.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="SSL Provider",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	SSLProvider string `json:"sslProvider,omitempty"`
+	// A regular expression used to match the server_name extension on incoming SSL connections. If the name doesn't match then the connection to the acceptor will be rejected.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="SNI Host",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	SNIHost string `json:"sniHost,omitempty"`
+	// Whether or not to expose this acceptor
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Expose",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	Expose bool `json:"expose,omitempty"`
+	// To indicate which kind of routing type to use.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Anycast Prefix",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	AnycastPrefix string `json:"anycastPrefix,omitempty"`
+	// To indicate which kind of routing type to use
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Multicast Prefix",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	MulticastPrefix string `json:"multicastPrefix,omitempty"`
+	// Max number of connections allowed to make
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Connections Allowed",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	ConnectionsAllowed int `json:"connectionsAllowed,omitempty"`
 }
 
 type ConnectorType struct {
-	Name                string `json:"name"`
-	Type                string `json:"type,omitempty"`
-	Host                string `json:"host"`
-	Port                int32  `json:"port"`
-	SSLEnabled          bool   `json:"sslEnabled,omitempty"`
-	SSLSecret           string `json:"sslSecret,omitempty"`
+	// The name of the connector
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Name",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	Name string `json:"name"`
+	// The type either tcp or vm
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Type",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	Type string `json:"type,omitempty"`
+	// Hostname or IP to connect to
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Host",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	Host string `json:"host"`
+	// Port number
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Port",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	Port int32 `json:"port"`
+	//  Whether or not to enable SSL on this port
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="SSL Enabled",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	SSLEnabled bool `json:"sslEnabled,omitempty"`
+	// Name of the secret to use for ssl information
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="SSL Secret",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	SSLSecret string `json:"sslSecret,omitempty"`
+	// Comma separated list of cipher suites used for SSL communication.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Enabled Cipher Suites",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	EnabledCipherSuites string `json:"enabledCipherSuites,omitempty"`
-	EnabledProtocols    string `json:"enabledProtocols,omitempty"`
-	NeedClientAuth      bool   `json:"needClientAuth,omitempty"`
-	WantClientAuth      bool   `json:"wantClientAuth,omitempty"`
-	VerifyHost          bool   `json:"verifyHost,omitempty"`
-	SSLProvider         string `json:"sslProvider,omitempty"`
-	SNIHost             string `json:"sniHost,omitempty"`
-	Expose              bool   `json:"expose,omitempty"`
+	// Comma separated list of protocols used for SSL communication.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Enabled Protocols",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	EnabledProtocols string `json:"enabledProtocols,omitempty"`
+	// Tells a client connecting to this connector that 2-way SSL is required. This property takes precedence over wantClientAuth.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Need Client Auth",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	NeedClientAuth bool `json:"needClientAuth,omitempty"`
+	// Tells a client connecting to this connector that 2-way SSL is requested but not required. Overridden by needClientAuth.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Want Client Auth",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	WantClientAuth bool `json:"wantClientAuth,omitempty"`
+	// The CN of the connecting client's SSL certificate will be compared to its hostname to verify they match. This is useful only for 2-way SSL.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Verify Host",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	VerifyHost bool `json:"verifyHost,omitempty"`
+	// Used to change the SSL Provider between JDK and OPENSSL. The default is JDK.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="SSL Provider",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	SSLProvider string `json:"sslProvider,omitempty"`
+	// A regular expression used to match the server_name extension on incoming SSL connections. If the name doesn't match then the connection to the acceptor will be rejected.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="SNI Host",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	SNIHost string `json:"sniHost,omitempty"`
+	// Whether or not to expose this connector
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Expose",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	Expose bool `json:"expose,omitempty"`
 }
 
 type ConsoleType struct {
-	Expose        bool   `json:"expose,omitempty"`
-	SSLEnabled    bool   `json:"sslEnabled,omitempty"`
-	SSLSecret     string `json:"sslSecret,omitempty"`
-	UseClientAuth bool   `json:"useClientAuth,omitempty"`
+	// Whether or not to expose this port
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Expose",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	Expose bool `json:"expose,omitempty"`
+	// Whether or not to enable SSL on this port
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="SSL Enabled",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	SSLEnabled bool `json:"sslEnabled,omitempty"`
+	// Name of the secret to use for ssl information
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="SSL Secret",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	SSLSecret string `json:"sslSecret,omitempty"`
+	// If the embedded server requires client authentication
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Use Client Auth",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	UseClientAuth bool `json:"useClientAuth,omitempty"`
 }
 
 // ActiveMQArtemisStatus defines the observed state of ActiveMQArtemis
@@ -111,7 +203,8 @@ type ActiveMQArtemisStatus struct {
 //+kubebuilder:resource:path=activemqartemises,shortName=aa
 //+operator-sdk:csv:customresourcedefinitions:resources={{"Secret", "v1"}}
 
-// ActiveMQArtemis is the Schema for the activemqartemises API
+// A stateful deployment of one or more brokers
+// +operator-sdk:csv:customresourcedefinitions:displayName="ActiveMQ Artemis"
 type ActiveMQArtemis struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v2alpha1/activemqartemisaddress_types.go
+++ b/api/v2alpha1/activemqartemisaddress_types.go
@@ -28,8 +28,14 @@ type ActiveMQArtemisAddressSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
+	// The Address Name
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Address Name",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	AddressName string `json:"addressName,omitempty"`
-	QueueName   string `json:"queueName,omitempty"`
+	// The Queue Name
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Queue Name",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	QueueName string `json:"queueName,omitempty"`
+	// The Routing Type
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Routing Type",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	RoutingType string `json:"routingType,omitempty"`
 }
 
@@ -53,7 +59,8 @@ type ActiveMQArtemisAddressStatus struct {
 //+operator-sdk:csv:customresourcedefinitions:resources={{"Secret", "v1"}}
 
 // +kubebuilder:deprecatedversion:warning="The ActiveMQArtemisAddress CRD is deprecated. Use the spec.brokerProperties attribute in the ActiveMQArtemis CR to create addresses and queues instead"
-// ActiveMQArtemisAddress is the Schema for the activemqartemisaddresses API
+// Adding and removing addresses using custom resource definitions
+// +operator-sdk:csv:customresourcedefinitions:displayName="ActiveMQ Artemis Address"
 type ActiveMQArtemisAddress struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v2alpha2/activemqartemis_types.go
+++ b/api/v2alpha2/activemqartemis_types.go
@@ -29,72 +29,172 @@ type ActiveMQArtemisSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
-	AdminUser      string                  `json:"adminUser,omitempty"`
-	AdminPassword  string                  `json:"adminPassword,omitempty"`
-	DeploymentPlan DeploymentPlanType      `json:"deploymentPlan,omitempty"`
-	Acceptors      []AcceptorType          `json:"acceptors,omitempty"`
-	Connectors     []ConnectorType         `json:"connectors,omitempty"`
-	Console        ConsoleType             `json:"console,omitempty"`
-	Version        string                  `json:"version,omitempty"`
-	Upgrades       ActiveMQArtemisUpgrades `json:"upgrades,omitempty"`
+	// User name for standard broker user. It is required for connecting to the broker and the web console. If left empty, it will be generated.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Admin User",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	AdminUser string `json:"adminUser,omitempty"`
+	// Password for standard broker user. It is required for connecting to the broker and the web console. If left empty, it will be generated.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Admin Password",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:password"}
+	AdminPassword string `json:"adminPassword,omitempty"`
+	// Specifies the deployment plan
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Deployment Plan"
+	DeploymentPlan DeploymentPlanType `json:"deploymentPlan,omitempty"`
+	// Specifies the acceptor configuration
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Acceptors"
+	Acceptors []AcceptorType `json:"acceptors,omitempty"`
+	// Specifies connectors and connector configuration
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Connectors"
+	Connectors []ConnectorType `json:"connectors,omitempty"`
+	// Specifies the console configuration
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Console Configurations"
+	Console ConsoleType `json:"console,omitempty"`
+	// The desired version of the broker. Can be x, or x.y or x.y.z to configure upgrades
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Version",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	Version string `json:"version,omitempty"`
+	// Specifies the upgrades (deprecated in favour of Version)
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Upgrades"
+	Upgrades ActiveMQArtemisUpgrades `json:"upgrades,omitempty"`
 }
 
 type DeploymentPlanType struct {
-	Image              string `json:"image,omitempty"`
-	Size               int32  `json:"size,omitempty"`
-	RequireLogin       bool   `json:"requireLogin,omitempty"`
-	PersistenceEnabled bool   `json:"persistenceEnabled,omitempty"`
-	JournalType        string `json:"journalType,omitempty"`
-	MessageMigration   *bool  `json:"messageMigration,omitempty"`
+	//The image used for the broker, all upgrades are disabled. Needs a corresponding initImage
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Image",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	Image string `json:"image,omitempty"`
+	// The number of broker pods to deploy
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Size",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:podCount"}
+	Size int32 `json:"size,omitempty"`
+	// If true require user password login credentials for broker protocol ports
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Require Login",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	RequireLogin bool `json:"requireLogin,omitempty"`
+	// If true use persistent volume via persistent volume claim for journal storage
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Persistence Enabled",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	PersistenceEnabled bool `json:"persistenceEnabled,omitempty"`
+	// If aio use ASYNCIO, if nio use NIO for journal IO
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Journal Type",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	JournalType string `json:"journalType,omitempty"`
+	//If true migrate messages on scaledown
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Message Migration",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	MessageMigration *bool `json:"messageMigration,omitempty"`
 }
 
 type AcceptorType struct {
-	Name                string `json:"name"`
-	Port                int32  `json:"port,omitempty"`
-	Protocols           string `json:"protocols,omitempty"`
-	SSLEnabled          bool   `json:"sslEnabled,omitempty"`
-	SSLSecret           string `json:"sslSecret,omitempty"`
+	// The acceptor name
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Name",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	Name string `json:"name"`
+	// Port number
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Port",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	Port int32 `json:"port,omitempty"`
+	// The protocols to enable for this acceptor
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Protocols",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	Protocols string `json:"protocols,omitempty"`
+	// Whether or not to enable SSL on this port
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="SSL Enabled",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	SSLEnabled bool `json:"sslEnabled,omitempty"`
+	// Name of the secret to use for ssl information
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="SSL Secret",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	SSLSecret string `json:"sslSecret,omitempty"`
+	// Comma separated list of cipher suites used for SSL communication.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Enabled Cipher Suites",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	EnabledCipherSuites string `json:"enabledCipherSuites,omitempty"`
-	EnabledProtocols    string `json:"enabledProtocols,omitempty"`
-	NeedClientAuth      bool   `json:"needClientAuth,omitempty"`
-	WantClientAuth      bool   `json:"wantClientAuth,omitempty"`
-	VerifyHost          bool   `json:"verifyHost,omitempty"`
-	SSLProvider         string `json:"sslProvider,omitempty"`
-	SNIHost             string `json:"sniHost,omitempty"`
-	Expose              bool   `json:"expose,omitempty"`
-	AnycastPrefix       string `json:"anycastPrefix,omitempty"`
-	MulticastPrefix     string `json:"multicastPrefix,omitempty"`
-	ConnectionsAllowed  int    `json:"connectionsAllowed,omitempty"`
+	// Comma separated list of protocols used for SSL communication.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Enabled Protocols",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	EnabledProtocols string `json:"enabledProtocols,omitempty"`
+	// Tells a client connecting to this acceptor that 2-way SSL is required. This property takes precedence over wantClientAuth.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Need Client Auth",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	NeedClientAuth bool `json:"needClientAuth,omitempty"`
+	// Tells a client connecting to this acceptor that 2-way SSL is requested but not required. Overridden by needClientAuth.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Want Client Auth",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	WantClientAuth bool `json:"wantClientAuth,omitempty"`
+	// The CN of the connecting client's SSL certificate will be compared to its hostname to verify they match. This is useful only for 2-way SSL.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Verify Host",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	VerifyHost bool `json:"verifyHost,omitempty"`
+	// Used to change the SSL Provider between JDK and OPENSSL. The default is JDK.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="SSL Provider",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	SSLProvider string `json:"sslProvider,omitempty"`
+	// A regular expression used to match the server_name extension on incoming SSL connections. If the name doesn't match then the connection to the acceptor will be rejected.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="SNI Host",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	SNIHost string `json:"sniHost,omitempty"`
+	// Whether or not to expose this acceptor
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Expose",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	Expose bool `json:"expose,omitempty"`
+	// To indicate which kind of routing type to use.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Anycast Prefix",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	AnycastPrefix string `json:"anycastPrefix,omitempty"`
+	// To indicate which kind of routing type to use
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Multicast Prefix",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	MulticastPrefix string `json:"multicastPrefix,omitempty"`
+	// Max number of connections allowed to make
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Connections Allowed",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	ConnectionsAllowed int `json:"connectionsAllowed,omitempty"`
 }
 
 type ConnectorType struct {
-	Name                string `json:"name"`
-	Type                string `json:"type,omitempty"`
-	Host                string `json:"host"`
-	Port                int32  `json:"port"`
-	SSLEnabled          bool   `json:"sslEnabled,omitempty"`
-	SSLSecret           string `json:"sslSecret,omitempty"`
+	// The name of the connector
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Name",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	Name string `json:"name"`
+	// The type either tcp or vm
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Type",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	Type string `json:"type,omitempty"`
+	// Hostname or IP to connect to
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Host",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	Host string `json:"host"`
+	// Port number
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Port",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	Port int32 `json:"port"`
+	//  Whether or not to enable SSL on this port
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="SSL Enabled",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	SSLEnabled bool `json:"sslEnabled,omitempty"`
+	// Name of the secret to use for ssl information
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="SSL Secret",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	SSLSecret string `json:"sslSecret,omitempty"`
+	// Comma separated list of cipher suites used for SSL communication.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Enabled Cipher Suites",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	EnabledCipherSuites string `json:"enabledCipherSuites,omitempty"`
-	EnabledProtocols    string `json:"enabledProtocols,omitempty"`
-	NeedClientAuth      bool   `json:"needClientAuth,omitempty"`
-	WantClientAuth      bool   `json:"wantClientAuth,omitempty"`
-	VerifyHost          bool   `json:"verifyHost,omitempty"`
-	SSLProvider         string `json:"sslProvider,omitempty"`
-	SNIHost             string `json:"sniHost,omitempty"`
-	Expose              bool   `json:"expose,omitempty"`
+	// Comma separated list of protocols used for SSL communication.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Enabled Protocols",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	EnabledProtocols string `json:"enabledProtocols,omitempty"`
+	// Tells a client connecting to this connector that 2-way SSL is required. This property takes precedence over wantClientAuth.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Need Client Auth",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	NeedClientAuth bool `json:"needClientAuth,omitempty"`
+	// Tells a client connecting to this connector that 2-way SSL is requested but not required. Overridden by needClientAuth.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Want Client Auth",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	WantClientAuth bool `json:"wantClientAuth,omitempty"`
+	// The CN of the connecting client's SSL certificate will be compared to its hostname to verify they match. This is useful only for 2-way SSL.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Verify Host",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	VerifyHost bool `json:"verifyHost,omitempty"`
+	// Used to change the SSL Provider between JDK and OPENSSL. The default is JDK.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="SSL Provider",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	SSLProvider string `json:"sslProvider,omitempty"`
+	// A regular expression used to match the server_name extension on incoming SSL connections. If the name doesn't match then the connection to the acceptor will be rejected.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="SNI Host",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	SNIHost string `json:"sniHost,omitempty"`
+	// Whether or not to expose this connector
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Expose",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	Expose bool `json:"expose,omitempty"`
 }
 
 type ConsoleType struct {
-	Expose        bool   `json:"expose,omitempty"`
-	SSLEnabled    bool   `json:"sslEnabled,omitempty"`
-	SSLSecret     string `json:"sslSecret,omitempty"`
-	UseClientAuth bool   `json:"useClientAuth,omitempty"`
+	// Whether or not to expose this port
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Expose",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	Expose bool `json:"expose,omitempty"`
+	// Whether or not to enable SSL on this port
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="SSL Enabled",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	SSLEnabled bool `json:"sslEnabled,omitempty"`
+	// Name of the secret to use for ssl information
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="SSL Secret",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	SSLSecret string `json:"sslSecret,omitempty"`
+	// If the embedded server requires client authentication
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Use Client Auth",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	UseClientAuth bool `json:"useClientAuth,omitempty"`
 }
 
 // ActiveMQArtemis App product upgrade flags
 type ActiveMQArtemisUpgrades struct {
+	// Set true to enable automatic micro version product upgrades, it is disabled by default.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Enable Upgrades",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:ui:booleanSwitch"}
 	Enabled bool `json:"enabled"`
-	Minor   bool `json:"minor"`
+	// Set true to enable automatic minor product version upgrades, it is disabled by default. Requires spec.upgrades.enabled to be true.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Include minor version upgrades",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldDependency:upgrades.enabled:true","urn:alm:descriptor:com.tectonic.ui:ui:booleanSwitch"}
+	Minor bool `json:"minor"`
 }
 
 // ActiveMQArtemisStatus defines the observed state of ActiveMQArtemis
@@ -119,7 +219,8 @@ type ActiveMQArtemisStatus struct {
 //+kubebuilder:resource:path=activemqartemises,shortName=aa
 //+operator-sdk:csv:customresourcedefinitions:resources={{"Secret", "v1"}}
 
-// ActiveMQArtemis is the Schema for the activemqartemises API
+// A stateful deployment of one or more brokers
+// +operator-sdk:csv:customresourcedefinitions:displayName="ActiveMQ Artemis"
 type ActiveMQArtemis struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v2alpha2/activemqartemisaddress_types.go
+++ b/api/v2alpha2/activemqartemisaddress_types.go
@@ -28,10 +28,18 @@ type ActiveMQArtemisAddressSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
-	AddressName              string `json:"addressName,omitempty"`
-	QueueName                string `json:"queueName,omitempty"`
-	RoutingType              string `json:"routingType,omitempty"`
-	RemoveFromBrokerOnDelete bool   `json:"removeFromBrokerOnDelete,omitempty"`
+	// The Address Name
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Address Name",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	AddressName string `json:"addressName,omitempty"`
+	// The Queue Name
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Queue Name",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	QueueName string `json:"queueName,omitempty"`
+	// The Routing Type
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Routing Type",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	RoutingType string `json:"routingType,omitempty"`
+	// Whether or not delete the queue from broker when CR is undeployed(default false)
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Remove From Broker On Delete",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	RemoveFromBrokerOnDelete bool `json:"removeFromBrokerOnDelete,omitempty"`
 }
 
 // ActiveMQArtemisAddressStatus defines the observed state of ActiveMQArtemisAddress
@@ -54,7 +62,8 @@ type ActiveMQArtemisAddressStatus struct {
 //+operator-sdk:csv:customresourcedefinitions:resources={{"Secret", "v1"}}
 
 // +kubebuilder:deprecatedversion:warning="The ActiveMQArtemisAddress CRD is deprecated. Use the spec.brokerProperties attribute in the ActiveMQArtemis CR to create addresses and queues instead"
-// ActiveMQArtemisAddress is the Schema for the activemqartemisaddresses API
+// Adding and removing addresses using custom resource definitions
+// +operator-sdk:csv:customresourcedefinitions:displayName="ActiveMQ Artemis Address"
 type ActiveMQArtemisAddress struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v2alpha3/activemqartemis_types.go
+++ b/api/v2alpha3/activemqartemis_types.go
@@ -30,152 +30,388 @@ type ActiveMQArtemisSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
-	AdminUser       string                  `json:"adminUser,omitempty"`
-	AdminPassword   string                  `json:"adminPassword,omitempty"`
-	DeploymentPlan  DeploymentPlanType      `json:"deploymentPlan,omitempty"`
-	Acceptors       []AcceptorType          `json:"acceptors,omitempty"`
-	Connectors      []ConnectorType         `json:"connectors,omitempty"`
-	Console         ConsoleType             `json:"console,omitempty"`
-	Version         string                  `json:"version,omitempty"`
-	Upgrades        ActiveMQArtemisUpgrades `json:"upgrades,omitempty"`
-	AddressSettings AddressSettingsType     `json:"addressSettings,omitempty"`
+	// User name for standard broker user. It is required for connecting to the broker and the web console. If left empty, it will be generated.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Admin User",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	AdminUser string `json:"adminUser,omitempty"`
+	// Password for standard broker user. It is required for connecting to the broker and the web console. If left empty, it will be generated.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Admin Password",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:password"}
+	AdminPassword string `json:"adminPassword,omitempty"`
+	// Specifies the deployment plan
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Deployment Plan"
+	DeploymentPlan DeploymentPlanType `json:"deploymentPlan,omitempty"`
+	// Specifies the acceptor configuration
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Acceptors"
+	Acceptors []AcceptorType `json:"acceptors,omitempty"`
+	// Specifies connectors and connector configuration
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Connectors"
+	Connectors []ConnectorType `json:"connectors,omitempty"`
+	// Specifies the console configuration
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Console Configurations"
+	Console ConsoleType `json:"console,omitempty"`
+	// The desired version of the broker. Can be x, or x.y or x.y.z to configure upgrades
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Version",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	Version string `json:"version,omitempty"`
+	// Specifies the upgrades (deprecated in favour of Version)
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Upgrades"
+	Upgrades ActiveMQArtemisUpgrades `json:"upgrades,omitempty"`
+	// Specifies the address configurations (deprecated in favour of BrokerProperties)
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Address Configurations"
+	AddressSettings AddressSettingsType `json:"addressSettings,omitempty"`
 }
 
 type AddressSettingsType struct {
-	ApplyRule      *string              `json:"applyRule,omitempty"`
+	// How to merge the address settings to broker configuration
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Apply Rule",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	ApplyRule *string `json:"applyRule,omitempty"`
+	// Specifies the address settings
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Address Settings"
 	AddressSetting []AddressSettingType `json:"addressSetting,omitempty"`
 }
 
 type AddressSettingType struct {
-	DeadLetterAddress             *string `json:"deadLetterAddress,omitempty"`
-	AutoCreateDeadLetterResources *bool   `json:"autoCreateDeadLetterResources,omitempty"`
-	DeadLetterQueuePrefix         *string `json:"deadLetterQueuePrefix,omitempty"`
-	DeadLetterQueueSuffix         *string `json:"deadLetterQueueSuffix,omitempty"`
-	ExpiryAddress                 *string `json:"expiryAddress,omitempty"`
-	AutoCreateExpiryResources     *bool   `json:"autoCreateExpiryResources,omitempty"`
-	ExpiryQueuePrefix             *string `json:"expiryQueuePrefix,omitempty"`
-	ExpiryQueueSuffix             *string `json:"expiryQueueSuffix,omitempty"`
-	ExpiryDelay                   *int32  `json:"expiryDelay,omitempty"`
-	MinExpiryDelay                *int32  `json:"minExpiryDelay,omitempty"`
-	MaxExpiryDelay                *int32  `json:"maxExpiryDelay,omitempty"`
-	RedeliveryDelay               *int32  `json:"redeliveryDelay,omitempty"`
-	RedeliveryDelayMultiplier     *int32  `json:"redeliveryDelayMultiplier,omitempty"`
+	// the address to send dead messages to
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Dead Letter Address",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	DeadLetterAddress *string `json:"deadLetterAddress,omitempty"`
+	// whether or not to automatically create the dead-letter-address and/or a corresponding queue on that address when a message found to be undeliverable
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="AutoCreateDeadLetterResources",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	AutoCreateDeadLetterResources *bool `json:"autoCreateDeadLetterResources,omitempty"`
+	// the prefix to use for auto-created dead letter queues
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Dead Letter Queue Prefix",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	DeadLetterQueuePrefix *string `json:"deadLetterQueuePrefix,omitempty"`
+	// the suffix to use for auto-created dead letter queues
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Dead Letter Queue Suffix",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	DeadLetterQueueSuffix *string `json:"deadLetterQueueSuffix,omitempty"`
+	// the address to send expired messages to
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Expiry Address",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	ExpiryAddress *string `json:"expiryAddress,omitempty"`
+	// whether or not to automatically create the expiry-address and/or a corresponding queue on that address when a message is sent to a matching queue
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Auto Create Expiry Resources",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	AutoCreateExpiryResources *bool `json:"autoCreateExpiryResources,omitempty"`
+	// the prefix to use for auto-created expiry queues
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Expiry Queue Prefix",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	ExpiryQueuePrefix *string `json:"expiryQueuePrefix,omitempty"`
+	// the suffix to use for auto-created expiry queues
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Expiry Queue Suffix",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	ExpiryQueueSuffix *string `json:"expiryQueueSuffix,omitempty"`
+	// Overrides the expiration time for messages using the default value for expiration time. "-1" disables this setting.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Expiry Delay",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	ExpiryDelay *int32 `json:"expiryDelay,omitempty"`
+	// Overrides the expiration time for messages using a lower value. "-1" disables this setting.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Min Expiry Delay",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	MinExpiryDelay *int32 `json:"minExpiryDelay,omitempty"`
+	// Overrides the expiration time for messages using a higher value. "-1" disables this setting.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Max Expiry Delay",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	MaxExpiryDelay *int32 `json:"maxExpiryDelay,omitempty"`
+	// the time (in ms) to wait before redelivering a cancelled message.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Redelivery Delay",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	RedeliveryDelay *int32 `json:"redeliveryDelay,omitempty"`
+
+	RedeliveryDelayMultiplier *int32 `json:"redeliveryDelayMultiplier,omitempty"`
 	//
 	RedeliveryCollisionAvoidanceFactor *float32 `json:"redeliveryCollisionAvoidanceFactor,omitempty"` // controller-gen requires crd:allowDangerousTypes=true to allow support float types
 	//
-	MaxRedeliveryDelay                 *int32  `json:"maxRedeliveryDelay,omitempty"`
-	MaxDeliveryAttempts                *int32  `json:"maxDeliveryAttempts,omitempty"`
-	MaxSizeBytes                       *string `json:"maxSizeBytes,omitempty"`
-	MaxSizeBytesRejectThreshold        *int32  `json:"maxSizeBytesRejectThreshold,omitempty"`
-	PageSizeBytes                      *string `json:"pageSizeBytes,omitempty"`
-	PageMaxCacheSize                   *int32  `json:"pageMaxCacheSize,omitempty"`
-	AddressFullPolicy                  *string `json:"addressFullPolicy,omitempty"`
-	MessageCounterHistoryDayLimit      *int32  `json:"messageCounterHistoryDayLimit,omitempty"`
-	LastValueQueue                     *bool   `json:"lastValueQueue,omitempty"`
-	DefaultLastValueQueue              *bool   `json:"defaultLastValueQueue,omitempty"`
-	DefaultLastValueKey                *string `json:"defaultLastValueKey,omitempty"`
-	DefaultNonDestructive              *bool   `json:"defaultNonDestructive,omitempty"`
-	DefaultExclusiveQueue              *bool   `json:"defaultExclusiveQueue,omitempty"`
-	DefaultGroupRebalance              *bool   `json:"defaultGroupRebalance,omitempty"`
-	DefaultGroupRebalancePauseDispatch *bool   `json:"defaultGroupRebalancePauseDispatch,omitempty"`
-	DefaultGroupBuckets                *int32  `json:"defaultGroupBuckets,omitempty"`
-	DefaultGroupFirstKey               *string `json:"defaultGroupFirstKey,omitempty"`
-	DefaultConsumersBeforeDispatch     *int32  `json:"defaultConsumersBeforeDispatch,omitempty"`
-	DefaultDelayBeforeDispatch         *int32  `json:"defaultDelayBeforeDispatch,omitempty"`
-	RedistributionDelay                *int32  `json:"redistributionDelay,omitempty"`
-	SendToDlaOnNoRoute                 *bool   `json:"sendToDlaOnNoRoute,omitempty"`
-	SlowConsumerThreshold              *int32  `json:"slowConsumerThreshold,omitempty"`
-	SlowConsumerPolicy                 *string `json:"slowConsumerPolicy,omitempty"`
-	SlowConsumerCheckPeriod            *int32  `json:"slowConsumerCheckPeriod,omitempty"`
-	AutoCreateJmsQueues                *bool   `json:"autoCreateJmsQueues,omitempty"`
-	AutoDeleteJmsQueues                *bool   `json:"autoDeleteJmsQueues,omitempty"`
-	AutoCreateJmsTopics                *bool   `json:"autoCreateJmsTopics,omitempty"`
-	AutoDeleteJmsTopics                *bool   `json:"autoDeleteJmsTopics,omitempty"`
-	AutoCreateQueues                   *bool   `json:"autoCreateQueues,omitempty"`
-	AutoDeleteQueues                   *bool   `json:"autoDeleteQueues,omitempty"`
-	AutoDeleteCreatedQueues            *bool   `json:"autoDeleteCreatedQueues,omitempty"`
-	AutoDeleteQueuesDelay              *int32  `json:"autoDeleteQueuesDelay,omitempty"`
-	AutoDeleteQueuesMessageCount       *int32  `json:"autoDeleteQueuesMessageCount,omitempty"`
-	ConfigDeleteQueues                 *string `json:"configDeleteQueues,omitempty"`
-	AutoCreateAddresses                *bool   `json:"autoCreateAddresses,omitempty"`
-	AutoDeleteAddresses                *bool   `json:"autoDeleteAddresses,omitempty"`
-	AutoDeleteAddressesDelay           *int32  `json:"autoDeleteAddressesDelay,omitempty"`
-	ConfigDeleteAddresses              *string `json:"configDeleteAddresses,omitempty"`
-	ManagementBrowsePageSize           *int32  `json:"managementBrowsePageSize,omitempty"`
-	DefaultPurgeOnNoConsumers          *bool   `json:"defaultPurgeOnNoConsumers,omitempty"`
-	DefaultMaxConsumers                *int32  `json:"defaultMaxConsumers,omitempty"`
-	DefaultQueueRoutingType            *string `json:"defaultQueueRoutingType,omitempty"`
-	DefaultAddressRoutingType          *string `json:"defaultAddressRoutingType,omitempty"`
-	DefaultConsumerWindowSize          *int32  `json:"defaultConsumerWindowSize,omitempty"`
-	DefaultRingSize                    *int32  `json:"defaultRingSize,omitempty"`
-	RetroactiveMessageCount            *int32  `json:"retroactiveMessageCount,omitempty"`
-	EnableMetrics                      *bool   `json:"enableMetrics,omitempty"`
-	Match                              string  `json:"match,omitempty"`
+
+	// Maximum value for the redelivery-delay
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Max Redelivery Delay",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	MaxRedeliveryDelay *int32 `json:"maxRedeliveryDelay,omitempty"`
+	// how many times to attempt to deliver a message before sending to dead letter address
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Max Delivery Attempts",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	MaxDeliveryAttempts *int32 `json:"maxDeliveryAttempts,omitempty"`
+	// the maximum size in bytes for an address. -1 means no limits. This is used in PAGING, BLOCK and FAIL policies. Supports byte notation like K, Mb, GB, etc.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Max Size Bytes",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	MaxSizeBytes *string `json:"maxSizeBytes,omitempty"`
+	// used with the address full BLOCK policy, the maximum size in bytes an address can reach before messages start getting rejected. Works in combination with max-size-bytes for AMQP protocol only.  Default = -1 (no limit).
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Max Size Bytes Reject Threshold",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	MaxSizeBytesRejectThreshold *int32 `json:"maxSizeBytesRejectThreshold,omitempty"`
+	// The page size in bytes to use for an address. Supports byte notation like K, Mb, GB, etc.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Page Size Bytes",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	PageSizeBytes *string `json:"pageSizeBytes,omitempty"`
+	// Number of paging files to cache in memory to avoid IO during paging navigation
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Page Max Cache Size",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	PageMaxCacheSize *int32 `json:"pageMaxCacheSize,omitempty"`
+	// what happens when an address where maxSizeBytes is specified becomes full
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Address Full Policy",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	AddressFullPolicy *string `json:"addressFullPolicy,omitempty"`
+	// how many days to keep message counter history for this address
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Message Counter History Day Limit",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	MessageCounterHistoryDayLimit *int32 `json:"messageCounterHistoryDayLimit,omitempty"`
+	// This is deprecated please use default-last-value-queue instead.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Last Value Queue",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	LastValueQueue *bool `json:"lastValueQueue,omitempty"`
+	// whether to treat the queues under the address as a last value queues by default
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Default Last Value Queue",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	DefaultLastValueQueue *bool `json:"defaultLastValueQueue,omitempty"`
+	// the property to use as the key for a last value queue by default
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Default Last Value Key",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	DefaultLastValueKey *string `json:"defaultLastValueKey,omitempty"`
+	// whether the queue should be non-destructive by default
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Default Non Destructive",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	DefaultNonDestructive *bool `json:"defaultNonDestructive,omitempty"`
+	// whether to treat the queues under the address as exclusive queues by default
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Default Exclusive Queue",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	DefaultExclusiveQueue *bool `json:"defaultExclusiveQueue,omitempty"`
+	// whether to rebalance groups when a consumer is added
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Default Group Rebalance",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	DefaultGroupRebalance *bool `json:"defaultGroupRebalance,omitempty"`
+	// whether to pause dispatch when rebalancing groups
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Default Group Rebalance Pause Dispatch",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	DefaultGroupRebalancePauseDispatch *bool `json:"defaultGroupRebalancePauseDispatch,omitempty"`
+	// number of buckets to use for grouping, -1 (default) is unlimited and uses the raw group, 0 disables message groups.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Default Group Buckets",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	DefaultGroupBuckets *int32 `json:"defaultGroupBuckets,omitempty"`
+	// key used to mark a message is first in a group for a consumer
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Default Group First Key",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	DefaultGroupFirstKey *string `json:"defaultGroupFirstKey,omitempty"`
+	// the default number of consumers needed before dispatch can start for queues under the address.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Default Consumers Before Dispatch",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	DefaultConsumersBeforeDispatch *int32 `json:"defaultConsumersBeforeDispatch,omitempty"`
+	// the default delay (in milliseconds) to wait before dispatching if number of consumers before dispatch is not met for queues under the address.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Default Delay Before Dispatch",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	DefaultDelayBeforeDispatch *int32 `json:"defaultDelayBeforeDispatch,omitempty"`
+	// how long (in ms) to wait after the last consumer is closed on a queue before redistributing messages.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Redistribution Delay",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	RedistributionDelay *int32 `json:"redistributionDelay,omitempty"`
+	// if there are no queues matching this address, whether to forward message to DLA (if it exists for this address)
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Send To DLA On No Route",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	SendToDlaOnNoRoute *bool `json:"sendToDlaOnNoRoute,omitempty"`
+	// The minimum rate of message consumption allowed before a consumer is considered "slow." Measured in messages-per-second.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Slow Consumer Threshold",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	SlowConsumerThreshold *int32 `json:"slowConsumerThreshold,omitempty"`
+	// what happens when a slow consumer is identified
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Slow Consumer Policy",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	SlowConsumerPolicy *string `json:"slowConsumerPolicy,omitempty"`
+	// How often to check for slow consumers on a particular queue. Measured in seconds.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Slow Consumer Check Period",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	SlowConsumerCheckPeriod *int32 `json:"slowConsumerCheckPeriod,omitempty"`
+	// DEPRECATED. whether or not to automatically create JMS queues when a producer sends or a consumer connects to a queue
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Auto Create Jms Queues",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	AutoCreateJmsQueues *bool `json:"autoCreateJmsQueues,omitempty"`
+	// DEPRECATED. whether or not to delete auto-created JMS queues when the queue has 0 consumers and 0 messages
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Auto Delete Jms Queues",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	AutoDeleteJmsQueues *bool `json:"autoDeleteJmsQueues,omitempty"`
+	// DEPRECATED. whether or not to automatically create JMS topics when a producer sends or a consumer subscribes to a topic
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Auto Create Jms Topics",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	AutoCreateJmsTopics *bool `json:"autoCreateJmsTopics,omitempty"`
+	// DEPRECATED. whether or not to delete auto-created JMS topics when the last subscription is closed
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Auto Delete Jms Topics",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	AutoDeleteJmsTopics *bool `json:"autoDeleteJmsTopics,omitempty"`
+	// whether or not to automatically create a queue when a client sends a message to or attempts to consume a message from a queue
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Auto Create Queues",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	AutoCreateQueues *bool `json:"autoCreateQueues,omitempty"`
+	// whether or not to delete auto-created queues when the queue has 0 consumers and 0 messages
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Auto Delete Queues",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	AutoDeleteQueues *bool `json:"autoDeleteQueues,omitempty"`
+	// whether or not to delete created queues when the queue has 0 consumers and 0 messages
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Auto Delete Created Queues",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	AutoDeleteCreatedQueues *bool `json:"autoDeleteCreatedQueues,omitempty"`
+	// how long to wait (in milliseconds) before deleting auto-created queues after the queue has 0 consumers.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Auto Delete Queues Delay",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	AutoDeleteQueuesDelay *int32 `json:"autoDeleteQueuesDelay,omitempty"`
+	// the message count the queue must be at or below before it can be evaluated to be auto deleted, 0 waits until empty queue (default) and -1 disables this check.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Auto Delete Queues Message Count",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	AutoDeleteQueuesMessageCount *int32 `json:"autoDeleteQueuesMessageCount,omitempty"`
+	//What to do when a queue is no longer in broker.xml.  OFF = will do nothing queues will remain, FORCE = delete queues even if messages remaining.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Config Delete Queues",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	ConfigDeleteQueues *string `json:"configDeleteQueues,omitempty"`
+	// whether or not to automatically create addresses when a client sends a message to or attempts to consume a message from a queue mapped to an address that doesnt exist
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Auto Create Addresses",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	AutoCreateAddresses *bool `json:"autoCreateAddresses,omitempty"`
+	// whether or not to delete auto-created addresses when it no longer has any queues
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Auto Delete Addresses",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	AutoDeleteAddresses *bool `json:"autoDeleteAddresses,omitempty"`
+	// how long to wait (in milliseconds) before deleting auto-created addresses after they no longer have any queues
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Auto Delete Addresses Delay",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	AutoDeleteAddressesDelay *int32 `json:"autoDeleteAddressesDelay,omitempty"`
+	// What to do when an address is no longer in broker.xml.  OFF = will do nothing addresses will remain, FORCE = delete address and its queues even if messages remaining.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Config Delete Addresses",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	ConfigDeleteAddresses *string `json:"configDeleteAddresses,omitempty"`
+	// how many message a management resource can browse
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Management Browse Page Size",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	ManagementBrowsePageSize *int32 `json:"managementBrowsePageSize,omitempty"`
+	// purge the contents of the queue once there are no consumers
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Default Purge On No Consumers",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	DefaultPurgeOnNoConsumers *bool `json:"defaultPurgeOnNoConsumers,omitempty"`
+	// the maximum number of consumers allowed on this queue at any one time
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Default Max Consumers",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	DefaultMaxConsumers *int32 `json:"defaultMaxConsumers,omitempty"`
+	// the routing-type used on auto-created queues
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Default Queue Routing Type",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	DefaultQueueRoutingType *string `json:"defaultQueueRoutingType,omitempty"`
+	// the routing-type used on auto-created addresses
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Default Address Routing Type",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	DefaultAddressRoutingType *string `json:"defaultAddressRoutingType,omitempty"`
+	// the default window size for a consumer
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Default Consumer Window Size",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	DefaultConsumerWindowSize *int32 `json:"defaultConsumerWindowSize,omitempty"`
+	// the default ring-size value for any matching queue which doesnt have ring-size explicitly defined
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Default Ring Size",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	DefaultRingSize *int32 `json:"defaultRingSize,omitempty"`
+	// the number of messages to preserve for future queues created on the matching address
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Retroactive Message Count",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	RetroactiveMessageCount *int32 `json:"retroactiveMessageCount,omitempty"`
+	// whether or not to enable metrics for metrics plugins on the matching address
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Enable Metrics",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	EnableMetrics *bool `json:"enableMetrics,omitempty"`
+	// pattern for matching settings against addresses; can use wildards
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Match",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	Match string `json:"match,omitempty"`
 }
 
 type DeploymentPlanType struct {
-	Image              string                      `json:"image,omitempty"`
-	Size               int32                       `json:"size,omitempty"`
-	RequireLogin       bool                        `json:"requireLogin,omitempty"`
-	PersistenceEnabled bool                        `json:"persistenceEnabled,omitempty"`
-	JournalType        string                      `json:"journalType,omitempty"`
-	MessageMigration   *bool                       `json:"messageMigration,omitempty"`
-	Resources          corev1.ResourceRequirements `json:"resources,omitempty"`
-	Storage            StorageType                 `json:"storage,omitempty"`
+	//The image used for the broker, all upgrades are disabled. Needs a corresponding initImage
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Image",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	Image string `json:"image,omitempty"`
+	// The number of broker pods to deploy
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Size",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:podCount"}
+	Size int32 `json:"size,omitempty"`
+	// If true require user password login credentials for broker protocol ports
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Require Login",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	RequireLogin bool `json:"requireLogin,omitempty"`
+	// If true use persistent volume via persistent volume claim for journal storage
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Persistence Enabled",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	PersistenceEnabled bool `json:"persistenceEnabled,omitempty"`
+	// If aio use ASYNCIO, if nio use NIO for journal IO
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Journal Type",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	JournalType string `json:"journalType,omitempty"`
+	//If true migrate messages on scaledown
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Message Migration",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	MessageMigration *bool `json:"messageMigration,omitempty"`
+	// Specifies the minimum/maximum amount of compute resources required/allowed
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Resource Requirements",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:resourceRequirements"}
+	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
+	// Specifies the storage configurations
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Storage Configurations"
+	Storage StorageType `json:"storage,omitempty"`
 }
 
 type StorageType struct {
+	// The storage size
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Size",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	Size string `json:"size,omitempty"`
 }
 
 type AcceptorType struct {
-	Name                    string `json:"name"`
-	Port                    int32  `json:"port,omitempty"`
-	Protocols               string `json:"protocols,omitempty"`
-	SSLEnabled              bool   `json:"sslEnabled,omitempty"`
-	SSLSecret               string `json:"sslSecret,omitempty"`
-	EnabledCipherSuites     string `json:"enabledCipherSuites,omitempty"`
-	EnabledProtocols        string `json:"enabledProtocols,omitempty"`
-	NeedClientAuth          bool   `json:"needClientAuth,omitempty"`
-	WantClientAuth          bool   `json:"wantClientAuth,omitempty"`
-	VerifyHost              bool   `json:"verifyHost,omitempty"`
-	SSLProvider             string `json:"sslProvider,omitempty"`
-	SNIHost                 string `json:"sniHost,omitempty"`
-	Expose                  bool   `json:"expose,omitempty"`
-	AnycastPrefix           string `json:"anycastPrefix,omitempty"`
-	MulticastPrefix         string `json:"multicastPrefix,omitempty"`
-	ConnectionsAllowed      int    `json:"connectionsAllowed,omitempty"`
-	AMQPMinLargeMessageSize int    `json:"amqpMinLargeMessageSize,omitempty"`
+	// The acceptor name
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Name",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	Name string `json:"name"`
+	// Port number
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Port",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	Port int32 `json:"port,omitempty"`
+	// The protocols to enable for this acceptor
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Protocols",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	Protocols string `json:"protocols,omitempty"`
+	// Whether or not to enable SSL on this port
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="SSL Enabled",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	SSLEnabled bool `json:"sslEnabled,omitempty"`
+	// Name of the secret to use for ssl information
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="SSL Secret",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	SSLSecret string `json:"sslSecret,omitempty"`
+	// Comma separated list of cipher suites used for SSL communication.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Enabled Cipher Suites",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	EnabledCipherSuites string `json:"enabledCipherSuites,omitempty"`
+	// Comma separated list of protocols used for SSL communication.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Enabled Protocols",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	EnabledProtocols string `json:"enabledProtocols,omitempty"`
+	// Tells a client connecting to this acceptor that 2-way SSL is required. This property takes precedence over wantClientAuth.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Need Client Auth",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	NeedClientAuth bool `json:"needClientAuth,omitempty"`
+	// Tells a client connecting to this acceptor that 2-way SSL is requested but not required. Overridden by needClientAuth.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Want Client Auth",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	WantClientAuth bool `json:"wantClientAuth,omitempty"`
+	// The CN of the connecting client's SSL certificate will be compared to its hostname to verify they match. This is useful only for 2-way SSL.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Verify Host",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	VerifyHost bool `json:"verifyHost,omitempty"`
+	// Used to change the SSL Provider between JDK and OPENSSL. The default is JDK.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="SSL Provider",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	SSLProvider string `json:"sslProvider,omitempty"`
+	// A regular expression used to match the server_name extension on incoming SSL connections. If the name doesn't match then the connection to the acceptor will be rejected.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="SNI Host",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	SNIHost string `json:"sniHost,omitempty"`
+	// Whether or not to expose this acceptor
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Expose",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	Expose bool `json:"expose,omitempty"`
+	// To indicate which kind of routing type to use.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Anycast Prefix",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	AnycastPrefix string `json:"anycastPrefix,omitempty"`
+	// To indicate which kind of routing type to use
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Multicast Prefix",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	MulticastPrefix string `json:"multicastPrefix,omitempty"`
+	// Max number of connections allowed to make
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Connections Allowed",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	ConnectionsAllowed int `json:"connectionsAllowed,omitempty"`
+	// AMQP Minimum Large Message Size
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="AMQP Min Large Message Size",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	AMQPMinLargeMessageSize int `json:"amqpMinLargeMessageSize,omitempty"`
 }
 
 type ConnectorType struct {
-	Name                string `json:"name"`
-	Type                string `json:"type,omitempty"`
-	Host                string `json:"host"`
-	Port                int32  `json:"port"`
-	SSLEnabled          bool   `json:"sslEnabled,omitempty"`
-	SSLSecret           string `json:"sslSecret,omitempty"`
+	// The name of the connector
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Name",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	Name string `json:"name"`
+	// The type either tcp or vm
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Type",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	Type string `json:"type,omitempty"`
+	// Hostname or IP to connect to
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Host",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	Host string `json:"host"`
+	// Port number
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Port",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	Port int32 `json:"port"`
+	//  Whether or not to enable SSL on this port
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="SSL Enabled",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	SSLEnabled bool `json:"sslEnabled,omitempty"`
+	// Name of the secret to use for ssl information
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="SSL Secret",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	SSLSecret string `json:"sslSecret,omitempty"`
+	// Comma separated list of cipher suites used for SSL communication.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Enabled Cipher Suites",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	EnabledCipherSuites string `json:"enabledCipherSuites,omitempty"`
-	EnabledProtocols    string `json:"enabledProtocols,omitempty"`
-	NeedClientAuth      bool   `json:"needClientAuth,omitempty"`
-	WantClientAuth      bool   `json:"wantClientAuth,omitempty"`
-	VerifyHost          bool   `json:"verifyHost,omitempty"`
-	SSLProvider         string `json:"sslProvider,omitempty"`
-	SNIHost             string `json:"sniHost,omitempty"`
-	Expose              bool   `json:"expose,omitempty"`
+	// Comma separated list of protocols used for SSL communication.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Enabled Protocols",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	EnabledProtocols string `json:"enabledProtocols,omitempty"`
+	// Tells a client connecting to this connector that 2-way SSL is required. This property takes precedence over wantClientAuth.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Need Client Auth",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	NeedClientAuth bool `json:"needClientAuth,omitempty"`
+	// Tells a client connecting to this connector that 2-way SSL is requested but not required. Overridden by needClientAuth.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Want Client Auth",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	WantClientAuth bool `json:"wantClientAuth,omitempty"`
+	// The CN of the connecting client's SSL certificate will be compared to its hostname to verify they match. This is useful only for 2-way SSL.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Verify Host",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	VerifyHost bool `json:"verifyHost,omitempty"`
+	// Used to change the SSL Provider between JDK and OPENSSL. The default is JDK.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="SSL Provider",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	SSLProvider string `json:"sslProvider,omitempty"`
+	// A regular expression used to match the server_name extension on incoming SSL connections. If the name doesn't match then the connection to the acceptor will be rejected.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="SNI Host",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	SNIHost string `json:"sniHost,omitempty"`
+	// Whether or not to expose this connector
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Expose",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	Expose bool `json:"expose,omitempty"`
 }
 
 type ConsoleType struct {
-	Expose        bool   `json:"expose,omitempty"`
-	SSLEnabled    bool   `json:"sslEnabled,omitempty"`
-	SSLSecret     string `json:"sslSecret,omitempty"`
-	UseClientAuth bool   `json:"useClientAuth,omitempty"`
+	// Whether or not to expose this port
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Expose",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	Expose bool `json:"expose,omitempty"`
+	// Whether or not to enable SSL on this port
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="SSL Enabled",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	SSLEnabled bool `json:"sslEnabled,omitempty"`
+	// Name of the secret to use for ssl information
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="SSL Secret",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	SSLSecret string `json:"sslSecret,omitempty"`
+	// If the embedded server requires client authentication
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Use Client Auth",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	UseClientAuth bool `json:"useClientAuth,omitempty"`
 }
 
 // ActiveMQArtemis App product upgrade flags
 type ActiveMQArtemisUpgrades struct {
+	// Set true to enable automatic micro version product upgrades, it is disabled by default.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Enable Upgrades",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:ui:booleanSwitch"}
 	Enabled bool `json:"enabled"`
-	Minor   bool `json:"minor"`
+	// Set true to enable automatic minor product version upgrades, it is disabled by default. Requires spec.upgrades.enabled to be true.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Include minor version upgrades",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldDependency:upgrades.enabled:true","urn:alm:descriptor:com.tectonic.ui:ui:booleanSwitch"}
+	Minor bool `json:"minor"`
 }
 
 // ActiveMQArtemisStatus defines the observed state of ActiveMQArtemis
@@ -183,6 +419,8 @@ type ActiveMQArtemisStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
+	// The current pods
+	//+operator-sdk:csv:customresourcedefinitions:type=status,displayName="Pods Status",xDescriptors="urn:alm:descriptor:com.tectonic.ui:podStatuses"
 	PodStatus olm.DeploymentStatus `json:"podStatus"`
 
 	// Current state of the resource
@@ -200,7 +438,8 @@ type ActiveMQArtemisStatus struct {
 //+kubebuilder:resource:path=activemqartemises,shortName=aa
 //+operator-sdk:csv:customresourcedefinitions:resources={{"Secret", "v1"}}
 
-// ActiveMQArtemis is the Schema for the activemqartemises API
+// A stateful deployment of one or more brokers
+// +operator-sdk:csv:customresourcedefinitions:displayName="ActiveMQ Artemis"
 type ActiveMQArtemis struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v2alpha3/activemqartemisaddress_types.go
+++ b/api/v2alpha3/activemqartemisaddress_types.go
@@ -28,43 +28,111 @@ type ActiveMQArtemisAddressSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
-	AddressName              string                  `json:"addressName,omitempty"`
-	QueueName                *string                 `json:"queueName,omitempty"`
-	RoutingType              *string                 `json:"routingType,omitempty"`
-	RemoveFromBrokerOnDelete bool                    `json:"removeFromBrokerOnDelete,omitempty"`
-	User                     *string                 `json:"user,omitempty"`
-	Password                 *string                 `json:"password,omitempty"`
-	QueueConfiguration       *QueueConfigurationType `json:"queueConfiguration,omitempty"`
-	ApplyToCrNames           []string                `json:"applyToCrNames,omitempty"`
+	// The Address Name
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Address Name",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	AddressName string `json:"addressName,omitempty"`
+	// The Queue Name
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Queue Name",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	QueueName *string `json:"queueName,omitempty"`
+	// The Routing Type
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Routing Type",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	RoutingType *string `json:"routingType,omitempty"`
+	// Whether or not delete the queue from broker when CR is undeployed(default false)
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Remove From Broker On Delete",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	RemoveFromBrokerOnDelete bool `json:"removeFromBrokerOnDelete,omitempty"`
+	// User name for creating the queue or address
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="User",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	User *string `json:"user,omitempty"`
+	// The password for the user
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Password",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:password"}
+	Password *string `json:"password,omitempty"`
+	// Specify the queue configuration
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Queue Configuration"
+	QueueConfiguration *QueueConfigurationType `json:"queueConfiguration,omitempty"`
+	// Apply to the broker crs in the current namespace. A value of * or empty string means applying to all broker crs. Default apply to all broker crs
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Apply To Broker CR Names"
+	ApplyToCrNames []string `json:"applyToCrNames,omitempty"`
 }
 
 type QueueConfigurationType struct {
-	IgnoreIfExists              *bool   `json:"ignoreIfExists,omitempty"`
-	RoutingType                 *string `json:"routingType,omitempty"`
-	FilterString                *string `json:"filterString,omitempty"`
-	Durable                     *bool   `json:"durable,omitempty"`
-	User                        *string `json:"user,omitempty"`
-	MaxConsumers                *int32  `json:"maxConsumers,omitempty"`
-	Exclusive                   *bool   `json:"exclusive,omitempty"`
-	GroupRebalance              *bool   `json:"groupRebalance,omitempty"`
-	GroupRebalancePauseDispatch *bool   `json:"groupRebalancePauseDispatch,omitempty"`
-	GroupBuckets                *int32  `json:"groupBuckets,omitempty"`
-	GroupFirstKey               *string `json:"groupFirstKey,omitempty"`
-	LastValue                   *bool   `json:"lastValue,omitempty"`
-	LastValueKey                *string `json:"lastValueKey,omitempty"`
-	NonDestructive              *bool   `json:"nonDestructive,omitempty"`
-	PurgeOnNoConsumers          *bool   `json:"purgeOnNoConsumers,omitempty"`
-	Enabled                     *bool   `json:"enabled,omitempty"`
-	ConsumersBeforeDispatch     *int32  `json:"consumersBeforeDispatch,omitempty"`
-	DelayBeforeDispatch         *int64  `json:"delayBeforeDispatch,omitempty"`
-	ConsumerPriority            *int32  `json:"consumerPriority,omitempty"`
-	AutoDelete                  *bool   `json:"autoDelete,omitempty"`
-	AutoDeleteDelay             *int64  `json:"autoDeleteDelay,omitempty"`
-	AutoDeleteMessageCount      *int64  `json:"autoDeleteMessageCount,omitempty"`
-	RingSize                    *int64  `json:"ringSize,omitempty"`
-	ConfigurationManaged        *bool   `json:"configurationManaged,omitempty"`
-	Temporary                   *bool   `json:"temporary,omitempty"`
-	AutoCreateAddress           *bool   `json:"autoCreateAddress,omitempty"`
+	// If ignore if the target queue already exists
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Ignore If Exists",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	IgnoreIfExists *bool `json:"ignoreIfExists,omitempty"`
+	// The routing type of the queue
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Routing Type",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	RoutingType *string `json:"routingType,omitempty"`
+	// The filter string for the queue
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Filter String",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	FilterString *string `json:"filterString,omitempty"`
+	// If the queue is durable or not
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Durable",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	Durable *bool `json:"durable,omitempty"`
+	// The user associated with the queue
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="User",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	User *string `json:"user,omitempty"`
+	// Max number of consumers allowed on this queue
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Max Consumers",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	MaxConsumers *int32 `json:"maxConsumers,omitempty"`
+	// If the queue is exclusive
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Exclusive",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	Exclusive *bool `json:"exclusive,omitempty"`
+	// If rebalance the message group
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Group Rebalance",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	GroupRebalance *bool `json:"groupRebalance,omitempty"`
+	// If pause message dispatch when rebalancing groups
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Group Rebalance Pause Dispatch",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	GroupRebalancePauseDispatch *bool `json:"groupRebalancePauseDispatch,omitempty"`
+	// Number of messaging group buckets
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Group Buckets",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	GroupBuckets *int32 `json:"groupBuckets,omitempty"`
+	// Header set on the first group message
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Group First Key",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	GroupFirstKey *string `json:"groupFirstKey,omitempty"`
+	// If it is a last value queue
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Last Value",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	LastValue *bool `json:"lastValue,omitempty"`
+	// The property used for last value queue to identify last values
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Last Value Key",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	LastValueKey *string `json:"lastValueKey,omitempty"`
+	// If force non-destructive consumers on the queue
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Non Destructive",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	NonDestructive *bool `json:"nonDestructive,omitempty"`
+	// Whether to delete all messages when no consumers connected to the queue
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Purge On No Consumers",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	PurgeOnNoConsumers *bool `json:"purgeOnNoConsumers,omitempty"`
+	// If the queue is enabled
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Enabled",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	Enabled *bool `json:"enabled,omitempty"`
+	// Number of consumers required before dispatching messages
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Consumers Before Dispatch",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	ConsumersBeforeDispatch *int32 `json:"consumersBeforeDispatch,omitempty"`
+	// Milliseconds to wait for `consumers-before-dispatch` to be met before dispatching messages anyway
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Delay Before Dispatch",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	DelayBeforeDispatch *int64 `json:"delayBeforeDispatch,omitempty"`
+	// Consumer Priority
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Consumer Priority",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	ConsumerPriority *int32 `json:"consumerPriority,omitempty"`
+	// Auto-delete the queue
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Auto Delete",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	AutoDelete *bool `json:"autoDelete,omitempty"`
+	// Delay (Milliseconds) before auto-delete the queue
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Auto Delete Delay",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	AutoDeleteDelay *int64 `json:"autoDeleteDelay,omitempty"`
+	// Message count of the queue to allow auto delete
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Auto Delete Message Count",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	AutoDeleteMessageCount *int64 `json:"autoDeleteMessageCount,omitempty"`
+	// The size the queue should maintain according to ring semantics
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Ring Size",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	RingSize *int64 `json:"ringSize,omitempty"`
+	//  If the queue is configuration managed
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Configuration Managed",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	ConfigurationManaged *bool `json:"configurationManaged,omitempty"`
+	// If the queue is temporary
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Temporary",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	Temporary *bool `json:"temporary,omitempty"`
+	// Whether auto create address
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Auto Create Address",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	AutoCreateAddress *bool `json:"autoCreateAddress,omitempty"`
 }
 
 // ActiveMQArtemisAddressStatus defines the observed state of ActiveMQArtemisAddress
@@ -87,7 +155,8 @@ type ActiveMQArtemisAddressStatus struct {
 //+operator-sdk:csv:customresourcedefinitions:resources={{"Secret", "v1"}}
 
 // +kubebuilder:deprecatedversion:warning="The ActiveMQArtemisAddress CRD is deprecated. Use the spec.brokerProperties attribute in the ActiveMQArtemis CR to create addresses and queues instead"
-// ActiveMQArtemisAddress is the Schema for the activemqartemisaddresses API
+// Adding and removing addresses using custom resource definitions
+// +operator-sdk:csv:customresourcedefinitions:displayName="ActiveMQ Artemis Address"
 type ActiveMQArtemisAddress struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v2alpha4/activemqartemis_types.go
+++ b/api/v2alpha4/activemqartemis_types.go
@@ -30,155 +30,395 @@ type ActiveMQArtemisSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
-	AdminUser       string                  `json:"adminUser,omitempty"`
-	AdminPassword   string                  `json:"adminPassword,omitempty"`
-	DeploymentPlan  DeploymentPlanType      `json:"deploymentPlan,omitempty"`
-	Acceptors       []AcceptorType          `json:"acceptors,omitempty"`
-	Connectors      []ConnectorType         `json:"connectors,omitempty"`
-	Console         ConsoleType             `json:"console,omitempty"`
-	Version         string                  `json:"version,omitempty"`
-	Upgrades        ActiveMQArtemisUpgrades `json:"upgrades,omitempty"`
-	AddressSettings AddressSettingsType     `json:"addressSettings,omitempty"`
+	// User name for standard broker user. It is required for connecting to the broker and the web console. If left empty, it will be generated.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Admin User",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	AdminUser string `json:"adminUser,omitempty"`
+	// Password for standard broker user. It is required for connecting to the broker and the web console. If left empty, it will be generated.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Admin Password",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:password"}
+	AdminPassword string `json:"adminPassword,omitempty"`
+	// Specifies the deployment plan
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Deployment Plan"
+	DeploymentPlan DeploymentPlanType `json:"deploymentPlan,omitempty"`
+	// Specifies the acceptor configuration
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Acceptors"
+	Acceptors []AcceptorType `json:"acceptors,omitempty"`
+	// Specifies connectors and connector configuration
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Connectors"
+	Connectors []ConnectorType `json:"connectors,omitempty"`
+	// Specifies the console configuration
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Console Configurations"
+	Console ConsoleType `json:"console,omitempty"`
+	// The desired version of the broker. Can be x, or x.y or x.y.z to configure upgrades
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Version",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	Version string `json:"version,omitempty"`
+	// Specifies the upgrades (deprecated in favour of Version)
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Upgrades"
+	Upgrades ActiveMQArtemisUpgrades `json:"upgrades,omitempty"`
+	// Specifies the address configurations (deprecated in favour of BrokerProperties)
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Address Configurations"
+	AddressSettings AddressSettingsType `json:"addressSettings,omitempty"`
 }
 
 type AddressSettingsType struct {
-	ApplyRule      *string              `json:"applyRule,omitempty"`
+	// How to merge the address settings to broker configuration
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Apply Rule",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	ApplyRule *string `json:"applyRule,omitempty"`
+	// Specifies the address settings
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Address Settings"
 	AddressSetting []AddressSettingType `json:"addressSetting,omitempty"`
 }
 
 type AddressSettingType struct {
-	DeadLetterAddress             *string `json:"deadLetterAddress,omitempty"`
-	AutoCreateDeadLetterResources *bool   `json:"autoCreateDeadLetterResources,omitempty"`
-	DeadLetterQueuePrefix         *string `json:"deadLetterQueuePrefix,omitempty"`
-	DeadLetterQueueSuffix         *string `json:"deadLetterQueueSuffix,omitempty"`
-	ExpiryAddress                 *string `json:"expiryAddress,omitempty"`
-	AutoCreateExpiryResources     *bool   `json:"autoCreateExpiryResources,omitempty"`
-	ExpiryQueuePrefix             *string `json:"expiryQueuePrefix,omitempty"`
-	ExpiryQueueSuffix             *string `json:"expiryQueueSuffix,omitempty"`
-	ExpiryDelay                   *int32  `json:"expiryDelay,omitempty"`
-	MinExpiryDelay                *int32  `json:"minExpiryDelay,omitempty"`
-	MaxExpiryDelay                *int32  `json:"maxExpiryDelay,omitempty"`
-	RedeliveryDelay               *int32  `json:"redeliveryDelay,omitempty"`
-	RedeliveryDelayMultiplier     *int32  `json:"redeliveryDelayMultiplier,omitempty"`
+	// the address to send dead messages to
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Dead Letter Address",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	DeadLetterAddress *string `json:"deadLetterAddress,omitempty"`
+	// whether or not to automatically create the dead-letter-address and/or a corresponding queue on that address when a message found to be undeliverable
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="AutoCreateDeadLetterResources",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	AutoCreateDeadLetterResources *bool `json:"autoCreateDeadLetterResources,omitempty"`
+	// the prefix to use for auto-created dead letter queues
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Dead Letter Queue Prefix",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	DeadLetterQueuePrefix *string `json:"deadLetterQueuePrefix,omitempty"`
+	// the suffix to use for auto-created dead letter queues
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Dead Letter Queue Suffix",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	DeadLetterQueueSuffix *string `json:"deadLetterQueueSuffix,omitempty"`
+	// the address to send expired messages to
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Expiry Address",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	ExpiryAddress *string `json:"expiryAddress,omitempty"`
+	// whether or not to automatically create the expiry-address and/or a corresponding queue on that address when a message is sent to a matching queue
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Auto Create Expiry Resources",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	AutoCreateExpiryResources *bool `json:"autoCreateExpiryResources,omitempty"`
+	// the prefix to use for auto-created expiry queues
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Expiry Queue Prefix",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	ExpiryQueuePrefix *string `json:"expiryQueuePrefix,omitempty"`
+	// the suffix to use for auto-created expiry queues
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Expiry Queue Suffix",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	ExpiryQueueSuffix *string `json:"expiryQueueSuffix,omitempty"`
+	// Overrides the expiration time for messages using the default value for expiration time. "-1" disables this setting.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Expiry Delay",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	ExpiryDelay *int32 `json:"expiryDelay,omitempty"`
+	// Overrides the expiration time for messages using a lower value. "-1" disables this setting.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Min Expiry Delay",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	MinExpiryDelay *int32 `json:"minExpiryDelay,omitempty"`
+	// Overrides the expiration time for messages using a higher value. "-1" disables this setting.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Max Expiry Delay",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	MaxExpiryDelay *int32 `json:"maxExpiryDelay,omitempty"`
+	// the time (in ms) to wait before redelivering a cancelled message.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Redelivery Delay",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	RedeliveryDelay           *int32 `json:"redeliveryDelay,omitempty"`
+	RedeliveryDelayMultiplier *int32 `json:"redeliveryDelayMultiplier,omitempty"`
 	//
 	RedeliveryCollisionAvoidanceFactor *float32 `json:"redeliveryCollisionAvoidanceFactor,omitempty"` // controller-gen requires crd:allowDangerousTypes=true to allow support float types
 	//
-	MaxRedeliveryDelay                 *int32  `json:"maxRedeliveryDelay,omitempty"`
-	MaxDeliveryAttempts                *int32  `json:"maxDeliveryAttempts,omitempty"`
-	MaxSizeBytes                       *string `json:"maxSizeBytes,omitempty"`
-	MaxSizeBytesRejectThreshold        *int32  `json:"maxSizeBytesRejectThreshold,omitempty"`
-	PageSizeBytes                      *string `json:"pageSizeBytes,omitempty"`
-	PageMaxCacheSize                   *int32  `json:"pageMaxCacheSize,omitempty"`
-	AddressFullPolicy                  *string `json:"addressFullPolicy,omitempty"`
-	MessageCounterHistoryDayLimit      *int32  `json:"messageCounterHistoryDayLimit,omitempty"`
-	LastValueQueue                     *bool   `json:"lastValueQueue,omitempty"`
-	DefaultLastValueQueue              *bool   `json:"defaultLastValueQueue,omitempty"`
-	DefaultLastValueKey                *string `json:"defaultLastValueKey,omitempty"`
-	DefaultNonDestructive              *bool   `json:"defaultNonDestructive,omitempty"`
-	DefaultExclusiveQueue              *bool   `json:"defaultExclusiveQueue,omitempty"`
-	DefaultGroupRebalance              *bool   `json:"defaultGroupRebalance,omitempty"`
-	DefaultGroupRebalancePauseDispatch *bool   `json:"defaultGroupRebalancePauseDispatch,omitempty"`
-	DefaultGroupBuckets                *int32  `json:"defaultGroupBuckets,omitempty"`
-	DefaultGroupFirstKey               *string `json:"defaultGroupFirstKey,omitempty"`
-	DefaultConsumersBeforeDispatch     *int32  `json:"defaultConsumersBeforeDispatch,omitempty"`
-	DefaultDelayBeforeDispatch         *int32  `json:"defaultDelayBeforeDispatch,omitempty"`
-	RedistributionDelay                *int32  `json:"redistributionDelay,omitempty"`
-	SendToDlaOnNoRoute                 *bool   `json:"sendToDlaOnNoRoute,omitempty"`
-	SlowConsumerThreshold              *int32  `json:"slowConsumerThreshold,omitempty"`
-	SlowConsumerPolicy                 *string `json:"slowConsumerPolicy,omitempty"`
-	SlowConsumerCheckPeriod            *int32  `json:"slowConsumerCheckPeriod,omitempty"`
-	AutoCreateJmsQueues                *bool   `json:"autoCreateJmsQueues,omitempty"`
-	AutoDeleteJmsQueues                *bool   `json:"autoDeleteJmsQueues,omitempty"`
-	AutoCreateJmsTopics                *bool   `json:"autoCreateJmsTopics,omitempty"`
-	AutoDeleteJmsTopics                *bool   `json:"autoDeleteJmsTopics,omitempty"`
-	AutoCreateQueues                   *bool   `json:"autoCreateQueues,omitempty"`
-	AutoDeleteQueues                   *bool   `json:"autoDeleteQueues,omitempty"`
-	AutoDeleteCreatedQueues            *bool   `json:"autoDeleteCreatedQueues,omitempty"`
-	AutoDeleteQueuesDelay              *int32  `json:"autoDeleteQueuesDelay,omitempty"`
-	AutoDeleteQueuesMessageCount       *int32  `json:"autoDeleteQueuesMessageCount,omitempty"`
-	ConfigDeleteQueues                 *string `json:"configDeleteQueues,omitempty"`
-	AutoCreateAddresses                *bool   `json:"autoCreateAddresses,omitempty"`
-	AutoDeleteAddresses                *bool   `json:"autoDeleteAddresses,omitempty"`
-	AutoDeleteAddressesDelay           *int32  `json:"autoDeleteAddressesDelay,omitempty"`
-	ConfigDeleteAddresses              *string `json:"configDeleteAddresses,omitempty"`
-	ManagementBrowsePageSize           *int32  `json:"managementBrowsePageSize,omitempty"`
-	DefaultPurgeOnNoConsumers          *bool   `json:"defaultPurgeOnNoConsumers,omitempty"`
-	DefaultMaxConsumers                *int32  `json:"defaultMaxConsumers,omitempty"`
-	DefaultQueueRoutingType            *string `json:"defaultQueueRoutingType,omitempty"`
-	DefaultAddressRoutingType          *string `json:"defaultAddressRoutingType,omitempty"`
-	DefaultConsumerWindowSize          *int32  `json:"defaultConsumerWindowSize,omitempty"`
-	DefaultRingSize                    *int32  `json:"defaultRingSize,omitempty"`
-	RetroactiveMessageCount            *int32  `json:"retroactiveMessageCount,omitempty"`
-	EnableMetrics                      *bool   `json:"enableMetrics,omitempty"`
-	Match                              string  `json:"match,omitempty"`
+	// Maximum value for the redelivery-delay
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Max Redelivery Delay",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	MaxRedeliveryDelay *int32 `json:"maxRedeliveryDelay,omitempty"`
+	// how many times to attempt to deliver a message before sending to dead letter address
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Max Delivery Attempts",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	MaxDeliveryAttempts *int32 `json:"maxDeliveryAttempts,omitempty"`
+	// the maximum size in bytes for an address. -1 means no limits. This is used in PAGING, BLOCK and FAIL policies. Supports byte notation like K, Mb, GB, etc.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Max Size Bytes",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	MaxSizeBytes *string `json:"maxSizeBytes,omitempty"`
+	// used with the address full BLOCK policy, the maximum size in bytes an address can reach before messages start getting rejected. Works in combination with max-size-bytes for AMQP protocol only.  Default = -1 (no limit).
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Max Size Bytes Reject Threshold",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	MaxSizeBytesRejectThreshold *int32 `json:"maxSizeBytesRejectThreshold,omitempty"`
+	// The page size in bytes to use for an address. Supports byte notation like K, Mb, GB, etc.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Page Size Bytes",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	PageSizeBytes *string `json:"pageSizeBytes,omitempty"`
+	// Number of paging files to cache in memory to avoid IO during paging navigation
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Page Max Cache Size",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	PageMaxCacheSize *int32 `json:"pageMaxCacheSize,omitempty"`
+	// what happens when an address where maxSizeBytes is specified becomes full
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Address Full Policy",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	AddressFullPolicy *string `json:"addressFullPolicy,omitempty"`
+	// how many days to keep message counter history for this address
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Message Counter History Day Limit",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	MessageCounterHistoryDayLimit *int32 `json:"messageCounterHistoryDayLimit,omitempty"`
+	// This is deprecated please use default-last-value-queue instead.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Last Value Queue",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	LastValueQueue *bool `json:"lastValueQueue,omitempty"`
+	// whether to treat the queues under the address as a last value queues by default
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Default Last Value Queue",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	DefaultLastValueQueue *bool `json:"defaultLastValueQueue,omitempty"`
+	// the property to use as the key for a last value queue by default
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Default Last Value Key",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	DefaultLastValueKey *string `json:"defaultLastValueKey,omitempty"`
+	// whether the queue should be non-destructive by default
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Default Non Destructive",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	DefaultNonDestructive *bool `json:"defaultNonDestructive,omitempty"`
+	// whether to treat the queues under the address as exclusive queues by default
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Default Exclusive Queue",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	DefaultExclusiveQueue *bool `json:"defaultExclusiveQueue,omitempty"`
+	// whether to rebalance groups when a consumer is added
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Default Group Rebalance",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	DefaultGroupRebalance *bool `json:"defaultGroupRebalance,omitempty"`
+	// whether to pause dispatch when rebalancing groups
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Default Group Rebalance Pause Dispatch",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	DefaultGroupRebalancePauseDispatch *bool `json:"defaultGroupRebalancePauseDispatch,omitempty"`
+	// number of buckets to use for grouping, -1 (default) is unlimited and uses the raw group, 0 disables message groups.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Default Group Buckets",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	DefaultGroupBuckets *int32 `json:"defaultGroupBuckets,omitempty"`
+	// key used to mark a message is first in a group for a consumer
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Default Group First Key",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	DefaultGroupFirstKey *string `json:"defaultGroupFirstKey,omitempty"`
+	// the default number of consumers needed before dispatch can start for queues under the address.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Default Consumers Before Dispatch",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	DefaultConsumersBeforeDispatch *int32 `json:"defaultConsumersBeforeDispatch,omitempty"`
+	// the default delay (in milliseconds) to wait before dispatching if number of consumers before dispatch is not met for queues under the address.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Default Delay Before Dispatch",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	DefaultDelayBeforeDispatch *int32 `json:"defaultDelayBeforeDispatch,omitempty"`
+	// how long (in ms) to wait after the last consumer is closed on a queue before redistributing messages.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Redistribution Delay",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	RedistributionDelay *int32 `json:"redistributionDelay,omitempty"`
+	// if there are no queues matching this address, whether to forward message to DLA (if it exists for this address)
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Send To DLA On No Route",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	SendToDlaOnNoRoute *bool `json:"sendToDlaOnNoRoute,omitempty"`
+	// The minimum rate of message consumption allowed before a consumer is considered "slow." Measured in messages-per-second.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Slow Consumer Threshold",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	SlowConsumerThreshold *int32 `json:"slowConsumerThreshold,omitempty"`
+	// what happens when a slow consumer is identified
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Slow Consumer Policy",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	SlowConsumerPolicy *string `json:"slowConsumerPolicy,omitempty"`
+	// How often to check for slow consumers on a particular queue. Measured in seconds.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Slow Consumer Check Period",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	SlowConsumerCheckPeriod *int32 `json:"slowConsumerCheckPeriod,omitempty"`
+	// DEPRECATED. whether or not to automatically create JMS queues when a producer sends or a consumer connects to a queue
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Auto Create Jms Queues",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	AutoCreateJmsQueues *bool `json:"autoCreateJmsQueues,omitempty"`
+	// DEPRECATED. whether or not to delete auto-created JMS queues when the queue has 0 consumers and 0 messages
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Auto Delete Jms Queues",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	AutoDeleteJmsQueues *bool `json:"autoDeleteJmsQueues,omitempty"`
+	// DEPRECATED. whether or not to automatically create JMS topics when a producer sends or a consumer subscribes to a topic
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Auto Create Jms Topics",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	AutoCreateJmsTopics *bool `json:"autoCreateJmsTopics,omitempty"`
+	// DEPRECATED. whether or not to delete auto-created JMS topics when the last subscription is closed
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Auto Delete Jms Topics",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	AutoDeleteJmsTopics *bool `json:"autoDeleteJmsTopics,omitempty"`
+	// whether or not to automatically create a queue when a client sends a message to or attempts to consume a message from a queue
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Auto Create Queues",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	AutoCreateQueues *bool `json:"autoCreateQueues,omitempty"`
+	// whether or not to delete auto-created queues when the queue has 0 consumers and 0 messages
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Auto Delete Queues",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	AutoDeleteQueues *bool `json:"autoDeleteQueues,omitempty"`
+	// whether or not to delete created queues when the queue has 0 consumers and 0 messages
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Auto Delete Created Queues",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	AutoDeleteCreatedQueues *bool `json:"autoDeleteCreatedQueues,omitempty"`
+	// how long to wait (in milliseconds) before deleting auto-created queues after the queue has 0 consumers.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Auto Delete Queues Delay",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	AutoDeleteQueuesDelay *int32 `json:"autoDeleteQueuesDelay,omitempty"`
+	// the message count the queue must be at or below before it can be evaluated to be auto deleted, 0 waits until empty queue (default) and -1 disables this check.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Auto Delete Queues Message Count",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	AutoDeleteQueuesMessageCount *int32 `json:"autoDeleteQueuesMessageCount,omitempty"`
+	//What to do when a queue is no longer in broker.xml.  OFF = will do nothing queues will remain, FORCE = delete queues even if messages remaining.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Config Delete Queues",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	ConfigDeleteQueues *string `json:"configDeleteQueues,omitempty"`
+	// whether or not to automatically create addresses when a client sends a message to or attempts to consume a message from a queue mapped to an address that doesnt exist
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Auto Create Addresses",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	AutoCreateAddresses *bool `json:"autoCreateAddresses,omitempty"`
+	// whether or not to delete auto-created addresses when it no longer has any queues
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Auto Delete Addresses",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	AutoDeleteAddresses *bool `json:"autoDeleteAddresses,omitempty"`
+	// how long to wait (in milliseconds) before deleting auto-created addresses after they no longer have any queues
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Auto Delete Addresses Delay",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	AutoDeleteAddressesDelay *int32 `json:"autoDeleteAddressesDelay,omitempty"`
+	// What to do when an address is no longer in broker.xml.  OFF = will do nothing addresses will remain, FORCE = delete address and its queues even if messages remaining.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Config Delete Addresses",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	ConfigDeleteAddresses *string `json:"configDeleteAddresses,omitempty"`
+	// how many message a management resource can browse
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Management Browse Page Size",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	ManagementBrowsePageSize *int32 `json:"managementBrowsePageSize,omitempty"`
+	// purge the contents of the queue once there are no consumers
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Default Purge On No Consumers",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	DefaultPurgeOnNoConsumers *bool `json:"defaultPurgeOnNoConsumers,omitempty"`
+	// the maximum number of consumers allowed on this queue at any one time
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Default Max Consumers",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	DefaultMaxConsumers *int32 `json:"defaultMaxConsumers,omitempty"`
+	// the routing-type used on auto-created queues
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Default Queue Routing Type",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	DefaultQueueRoutingType *string `json:"defaultQueueRoutingType,omitempty"`
+	// the routing-type used on auto-created addresses
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Default Address Routing Type",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	DefaultAddressRoutingType *string `json:"defaultAddressRoutingType,omitempty"`
+	// the default window size for a consumer
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Default Consumer Window Size",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	DefaultConsumerWindowSize *int32 `json:"defaultConsumerWindowSize,omitempty"`
+	// the default ring-size value for any matching queue which doesnt have ring-size explicitly defined
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Default Ring Size",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	DefaultRingSize *int32 `json:"defaultRingSize,omitempty"`
+	// the number of messages to preserve for future queues created on the matching address
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Retroactive Message Count",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	RetroactiveMessageCount *int32 `json:"retroactiveMessageCount,omitempty"`
+	// whether or not to enable metrics for metrics plugins on the matching address
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Enable Metrics",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	EnableMetrics *bool `json:"enableMetrics,omitempty"`
+	// pattern for matching settings against addresses; can use wildards
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Match",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	Match string `json:"match,omitempty"`
 }
 
 type DeploymentPlanType struct {
-	Image                 string                      `json:"image,omitempty"`
-	InitImage             string                      `json:"initImage,omitempty"`
-	Size                  int32                       `json:"size,omitempty"`
-	RequireLogin          bool                        `json:"requireLogin,omitempty"`
-	PersistenceEnabled    bool                        `json:"persistenceEnabled,omitempty"`
-	JournalType           string                      `json:"journalType,omitempty"`
-	MessageMigration      *bool                       `json:"messageMigration,omitempty"`
-	Resources             corev1.ResourceRequirements `json:"resources,omitempty"`
-	Storage               StorageType                 `json:"storage,omitempty"`
-	JolokiaAgentEnabled   bool                        `json:"jolokiaAgentEnabled,omitempty"`
-	ManagementRBACEnabled bool                        `json:"managementRBACEnabled,omitempty"`
+	//The image used for the broker, all upgrades are disabled. Needs a corresponding initImage
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Image",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	Image string `json:"image,omitempty"`
+	// The init container image used to configure broker, all upgrades are disabled. Needs a corresponding image
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Init Image",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	InitImage string `json:"initImage,omitempty"`
+	// The number of broker pods to deploy
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Size",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:podCount"}
+	Size int32 `json:"size,omitempty"`
+	// If true require user password login credentials for broker protocol ports
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Require Login",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	RequireLogin bool `json:"requireLogin,omitempty"`
+	// If true use persistent volume via persistent volume claim for journal storage
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Persistence Enabled",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	PersistenceEnabled bool `json:"persistenceEnabled,omitempty"`
+	// If aio use ASYNCIO, if nio use NIO for journal IO
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Journal Type",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	JournalType string `json:"journalType,omitempty"`
+	//If true migrate messages on scaledown
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Message Migration",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	MessageMigration *bool `json:"messageMigration,omitempty"`
+	// Specifies the minimum/maximum amount of compute resources required/allowed
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Resource Requirements",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:resourceRequirements"}
+	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
+	// Specifies the storage configurations
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Storage Configurations"
+	Storage StorageType `json:"storage,omitempty"`
+	// If true enable the Jolokia JVM Agent
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Jolokia Agent Enabled",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	JolokiaAgentEnabled bool `json:"jolokiaAgentEnabled,omitempty"`
+	// If true enable the management role based access control
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Management RBAC Enabled",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	ManagementRBACEnabled bool `json:"managementRBACEnabled,omitempty"`
 }
 
 type StorageType struct {
+	// The storage size
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Size",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	Size string `json:"size,omitempty"`
 }
 
 type AcceptorType struct {
-	Name                    string `json:"name"`
-	Port                    int32  `json:"port,omitempty"`
-	Protocols               string `json:"protocols,omitempty"`
-	SSLEnabled              bool   `json:"sslEnabled,omitempty"`
-	SSLSecret               string `json:"sslSecret,omitempty"`
-	EnabledCipherSuites     string `json:"enabledCipherSuites,omitempty"`
-	EnabledProtocols        string `json:"enabledProtocols,omitempty"`
-	NeedClientAuth          bool   `json:"needClientAuth,omitempty"`
-	WantClientAuth          bool   `json:"wantClientAuth,omitempty"`
-	VerifyHost              bool   `json:"verifyHost,omitempty"`
-	SSLProvider             string `json:"sslProvider,omitempty"`
-	SNIHost                 string `json:"sniHost,omitempty"`
-	Expose                  bool   `json:"expose,omitempty"`
-	AnycastPrefix           string `json:"anycastPrefix,omitempty"`
-	MulticastPrefix         string `json:"multicastPrefix,omitempty"`
-	ConnectionsAllowed      int    `json:"connectionsAllowed,omitempty"`
-	AMQPMinLargeMessageSize int    `json:"amqpMinLargeMessageSize,omitempty"`
+	// The acceptor name
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Name",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	Name string `json:"name"`
+	// Port number
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Port",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	Port int32 `json:"port,omitempty"`
+	// The protocols to enable for this acceptor
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Protocols",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	Protocols string `json:"protocols,omitempty"`
+	// Whether or not to enable SSL on this port
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="SSL Enabled",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	SSLEnabled bool `json:"sslEnabled,omitempty"`
+	// Name of the secret to use for ssl information
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="SSL Secret",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	SSLSecret string `json:"sslSecret,omitempty"`
+	// Comma separated list of cipher suites used for SSL communication.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Enabled Cipher Suites",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	EnabledCipherSuites string `json:"enabledCipherSuites,omitempty"`
+	// Comma separated list of protocols used for SSL communication.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Enabled Protocols",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	EnabledProtocols string `json:"enabledProtocols,omitempty"`
+	// Tells a client connecting to this acceptor that 2-way SSL is required. This property takes precedence over wantClientAuth.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Need Client Auth",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	NeedClientAuth bool `json:"needClientAuth,omitempty"`
+	// Tells a client connecting to this acceptor that 2-way SSL is requested but not required. Overridden by needClientAuth.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Want Client Auth",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	WantClientAuth bool `json:"wantClientAuth,omitempty"`
+	// The CN of the connecting client's SSL certificate will be compared to its hostname to verify they match. This is useful only for 2-way SSL.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Verify Host",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	VerifyHost bool `json:"verifyHost,omitempty"`
+	// Used to change the SSL Provider between JDK and OPENSSL. The default is JDK.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="SSL Provider",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	SSLProvider string `json:"sslProvider,omitempty"`
+	// A regular expression used to match the server_name extension on incoming SSL connections. If the name doesn't match then the connection to the acceptor will be rejected.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="SNI Host",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	SNIHost string `json:"sniHost,omitempty"`
+	// Whether or not to expose this acceptor
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Expose",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	Expose bool `json:"expose,omitempty"`
+	// To indicate which kind of routing type to use.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Anycast Prefix",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	AnycastPrefix string `json:"anycastPrefix,omitempty"`
+	// To indicate which kind of routing type to use
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Multicast Prefix",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	MulticastPrefix string `json:"multicastPrefix,omitempty"`
+	// Max number of connections allowed to make
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Connections Allowed",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	ConnectionsAllowed int `json:"connectionsAllowed,omitempty"`
+	// AMQP Minimum Large Message Size
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="AMQP Min Large Message Size",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	AMQPMinLargeMessageSize int `json:"amqpMinLargeMessageSize,omitempty"`
 }
 
 type ConnectorType struct {
-	Name                string `json:"name"`
-	Type                string `json:"type,omitempty"`
-	Host                string `json:"host"`
-	Port                int32  `json:"port"`
-	SSLEnabled          bool   `json:"sslEnabled,omitempty"`
-	SSLSecret           string `json:"sslSecret,omitempty"`
+	// The name of the connector
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Name",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	Name string `json:"name"`
+	// The type either tcp or vm
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Type",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	Type string `json:"type,omitempty"`
+	// Hostname or IP to connect to
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Host",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	Host string `json:"host"`
+	// Port number
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Port",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	Port int32 `json:"port"`
+	//  Whether or not to enable SSL on this port
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="SSL Enabled",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	SSLEnabled bool `json:"sslEnabled,omitempty"`
+	// Name of the secret to use for ssl information
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="SSL Secret",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	SSLSecret string `json:"sslSecret,omitempty"`
+	// Comma separated list of cipher suites used for SSL communication.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Enabled Cipher Suites",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	EnabledCipherSuites string `json:"enabledCipherSuites,omitempty"`
-	EnabledProtocols    string `json:"enabledProtocols,omitempty"`
-	NeedClientAuth      bool   `json:"needClientAuth,omitempty"`
-	WantClientAuth      bool   `json:"wantClientAuth,omitempty"`
-	VerifyHost          bool   `json:"verifyHost,omitempty"`
-	SSLProvider         string `json:"sslProvider,omitempty"`
-	SNIHost             string `json:"sniHost,omitempty"`
-	Expose              bool   `json:"expose,omitempty"`
+	// Comma separated list of protocols used for SSL communication.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Enabled Protocols",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	EnabledProtocols string `json:"enabledProtocols,omitempty"`
+	// Tells a client connecting to this connector that 2-way SSL is required. This property takes precedence over wantClientAuth.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Need Client Auth",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	NeedClientAuth bool `json:"needClientAuth,omitempty"`
+	// Tells a client connecting to this connector that 2-way SSL is requested but not required. Overridden by needClientAuth.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Want Client Auth",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	WantClientAuth bool `json:"wantClientAuth,omitempty"`
+	// The CN of the connecting client's SSL certificate will be compared to its hostname to verify they match. This is useful only for 2-way SSL.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Verify Host",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	VerifyHost bool `json:"verifyHost,omitempty"`
+	// Used to change the SSL Provider between JDK and OPENSSL. The default is JDK.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="SSL Provider",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	SSLProvider string `json:"sslProvider,omitempty"`
+	// A regular expression used to match the server_name extension on incoming SSL connections. If the name doesn't match then the connection to the acceptor will be rejected.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="SNI Host",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	SNIHost string `json:"sniHost,omitempty"`
+	// Whether or not to expose this connector
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Expose",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	Expose bool `json:"expose,omitempty"`
 }
 
 type ConsoleType struct {
-	Expose        bool   `json:"expose,omitempty"`
-	SSLEnabled    bool   `json:"sslEnabled,omitempty"`
-	SSLSecret     string `json:"sslSecret,omitempty"`
-	UseClientAuth bool   `json:"useClientAuth,omitempty"`
+	// Whether or not to expose this port
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Expose",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	Expose bool `json:"expose,omitempty"`
+	// Whether or not to enable SSL on this port
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="SSL Enabled",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	SSLEnabled bool `json:"sslEnabled,omitempty"`
+	// Name of the secret to use for ssl information
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="SSL Secret",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	SSLSecret string `json:"sslSecret,omitempty"`
+	// If the embedded server requires client authentication
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Use Client Auth",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	UseClientAuth bool `json:"useClientAuth,omitempty"`
 }
 
 // ActiveMQArtemis App product upgrade flags
 type ActiveMQArtemisUpgrades struct {
+	// Set true to enable automatic micro version product upgrades, it is disabled by default.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Enable Upgrades",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:ui:booleanSwitch"}
 	Enabled bool `json:"enabled"`
-	Minor   bool `json:"minor"`
+	// Set true to enable automatic minor product version upgrades, it is disabled by default. Requires spec.upgrades.enabled to be true.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Include minor version upgrades",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldDependency:upgrades.enabled:true","urn:alm:descriptor:com.tectonic.ui:ui:booleanSwitch"}
+	Minor bool `json:"minor"`
 }
 
 // ActiveMQArtemisStatus defines the observed state of ActiveMQArtemis
@@ -186,6 +426,8 @@ type ActiveMQArtemisStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
+	// The current pods
+	//+operator-sdk:csv:customresourcedefinitions:type=status,displayName="Pods Status",xDescriptors="urn:alm:descriptor:com.tectonic.ui:podStatuses"
 	PodStatus olm.DeploymentStatus `json:"podStatus"`
 
 	// Current state of the resource
@@ -203,7 +445,8 @@ type ActiveMQArtemisStatus struct {
 //+kubebuilder:resource:path=activemqartemises,shortName=aa
 //+operator-sdk:csv:customresourcedefinitions:resources={{"Secret", "v1"}}
 
-// ActiveMQArtemis is the Schema for the activemqartemises API
+// A stateful deployment of one or more brokers
+// +operator-sdk:csv:customresourcedefinitions:displayName="ActiveMQ Artemis"
 type ActiveMQArtemis struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v2alpha5/activemqartemis_types.go
+++ b/api/v2alpha5/activemqartemis_types.go
@@ -30,110 +30,292 @@ type ActiveMQArtemisSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
-	AdminUser       string                  `json:"adminUser,omitempty"`
-	AdminPassword   string                  `json:"adminPassword,omitempty"`
-	DeploymentPlan  DeploymentPlanType      `json:"deploymentPlan,omitempty"`
-	Acceptors       []AcceptorType          `json:"acceptors,omitempty"`
-	Connectors      []ConnectorType         `json:"connectors,omitempty"`
-	Console         ConsoleType             `json:"console,omitempty"`
-	Version         string                  `json:"version,omitempty"`
-	Upgrades        ActiveMQArtemisUpgrades `json:"upgrades,omitempty"`
-	AddressSettings AddressSettingsType     `json:"addressSettings,omitempty"`
+	// User name for standard broker user. It is required for connecting to the broker and the web console. If left empty, it will be generated.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Admin User",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	AdminUser string `json:"adminUser,omitempty"`
+	// Password for standard broker user. It is required for connecting to the broker and the web console. If left empty, it will be generated.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Admin Password",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:password"}
+	AdminPassword string `json:"adminPassword,omitempty"`
+	// Specifies the deployment plan
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Deployment Plan"
+	DeploymentPlan DeploymentPlanType `json:"deploymentPlan,omitempty"`
+	// Specifies the acceptor configuration
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Acceptors"
+	Acceptors []AcceptorType `json:"acceptors,omitempty"`
+	// Specifies connectors and connector configuration
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Connectors"
+	Connectors []ConnectorType `json:"connectors,omitempty"`
+	// Specifies the console configuration
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Console Configurations"
+	Console ConsoleType `json:"console,omitempty"`
+	// The desired version of the broker. Can be x, or x.y or x.y.z to configure upgrades
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Version",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	Version string `json:"version,omitempty"`
+	// Specifies the upgrades (deprecated in favour of Version)
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Upgrades"
+	Upgrades ActiveMQArtemisUpgrades `json:"upgrades,omitempty"`
+	// Specifies the address configurations (deprecated in favour of BrokerProperties)
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Address Configurations"
+	AddressSettings AddressSettingsType `json:"addressSettings,omitempty"`
 }
 
 type AddressSettingsType struct {
-	ApplyRule      *string              `json:"applyRule,omitempty"`
+	// How to merge the address settings to broker configuration
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Apply Rule",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	ApplyRule *string `json:"applyRule,omitempty"`
+	// Specifies the address settings
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Address Settings"
 	AddressSetting []AddressSettingType `json:"addressSetting,omitempty"`
 }
 
 type AddressSettingType struct {
-	DeadLetterAddress             *string `json:"deadLetterAddress,omitempty"`
-	AutoCreateDeadLetterResources *bool   `json:"autoCreateDeadLetterResources,omitempty"`
-	DeadLetterQueuePrefix         *string `json:"deadLetterQueuePrefix,omitempty"`
-	DeadLetterQueueSuffix         *string `json:"deadLetterQueueSuffix,omitempty"`
-	ExpiryAddress                 *string `json:"expiryAddress,omitempty"`
-	AutoCreateExpiryResources     *bool   `json:"autoCreateExpiryResources,omitempty"`
-	ExpiryQueuePrefix             *string `json:"expiryQueuePrefix,omitempty"`
-	ExpiryQueueSuffix             *string `json:"expiryQueueSuffix,omitempty"`
-	ExpiryDelay                   *int32  `json:"expiryDelay,omitempty"`
-	MinExpiryDelay                *int32  `json:"minExpiryDelay,omitempty"`
-	MaxExpiryDelay                *int32  `json:"maxExpiryDelay,omitempty"`
-	RedeliveryDelay               *int32  `json:"redeliveryDelay,omitempty"`
+	// the address to send dead messages to
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Dead Letter Address",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	DeadLetterAddress *string `json:"deadLetterAddress,omitempty"`
+	// whether or not to automatically create the dead-letter-address and/or a corresponding queue on that address when a message found to be undeliverable
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="AutoCreateDeadLetterResources",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	AutoCreateDeadLetterResources *bool `json:"autoCreateDeadLetterResources,omitempty"`
+	// the prefix to use for auto-created dead letter queues
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Dead Letter Queue Prefix",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	DeadLetterQueuePrefix *string `json:"deadLetterQueuePrefix,omitempty"`
+	// the suffix to use for auto-created dead letter queues
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Dead Letter Queue Suffix",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	DeadLetterQueueSuffix *string `json:"deadLetterQueueSuffix,omitempty"`
+	// the address to send expired messages to
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Expiry Address",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	ExpiryAddress *string `json:"expiryAddress,omitempty"`
+	// whether or not to automatically create the expiry-address and/or a corresponding queue on that address when a message is sent to a matching queue
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Auto Create Expiry Resources",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	AutoCreateExpiryResources *bool `json:"autoCreateExpiryResources,omitempty"`
+	// the prefix to use for auto-created expiry queues
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Expiry Queue Prefix",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	ExpiryQueuePrefix *string `json:"expiryQueuePrefix,omitempty"`
+	// the suffix to use for auto-created expiry queues
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Expiry Queue Suffix",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	ExpiryQueueSuffix *string `json:"expiryQueueSuffix,omitempty"`
+	// Overrides the expiration time for messages using the default value for expiration time. "-1" disables this setting.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Expiry Delay",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	ExpiryDelay *int32 `json:"expiryDelay,omitempty"`
+	// Overrides the expiration time for messages using a lower value. "-1" disables this setting.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Min Expiry Delay",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	MinExpiryDelay *int32 `json:"minExpiryDelay,omitempty"`
+	// Overrides the expiration time for messages using a higher value. "-1" disables this setting.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Max Expiry Delay",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	MaxExpiryDelay *int32 `json:"maxExpiryDelay,omitempty"`
+	// the time (in ms) to wait before redelivering a cancelled message.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Redelivery Delay",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	RedeliveryDelay *int32 `json:"redeliveryDelay,omitempty"`
 	//
 	RedeliveryDelayMultiplier          *float32 `json:"redeliveryDelayMultiplier,omitempty"`          // controller-gen requires crd:allowDangerousTypes=true to allow support float types
 	RedeliveryCollisionAvoidanceFactor *float32 `json:"redeliveryCollisionAvoidanceFactor,omitempty"` // controller-gen requires crd:allowDangerousTypes=true to allow support float types
 	//
-	MaxRedeliveryDelay                   *int32  `json:"maxRedeliveryDelay,omitempty"`
-	MaxDeliveryAttempts                  *int32  `json:"maxDeliveryAttempts,omitempty"`
-	MaxSizeBytes                         *string `json:"maxSizeBytes,omitempty"`
-	MaxSizeBytesRejectThreshold          *int32  `json:"maxSizeBytesRejectThreshold,omitempty"`
-	PageSizeBytes                        *string `json:"pageSizeBytes,omitempty"`
-	PageMaxCacheSize                     *int32  `json:"pageMaxCacheSize,omitempty"`
-	AddressFullPolicy                    *string `json:"addressFullPolicy,omitempty"`
-	MessageCounterHistoryDayLimit        *int32  `json:"messageCounterHistoryDayLimit,omitempty"`
-	LastValueQueue                       *bool   `json:"lastValueQueue,omitempty"`
-	DefaultLastValueQueue                *bool   `json:"defaultLastValueQueue,omitempty"`
-	DefaultLastValueKey                  *string `json:"defaultLastValueKey,omitempty"`
-	DefaultNonDestructive                *bool   `json:"defaultNonDestructive,omitempty"`
-	DefaultExclusiveQueue                *bool   `json:"defaultExclusiveQueue,omitempty"`
-	DefaultGroupRebalance                *bool   `json:"defaultGroupRebalance,omitempty"`
-	DefaultGroupRebalancePauseDispatch   *bool   `json:"defaultGroupRebalancePauseDispatch,omitempty"`
-	DefaultGroupBuckets                  *int32  `json:"defaultGroupBuckets,omitempty"`
-	DefaultGroupFirstKey                 *string `json:"defaultGroupFirstKey,omitempty"`
-	DefaultConsumersBeforeDispatch       *int32  `json:"defaultConsumersBeforeDispatch,omitempty"`
-	DefaultDelayBeforeDispatch           *int32  `json:"defaultDelayBeforeDispatch,omitempty"`
-	RedistributionDelay                  *int32  `json:"redistributionDelay,omitempty"`
-	SendToDlaOnNoRoute                   *bool   `json:"sendToDlaOnNoRoute,omitempty"`
-	SlowConsumerThreshold                *int32  `json:"slowConsumerThreshold,omitempty"`
-	SlowConsumerPolicy                   *string `json:"slowConsumerPolicy,omitempty"`
-	SlowConsumerCheckPeriod              *int32  `json:"slowConsumerCheckPeriod,omitempty"`
-	AutoCreateJmsQueues                  *bool   `json:"autoCreateJmsQueues,omitempty"`
-	AutoDeleteJmsQueues                  *bool   `json:"autoDeleteJmsQueues,omitempty"`
-	AutoCreateJmsTopics                  *bool   `json:"autoCreateJmsTopics,omitempty"`
-	AutoDeleteJmsTopics                  *bool   `json:"autoDeleteJmsTopics,omitempty"`
-	AutoCreateQueues                     *bool   `json:"autoCreateQueues,omitempty"`
-	AutoDeleteQueues                     *bool   `json:"autoDeleteQueues,omitempty"`
-	AutoDeleteCreatedQueues              *bool   `json:"autoDeleteCreatedQueues,omitempty"`
-	AutoDeleteQueuesDelay                *int32  `json:"autoDeleteQueuesDelay,omitempty"`
-	AutoDeleteQueuesMessageCount         *int32  `json:"autoDeleteQueuesMessageCount,omitempty"`
-	ConfigDeleteQueues                   *string `json:"configDeleteQueues,omitempty"`
-	AutoCreateAddresses                  *bool   `json:"autoCreateAddresses,omitempty"`
-	AutoDeleteAddresses                  *bool   `json:"autoDeleteAddresses,omitempty"`
-	AutoDeleteAddressesDelay             *int32  `json:"autoDeleteAddressesDelay,omitempty"`
-	ConfigDeleteAddresses                *string `json:"configDeleteAddresses,omitempty"`
-	ManagementBrowsePageSize             *int32  `json:"managementBrowsePageSize,omitempty"`
-	DefaultPurgeOnNoConsumers            *bool   `json:"defaultPurgeOnNoConsumers,omitempty"`
-	DefaultMaxConsumers                  *int32  `json:"defaultMaxConsumers,omitempty"`
-	DefaultQueueRoutingType              *string `json:"defaultQueueRoutingType,omitempty"`
-	DefaultAddressRoutingType            *string `json:"defaultAddressRoutingType,omitempty"`
-	DefaultConsumerWindowSize            *int32  `json:"defaultConsumerWindowSize,omitempty"`
-	DefaultRingSize                      *int32  `json:"defaultRingSize,omitempty"`
-	RetroactiveMessageCount              *int32  `json:"retroactiveMessageCount,omitempty"`
-	EnableMetrics                        *bool   `json:"enableMetrics,omitempty"`
-	Match                                string  `json:"match,omitempty"`
-	ManagementMessageAttributeSizeLimit  *int32  `json:"managementMessageAttributeSizeLimit,omitempty"`
+	// Maximum value for the redelivery-delay
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Max Redelivery Delay",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	MaxRedeliveryDelay *int32 `json:"maxRedeliveryDelay,omitempty"`
+	// how many times to attempt to deliver a message before sending to dead letter address
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Max Delivery Attempts",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	MaxDeliveryAttempts *int32 `json:"maxDeliveryAttempts,omitempty"`
+	// the maximum size in bytes for an address. -1 means no limits. This is used in PAGING, BLOCK and FAIL policies. Supports byte notation like K, Mb, GB, etc.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Max Size Bytes",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	MaxSizeBytes *string `json:"maxSizeBytes,omitempty"`
+	// used with the address full BLOCK policy, the maximum size in bytes an address can reach before messages start getting rejected. Works in combination with max-size-bytes for AMQP protocol only.  Default = -1 (no limit).
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Max Size Bytes Reject Threshold",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	MaxSizeBytesRejectThreshold *int32 `json:"maxSizeBytesRejectThreshold,omitempty"`
+	// The page size in bytes to use for an address. Supports byte notation like K, Mb, GB, etc.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Page Size Bytes",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	PageSizeBytes *string `json:"pageSizeBytes,omitempty"`
+	// Number of paging files to cache in memory to avoid IO during paging navigation
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Page Max Cache Size",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	PageMaxCacheSize *int32 `json:"pageMaxCacheSize,omitempty"`
+	// what happens when an address where maxSizeBytes is specified becomes full
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Address Full Policy",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	AddressFullPolicy *string `json:"addressFullPolicy,omitempty"`
+	// how many days to keep message counter history for this address
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Message Counter History Day Limit",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	MessageCounterHistoryDayLimit *int32 `json:"messageCounterHistoryDayLimit,omitempty"`
+	// This is deprecated please use default-last-value-queue instead.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Last Value Queue",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	LastValueQueue *bool `json:"lastValueQueue,omitempty"`
+	// whether to treat the queues under the address as a last value queues by default
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Default Last Value Queue",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	DefaultLastValueQueue *bool `json:"defaultLastValueQueue,omitempty"`
+	// the property to use as the key for a last value queue by default
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Default Last Value Key",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	DefaultLastValueKey *string `json:"defaultLastValueKey,omitempty"`
+	// whether the queue should be non-destructive by default
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Default Non Destructive",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	DefaultNonDestructive *bool `json:"defaultNonDestructive,omitempty"`
+	// whether to treat the queues under the address as exclusive queues by default
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Default Exclusive Queue",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	DefaultExclusiveQueue *bool `json:"defaultExclusiveQueue,omitempty"`
+	// whether to rebalance groups when a consumer is added
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Default Group Rebalance",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	DefaultGroupRebalance *bool `json:"defaultGroupRebalance,omitempty"`
+	// whether to pause dispatch when rebalancing groups
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Default Group Rebalance Pause Dispatch",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	DefaultGroupRebalancePauseDispatch *bool `json:"defaultGroupRebalancePauseDispatch,omitempty"`
+	// number of buckets to use for grouping, -1 (default) is unlimited and uses the raw group, 0 disables message groups.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Default Group Buckets",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	DefaultGroupBuckets *int32 `json:"defaultGroupBuckets,omitempty"`
+	// key used to mark a message is first in a group for a consumer
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Default Group First Key",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	DefaultGroupFirstKey *string `json:"defaultGroupFirstKey,omitempty"`
+	// the default number of consumers needed before dispatch can start for queues under the address.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Default Consumers Before Dispatch",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	DefaultConsumersBeforeDispatch *int32 `json:"defaultConsumersBeforeDispatch,omitempty"`
+	// the default delay (in milliseconds) to wait before dispatching if number of consumers before dispatch is not met for queues under the address.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Default Delay Before Dispatch",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	DefaultDelayBeforeDispatch *int32 `json:"defaultDelayBeforeDispatch,omitempty"`
+	// how long (in ms) to wait after the last consumer is closed on a queue before redistributing messages.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Redistribution Delay",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	RedistributionDelay *int32 `json:"redistributionDelay,omitempty"`
+	// if there are no queues matching this address, whether to forward message to DLA (if it exists for this address)
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Send To DLA On No Route",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	SendToDlaOnNoRoute *bool `json:"sendToDlaOnNoRoute,omitempty"`
+	// The minimum rate of message consumption allowed before a consumer is considered "slow." Measured in messages-per-second.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Slow Consumer Threshold",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	SlowConsumerThreshold *int32 `json:"slowConsumerThreshold,omitempty"`
+	// what happens when a slow consumer is identified
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Slow Consumer Policy",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	SlowConsumerPolicy *string `json:"slowConsumerPolicy,omitempty"`
+	// How often to check for slow consumers on a particular queue. Measured in seconds.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Slow Consumer Check Period",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	SlowConsumerCheckPeriod *int32 `json:"slowConsumerCheckPeriod,omitempty"`
+	// DEPRECATED. whether or not to automatically create JMS queues when a producer sends or a consumer connects to a queue
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Auto Create Jms Queues",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	AutoCreateJmsQueues *bool `json:"autoCreateJmsQueues,omitempty"`
+	// DEPRECATED. whether or not to delete auto-created JMS queues when the queue has 0 consumers and 0 messages
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Auto Delete Jms Queues",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	AutoDeleteJmsQueues *bool `json:"autoDeleteJmsQueues,omitempty"`
+	// DEPRECATED. whether or not to automatically create JMS topics when a producer sends or a consumer subscribes to a topic
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Auto Create Jms Topics",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	AutoCreateJmsTopics *bool `json:"autoCreateJmsTopics,omitempty"`
+	// DEPRECATED. whether or not to delete auto-created JMS topics when the last subscription is closed
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Auto Delete Jms Topics",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	AutoDeleteJmsTopics *bool `json:"autoDeleteJmsTopics,omitempty"`
+	// whether or not to automatically create a queue when a client sends a message to or attempts to consume a message from a queue
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Auto Create Queues",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	AutoCreateQueues *bool `json:"autoCreateQueues,omitempty"`
+	// whether or not to delete auto-created queues when the queue has 0 consumers and 0 messages
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Auto Delete Queues",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	AutoDeleteQueues *bool `json:"autoDeleteQueues,omitempty"`
+	// whether or not to delete created queues when the queue has 0 consumers and 0 messages
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Auto Delete Created Queues",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	AutoDeleteCreatedQueues *bool `json:"autoDeleteCreatedQueues,omitempty"`
+	// how long to wait (in milliseconds) before deleting auto-created queues after the queue has 0 consumers.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Auto Delete Queues Delay",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	AutoDeleteQueuesDelay *int32 `json:"autoDeleteQueuesDelay,omitempty"`
+	// the message count the queue must be at or below before it can be evaluated to be auto deleted, 0 waits until empty queue (default) and -1 disables this check.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Auto Delete Queues Message Count",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	AutoDeleteQueuesMessageCount *int32 `json:"autoDeleteQueuesMessageCount,omitempty"`
+	//What to do when a queue is no longer in broker.xml.  OFF = will do nothing queues will remain, FORCE = delete queues even if messages remaining.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Config Delete Queues",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	ConfigDeleteQueues *string `json:"configDeleteQueues,omitempty"`
+	// whether or not to automatically create addresses when a client sends a message to or attempts to consume a message from a queue mapped to an address that doesnt exist
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Auto Create Addresses",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	AutoCreateAddresses *bool `json:"autoCreateAddresses,omitempty"`
+	// whether or not to delete auto-created addresses when it no longer has any queues
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Auto Delete Addresses",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	AutoDeleteAddresses *bool `json:"autoDeleteAddresses,omitempty"`
+	// how long to wait (in milliseconds) before deleting auto-created addresses after they no longer have any queues
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Auto Delete Addresses Delay",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	AutoDeleteAddressesDelay *int32 `json:"autoDeleteAddressesDelay,omitempty"`
+	// What to do when an address is no longer in broker.xml.  OFF = will do nothing addresses will remain, FORCE = delete address and its queues even if messages remaining.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Config Delete Addresses",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	ConfigDeleteAddresses *string `json:"configDeleteAddresses,omitempty"`
+	// how many message a management resource can browse
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Management Browse Page Size",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	ManagementBrowsePageSize *int32 `json:"managementBrowsePageSize,omitempty"`
+	// purge the contents of the queue once there are no consumers
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Default Purge On No Consumers",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	DefaultPurgeOnNoConsumers *bool `json:"defaultPurgeOnNoConsumers,omitempty"`
+	// the maximum number of consumers allowed on this queue at any one time
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Default Max Consumers",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	DefaultMaxConsumers *int32 `json:"defaultMaxConsumers,omitempty"`
+	// the routing-type used on auto-created queues
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Default Queue Routing Type",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	DefaultQueueRoutingType *string `json:"defaultQueueRoutingType,omitempty"`
+	// the routing-type used on auto-created addresses
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Default Address Routing Type",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	DefaultAddressRoutingType *string `json:"defaultAddressRoutingType,omitempty"`
+	// the default window size for a consumer
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Default Consumer Window Size",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	DefaultConsumerWindowSize *int32 `json:"defaultConsumerWindowSize,omitempty"`
+	// the default ring-size value for any matching queue which doesnt have ring-size explicitly defined
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Default Ring Size",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	DefaultRingSize *int32 `json:"defaultRingSize,omitempty"`
+	// the number of messages to preserve for future queues created on the matching address
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Retroactive Message Count",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	RetroactiveMessageCount *int32 `json:"retroactiveMessageCount,omitempty"`
+	// whether or not to enable metrics for metrics plugins on the matching address
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Enable Metrics",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	EnableMetrics *bool `json:"enableMetrics,omitempty"`
+	// pattern for matching settings against addresses; can use wildards
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Match",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	Match string `json:"match,omitempty"`
+	// max size of the message returned from management API, default 256
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Max Management Message Size Limit",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	ManagementMessageAttributeSizeLimit *int32 `json:"managementMessageAttributeSizeLimit,omitempty"`
+	// Unit used in specifying slow consumer threshold, default is MESSAGE_PER_SECOND
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Slow Consumer Threshold Measurement Unit",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	SlowConsumerThresholdMeasurementUnit *string `json:"slowConsumerThresholdMeasurementUnit,omitempty"`
-	EnableIngressTimestamp               *bool   `json:"enableIngressTimestamp,omitempty"`
+	// Whether or not set the timestamp of arrival on messages. default false
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Enable Ingress Timestamp",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	EnableIngressTimestamp *bool `json:"enableIngressTimestamp,omitempty"`
 }
 
 type DeploymentPlanType struct {
-	Image                 string                      `json:"image,omitempty"`
-	InitImage             string                      `json:"initImage,omitempty"`
-	Size                  *int32                      `json:"size,omitempty"`
-	RequireLogin          bool                        `json:"requireLogin,omitempty"`
-	PersistenceEnabled    bool                        `json:"persistenceEnabled,omitempty"`
-	JournalType           string                      `json:"journalType,omitempty"`
-	MessageMigration      *bool                       `json:"messageMigration,omitempty"`
-	Resources             corev1.ResourceRequirements `json:"resources,omitempty"`
-	Storage               StorageType                 `json:"storage,omitempty"`
-	JolokiaAgentEnabled   bool                        `json:"jolokiaAgentEnabled,omitempty"`
-	ManagementRBACEnabled bool                        `json:"managementRBACEnabled,omitempty"`
-	ExtraMounts           ExtraMountsType             `json:"extraMounts,omitempty"`
-	Clustered             *bool                       `json:"clustered,omitempty"`
-	PodSecurity           PodSecurityType             `json:"podSecurity,omitempty"`
-	LivenessProbe         LivenessProbeType           `json:"livenessProbe,omitempty"`
-	ReadinessProbe        ReadinessProbeType          `json:"readinessProbe,omitempty"`
-	EnableMetricsPlugin   *bool                       `json:"enableMetricsPlugin,omitempty"`
+	//The image used for the broker, all upgrades are disabled. Needs a corresponding initImage
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Image",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	Image string `json:"image,omitempty"`
+	// The init container image used to configure broker, all upgrades are disabled. Needs a corresponding image
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Init Image",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	InitImage string `json:"initImage,omitempty"`
+	// The number of broker pods to deploy
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Size",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:podCount"}
+	Size *int32 `json:"size,omitempty"`
+	// If true require user password login credentials for broker protocol ports
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Require Login",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	RequireLogin bool `json:"requireLogin,omitempty"`
+	// If true use persistent volume via persistent volume claim for journal storage
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Persistence Enabled",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	PersistenceEnabled bool `json:"persistenceEnabled,omitempty"`
+	// If aio use ASYNCIO, if nio use NIO for journal IO
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Journal Type",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	JournalType string `json:"journalType,omitempty"`
+	//If true migrate messages on scaledown
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Message Migration",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	MessageMigration *bool `json:"messageMigration,omitempty"`
+	// Specifies the minimum/maximum amount of compute resources required/allowed
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Resource Requirements",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:resourceRequirements"}
+	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
+	// Specifies the storage configurations
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Storage Configurations"
+	Storage StorageType `json:"storage,omitempty"`
+	// If true enable the Jolokia JVM Agent
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Jolokia Agent Enabled",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	JolokiaAgentEnabled bool `json:"jolokiaAgentEnabled,omitempty"`
+	// If true enable the management role based access control
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Management RBAC Enabled",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	ManagementRBACEnabled bool `json:"managementRBACEnabled,omitempty"`
+	// Specifies extra mounts
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Extra Mounts"
+	ExtraMounts ExtraMountsType `json:"extraMounts,omitempty"`
+	// Whether broker is clustered
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Clustered",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	Clustered *bool `json:"clustered,omitempty"`
+	// Specifies the pod security configurations
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Pod Security Configurations"
+	PodSecurity PodSecurityType `json:"podSecurity,omitempty"`
+	// Specifies the liveness probe configuration
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Liveness Probe Configurations"
+	LivenessProbe LivenessProbeType `json:"livenessProbe,omitempty"`
+	// Specifies the readiness probe configuration
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Readiness Probe Configurations"
+	ReadinessProbe ReadinessProbeType `json:"readinessProbe,omitempty"`
+	// Whether or not to install the artemis metrics plugin
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Enable Metrics Plugin",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	EnableMetricsPlugin *bool `json:"enableMetricsPlugin,omitempty"`
 }
 
 type LivenessProbeType struct {
@@ -145,75 +327,166 @@ type ReadinessProbeType struct {
 }
 
 type PodSecurityType struct {
+	// ServiceAccount Name of the pod
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Service Account Name",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	ServiceAccountName *string `json:"serviceAccountName,omitempty"`
-	RunAsUser          *int64  `json:"runAsUser,omitempty"`
+	// runAsUser as defined in PodSecurityContext for the pod
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Run As User",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	RunAsUser *int64 `json:"runAsUser,omitempty"`
 }
 
 type ExtraMountsType struct {
+	// Specifies ConfigMap names
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="ConfigMap Names"
 	ConfigMaps []string `json:"configMaps,omitempty"`
-	Secrets    []string `json:"secrets,omitempty"`
+	// Specifies Secret names
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Secret Names"
+	Secrets []string `json:"secrets,omitempty"`
 }
 
 type StorageType struct {
+	// The storage size
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Size",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	Size string `json:"size,omitempty"`
 }
 
 type AcceptorType struct {
-	Name                              string `json:"name"`
-	Port                              int32  `json:"port,omitempty"`
-	Protocols                         string `json:"protocols,omitempty"`
-	SSLEnabled                        bool   `json:"sslEnabled,omitempty"`
-	SSLSecret                         string `json:"sslSecret,omitempty"`
-	EnabledCipherSuites               string `json:"enabledCipherSuites,omitempty"`
-	EnabledProtocols                  string `json:"enabledProtocols,omitempty"`
-	NeedClientAuth                    bool   `json:"needClientAuth,omitempty"`
-	WantClientAuth                    bool   `json:"wantClientAuth,omitempty"`
-	VerifyHost                        bool   `json:"verifyHost,omitempty"`
-	SSLProvider                       string `json:"sslProvider,omitempty"`
-	SNIHost                           string `json:"sniHost,omitempty"`
-	Expose                            bool   `json:"expose,omitempty"`
-	AnycastPrefix                     string `json:"anycastPrefix,omitempty"`
-	MulticastPrefix                   string `json:"multicastPrefix,omitempty"`
-	ConnectionsAllowed                int    `json:"connectionsAllowed,omitempty"`
-	AMQPMinLargeMessageSize           int    `json:"amqpMinLargeMessageSize,omitempty"`
-	SupportAdvisory                   *bool  `json:"supportAdvisory,omitempty"`
-	SuppressInternalManagementObjects *bool  `json:"suppressInternalManagementObjects,omitempty"`
+	// The acceptor name
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Name",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	Name string `json:"name"`
+	// Port number
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Port",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	Port int32 `json:"port,omitempty"`
+	// The protocols to enable for this acceptor
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Protocols",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	Protocols string `json:"protocols,omitempty"`
+	// Whether or not to enable SSL on this port
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="SSL Enabled",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	SSLEnabled bool `json:"sslEnabled,omitempty"`
+	// Name of the secret to use for ssl information
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="SSL Secret",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	SSLSecret string `json:"sslSecret,omitempty"`
+	// Comma separated list of cipher suites used for SSL communication.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Enabled Cipher Suites",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	EnabledCipherSuites string `json:"enabledCipherSuites,omitempty"`
+	// Comma separated list of protocols used for SSL communication.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Enabled Protocols",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	EnabledProtocols string `json:"enabledProtocols,omitempty"`
+	// Tells a client connecting to this acceptor that 2-way SSL is required. This property takes precedence over wantClientAuth.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Need Client Auth",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	NeedClientAuth bool `json:"needClientAuth,omitempty"`
+	// Tells a client connecting to this acceptor that 2-way SSL is requested but not required. Overridden by needClientAuth.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Want Client Auth",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	WantClientAuth bool `json:"wantClientAuth,omitempty"`
+	// The CN of the connecting client's SSL certificate will be compared to its hostname to verify they match. This is useful only for 2-way SSL.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Verify Host",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	VerifyHost bool `json:"verifyHost,omitempty"`
+	// Used to change the SSL Provider between JDK and OPENSSL. The default is JDK.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="SSL Provider",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	SSLProvider string `json:"sslProvider,omitempty"`
+	// A regular expression used to match the server_name extension on incoming SSL connections. If the name doesn't match then the connection to the acceptor will be rejected.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="SNI Host",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	SNIHost string `json:"sniHost,omitempty"`
+	// Whether or not to expose this acceptor
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Expose",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	Expose bool `json:"expose,omitempty"`
+	// To indicate which kind of routing type to use.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Anycast Prefix",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	AnycastPrefix string `json:"anycastPrefix,omitempty"`
+	// To indicate which kind of routing type to use
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Multicast Prefix",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	MulticastPrefix string `json:"multicastPrefix,omitempty"`
+	// Max number of connections allowed to make
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Connections Allowed",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	ConnectionsAllowed int `json:"connectionsAllowed,omitempty"`
+	// AMQP Minimum Large Message Size
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="AMQP Min Large Message Size",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	AMQPMinLargeMessageSize int `json:"amqpMinLargeMessageSize,omitempty"`
+	// For openwire protocol if advisory topics are enabled, default false
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Support Advisory",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	SupportAdvisory *bool `json:"supportAdvisory,omitempty"`
+	// If prevents advisory addresses/queues to be registered to management service, default false
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Suppress Internal Management Objects",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	SuppressInternalManagementObjects *bool `json:"suppressInternalManagementObjects,omitempty"`
 }
 
 type ConnectorType struct {
-	Name                string `json:"name"`
-	Type                string `json:"type,omitempty"`
-	Host                string `json:"host"`
-	Port                int32  `json:"port"`
-	SSLEnabled          bool   `json:"sslEnabled,omitempty"`
-	SSLSecret           string `json:"sslSecret,omitempty"`
+	// The name of the connector
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Name",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	Name string `json:"name"`
+	// The type either tcp or vm
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Type",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	Type string `json:"type,omitempty"`
+	// Hostname or IP to connect to
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Host",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	Host string `json:"host"`
+	// Port number
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Port",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	Port int32 `json:"port"`
+	//  Whether or not to enable SSL on this port
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="SSL Enabled",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	SSLEnabled bool `json:"sslEnabled,omitempty"`
+	// Name of the secret to use for ssl information
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="SSL Secret",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	SSLSecret string `json:"sslSecret,omitempty"`
+	// Comma separated list of cipher suites used for SSL communication.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Enabled Cipher Suites",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	EnabledCipherSuites string `json:"enabledCipherSuites,omitempty"`
-	EnabledProtocols    string `json:"enabledProtocols,omitempty"`
-	NeedClientAuth      bool   `json:"needClientAuth,omitempty"`
-	WantClientAuth      bool   `json:"wantClientAuth,omitempty"`
-	VerifyHost          bool   `json:"verifyHost,omitempty"`
-	SSLProvider         string `json:"sslProvider,omitempty"`
-	SNIHost             string `json:"sniHost,omitempty"`
-	Expose              bool   `json:"expose,omitempty"`
+	// Comma separated list of protocols used for SSL communication.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Enabled Protocols",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	EnabledProtocols string `json:"enabledProtocols,omitempty"`
+	// Tells a client connecting to this connector that 2-way SSL is required. This property takes precedence over wantClientAuth.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Need Client Auth",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	NeedClientAuth bool `json:"needClientAuth,omitempty"`
+	// Tells a client connecting to this connector that 2-way SSL is requested but not required. Overridden by needClientAuth.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Want Client Auth",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	WantClientAuth bool `json:"wantClientAuth,omitempty"`
+	// The CN of the connecting client's SSL certificate will be compared to its hostname to verify they match. This is useful only for 2-way SSL.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Verify Host",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	VerifyHost bool `json:"verifyHost,omitempty"`
+	// Used to change the SSL Provider between JDK and OPENSSL. The default is JDK.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="SSL Provider",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	SSLProvider string `json:"sslProvider,omitempty"`
+	// A regular expression used to match the server_name extension on incoming SSL connections. If the name doesn't match then the connection to the acceptor will be rejected.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="SNI Host",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	SNIHost string `json:"sniHost,omitempty"`
+	// Whether or not to expose this connector
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Expose",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	Expose bool `json:"expose,omitempty"`
 }
 
 type ConsoleType struct {
-	Expose        bool   `json:"expose,omitempty"`
-	SSLEnabled    bool   `json:"sslEnabled,omitempty"`
-	SSLSecret     string `json:"sslSecret,omitempty"`
-	UseClientAuth bool   `json:"useClientAuth,omitempty"`
+	// Whether or not to expose this port
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Expose",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	Expose bool `json:"expose,omitempty"`
+	// Whether or not to enable SSL on this port
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="SSL Enabled",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	SSLEnabled bool `json:"sslEnabled,omitempty"`
+	// Name of the secret to use for ssl information
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="SSL Secret",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	SSLSecret string `json:"sslSecret,omitempty"`
+	// If the embedded server requires client authentication
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Use Client Auth",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	UseClientAuth bool `json:"useClientAuth,omitempty"`
 }
 
 // ActiveMQArtemis App product upgrade flags
 type ActiveMQArtemisUpgrades struct {
+	// Set true to enable automatic micro version product upgrades, it is disabled by default.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Enable Upgrades",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:ui:booleanSwitch"}
 	Enabled bool `json:"enabled"`
-	Minor   bool `json:"minor"`
+	// Set true to enable automatic minor product version upgrades, it is disabled by default. Requires spec.upgrades.enabled to be true.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Include minor version upgrades",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldDependency:upgrades.enabled:true","urn:alm:descriptor:com.tectonic.ui:ui:booleanSwitch"}
+	Minor bool `json:"minor"`
 }
 
 // ActiveMQArtemisStatus defines the observed state of ActiveMQArtemis
 type ActiveMQArtemisStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
+
+	// The current pods
+	//+operator-sdk:csv:customresourcedefinitions:type=status,displayName="Pods Status",xDescriptors="urn:alm:descriptor:com.tectonic.ui:podStatuses"
 	PodStatus olm.DeploymentStatus `json:"podStatus"`
 
 	// Current state of the resource
@@ -231,7 +504,8 @@ type ActiveMQArtemisStatus struct {
 //+kubebuilder:resource:path=activemqartemises,shortName=aa
 //+operator-sdk:csv:customresourcedefinitions:resources={{"Secret", "v1"}}
 
-// ActiveMQArtemis is the Schema for the activemqartemises API
+// A stateful deployment of one or more brokers
+// +operator-sdk:csv:customresourcedefinitions:displayName="ActiveMQ Artemis"
 type ActiveMQArtemis struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/bundle/manifests/activemq-artemis-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/activemq-artemis-operator.clusterserviceversion.yaml
@@ -486,15 +486,30 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:io.kubernetes.conditions
       version: v1beta1
-    - description: ActiveMQArtemisAddress is the Schema for the activemqartemisaddresses
-        API
-      displayName: Active MQArtemis Address
+    - description: Adding and removing addresses using custom resource definitions
+      displayName: ActiveMQ Artemis Address
       kind: ActiveMQArtemisAddress
       name: activemqartemisaddresses.broker.amq.io
       resources:
       - kind: Secret
         name: ""
         version: v1
+      specDescriptors:
+      - description: The Address Name
+        displayName: Address Name
+        path: addressName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The Queue Name
+        displayName: Queue Name
+        path: queueName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The Routing Type
+        displayName: Routing Type
+        path: routingType
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
       statusDescriptors:
       - description: Current state of the resource Conditions represent the latest
           available observations of an object's state
@@ -503,15 +518,36 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:io.kubernetes.conditions
       version: v2alpha1
-    - description: ActiveMQArtemisAddress is the Schema for the activemqartemisaddresses
-        API
-      displayName: Active MQArtemis Address
+    - description: Adding and removing addresses using custom resource definitions
+      displayName: ActiveMQ Artemis Address
       kind: ActiveMQArtemisAddress
       name: activemqartemisaddresses.broker.amq.io
       resources:
       - kind: Secret
         name: ""
         version: v1
+      specDescriptors:
+      - description: The Address Name
+        displayName: Address Name
+        path: addressName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The Queue Name
+        displayName: Queue Name
+        path: queueName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Whether or not delete the queue from broker when CR is undeployed(default
+          false)
+        displayName: Remove From Broker On Delete
+        path: removeFromBrokerOnDelete
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: The Routing Type
+        displayName: Routing Type
+        path: routingType
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
       statusDescriptors:
       - description: Current state of the resource Conditions represent the latest
           available observations of an object's state
@@ -520,15 +556,186 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:io.kubernetes.conditions
       version: v2alpha2
-    - description: ActiveMQArtemisAddress is the Schema for the activemqartemisaddresses
-        API
-      displayName: Active MQArtemis Address
+    - description: Adding and removing addresses using custom resource definitions
+      displayName: ActiveMQ Artemis Address
       kind: ActiveMQArtemisAddress
       name: activemqartemisaddresses.broker.amq.io
       resources:
       - kind: Secret
         name: ""
         version: v1
+      specDescriptors:
+      - description: The Address Name
+        displayName: Address Name
+        path: addressName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Apply to the broker crs in the current namespace. A value of
+          * or empty string means applying to all broker crs. Default apply to all
+          broker crs
+        displayName: Apply To Broker CR Names
+        path: applyToCrNames
+      - description: The password for the user
+        displayName: Password
+        path: password
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:password
+      - description: Specify the queue configuration
+        displayName: Queue Configuration
+        path: queueConfiguration
+      - description: Whether auto create address
+        displayName: Auto Create Address
+        path: queueConfiguration.autoCreateAddress
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Auto-delete the queue
+        displayName: Auto Delete
+        path: queueConfiguration.autoDelete
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Delay (Milliseconds) before auto-delete the queue
+        displayName: Auto Delete Delay
+        path: queueConfiguration.autoDeleteDelay
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: Message count of the queue to allow auto delete
+        displayName: Auto Delete Message Count
+        path: queueConfiguration.autoDeleteMessageCount
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: If the queue is configuration managed
+        displayName: Configuration Managed
+        path: queueConfiguration.configurationManaged
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Consumer Priority
+        displayName: Consumer Priority
+        path: queueConfiguration.consumerPriority
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: Number of consumers required before dispatching messages
+        displayName: Consumers Before Dispatch
+        path: queueConfiguration.consumersBeforeDispatch
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: Milliseconds to wait for `consumers-before-dispatch` to be met
+          before dispatching messages anyway
+        displayName: Delay Before Dispatch
+        path: queueConfiguration.delayBeforeDispatch
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: If the queue is durable or not
+        displayName: Durable
+        path: queueConfiguration.durable
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: If the queue is enabled
+        displayName: Enabled
+        path: queueConfiguration.enabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: If the queue is exclusive
+        displayName: Exclusive
+        path: queueConfiguration.exclusive
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: The filter string for the queue
+        displayName: Filter String
+        path: queueConfiguration.filterString
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Number of messaging group buckets
+        displayName: Group Buckets
+        path: queueConfiguration.groupBuckets
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: Header set on the first group message
+        displayName: Group First Key
+        path: queueConfiguration.groupFirstKey
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: If rebalance the message group
+        displayName: Group Rebalance
+        path: queueConfiguration.groupRebalance
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: If pause message dispatch when rebalancing groups
+        displayName: Group Rebalance Pause Dispatch
+        path: queueConfiguration.groupRebalancePauseDispatch
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: If ignore if the target queue already exists
+        displayName: Ignore If Exists
+        path: queueConfiguration.ignoreIfExists
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: If it is a last value queue
+        displayName: Last Value
+        path: queueConfiguration.lastValue
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: The property used for last value queue to identify last values
+        displayName: Last Value Key
+        path: queueConfiguration.lastValueKey
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Max number of consumers allowed on this queue
+        displayName: Max Consumers
+        path: queueConfiguration.maxConsumers
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: If force non-destructive consumers on the queue
+        displayName: Non Destructive
+        path: queueConfiguration.nonDestructive
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Whether to delete all messages when no consumers connected to
+          the queue
+        displayName: Purge On No Consumers
+        path: queueConfiguration.purgeOnNoConsumers
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: The size the queue should maintain according to ring semantics
+        displayName: Ring Size
+        path: queueConfiguration.ringSize
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: The routing type of the queue
+        displayName: Routing Type
+        path: queueConfiguration.routingType
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: If the queue is temporary
+        displayName: Temporary
+        path: queueConfiguration.temporary
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: The user associated with the queue
+        displayName: User
+        path: queueConfiguration.user
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The Queue Name
+        displayName: Queue Name
+        path: queueName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Whether or not delete the queue from broker when CR is undeployed(default
+          false)
+        displayName: Remove From Broker On Delete
+        path: removeFromBrokerOnDelete
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: The Routing Type
+        displayName: Routing Type
+        path: routingType
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: User name for creating the queue or address
+        displayName: User
+        path: user
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
       statusDescriptors:
       - description: Current state of the resource Conditions represent the latest
           available observations of an object's state
@@ -1589,14 +1796,254 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:org.w3:link
       version: v1beta1
-    - description: ActiveMQArtemis is the Schema for the activemqartemises API
-      displayName: Active MQArtemis
+    - description: A stateful deployment of one or more brokers
+      displayName: ActiveMQ Artemis
       kind: ActiveMQArtemis
       name: activemqartemises.broker.amq.io
       resources:
       - kind: Secret
         name: ""
         version: v1
+      specDescriptors:
+      - description: Specifies the acceptor configuration
+        displayName: Acceptors
+        path: acceptors
+      - description: To indicate which kind of routing type to use.
+        displayName: Anycast Prefix
+        path: acceptors[0].anycastPrefix
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Max number of connections allowed to make
+        displayName: Connections Allowed
+        path: acceptors[0].connectionsAllowed
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: Comma separated list of cipher suites used for SSL communication.
+        displayName: Enabled Cipher Suites
+        path: acceptors[0].enabledCipherSuites
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Comma separated list of protocols used for SSL communication.
+        displayName: Enabled Protocols
+        path: acceptors[0].enabledProtocols
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Whether or not to expose this acceptor
+        displayName: Expose
+        path: acceptors[0].expose
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: To indicate which kind of routing type to use
+        displayName: Multicast Prefix
+        path: acceptors[0].multicastPrefix
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The acceptor name
+        displayName: Name
+        path: acceptors[0].name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Tells a client connecting to this acceptor that 2-way SSL is
+          required. This property takes precedence over wantClientAuth.
+        displayName: Need Client Auth
+        path: acceptors[0].needClientAuth
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Port number
+        displayName: Port
+        path: acceptors[0].port
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: The protocols to enable for this acceptor
+        displayName: Protocols
+        path: acceptors[0].protocols
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: A regular expression used to match the server_name extension
+          on incoming SSL connections. If the name doesn't match then the connection
+          to the acceptor will be rejected.
+        displayName: SNI Host
+        path: acceptors[0].sniHost
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Whether or not to enable SSL on this port
+        displayName: SSL Enabled
+        path: acceptors[0].sslEnabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Used to change the SSL Provider between JDK and OPENSSL. The
+          default is JDK.
+        displayName: SSL Provider
+        path: acceptors[0].sslProvider
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Name of the secret to use for ssl information
+        displayName: SSL Secret
+        path: acceptors[0].sslSecret
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The CN of the connecting client's SSL certificate will be compared
+          to its hostname to verify they match. This is useful only for 2-way SSL.
+        displayName: Verify Host
+        path: acceptors[0].verifyHost
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Tells a client connecting to this acceptor that 2-way SSL is
+          requested but not required. Overridden by needClientAuth.
+        displayName: Want Client Auth
+        path: acceptors[0].wantClientAuth
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Password for standard broker user. It is required for connecting
+          to the broker and the web console. If left empty, it will be generated.
+        displayName: Admin Password
+        path: adminPassword
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:password
+      - description: User name for standard broker user. It is required for connecting
+          to the broker and the web console. If left empty, it will be generated.
+        displayName: Admin User
+        path: adminUser
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Specifies connectors and connector configuration
+        displayName: Connectors
+        path: connectors
+      - description: Comma separated list of cipher suites used for SSL communication.
+        displayName: Enabled Cipher Suites
+        path: connectors[0].enabledCipherSuites
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Comma separated list of protocols used for SSL communication.
+        displayName: Enabled Protocols
+        path: connectors[0].enabledProtocols
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Whether or not to expose this connector
+        displayName: Expose
+        path: connectors[0].expose
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Hostname or IP to connect to
+        displayName: Host
+        path: connectors[0].host
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The name of the connector
+        displayName: Name
+        path: connectors[0].name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Tells a client connecting to this connector that 2-way SSL is
+          required. This property takes precedence over wantClientAuth.
+        displayName: Need Client Auth
+        path: connectors[0].needClientAuth
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Port number
+        displayName: Port
+        path: connectors[0].port
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: A regular expression used to match the server_name extension
+          on incoming SSL connections. If the name doesn't match then the connection
+          to the acceptor will be rejected.
+        displayName: SNI Host
+        path: connectors[0].sniHost
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Whether or not to enable SSL on this port
+        displayName: SSL Enabled
+        path: connectors[0].sslEnabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Used to change the SSL Provider between JDK and OPENSSL. The
+          default is JDK.
+        displayName: SSL Provider
+        path: connectors[0].sslProvider
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Name of the secret to use for ssl information
+        displayName: SSL Secret
+        path: connectors[0].sslSecret
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The type either tcp or vm
+        displayName: Type
+        path: connectors[0].type
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The CN of the connecting client's SSL certificate will be compared
+          to its hostname to verify they match. This is useful only for 2-way SSL.
+        displayName: Verify Host
+        path: connectors[0].verifyHost
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Tells a client connecting to this connector that 2-way SSL is
+          requested but not required. Overridden by needClientAuth.
+        displayName: Want Client Auth
+        path: connectors[0].wantClientAuth
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Specifies the console configuration
+        displayName: Console Configurations
+        path: console
+      - description: Whether or not to expose this port
+        displayName: Expose
+        path: console.expose
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Whether or not to enable SSL on this port
+        displayName: SSL Enabled
+        path: console.sslEnabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Name of the secret to use for ssl information
+        displayName: SSL Secret
+        path: console.sslSecret
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: If the embedded server requires client authentication
+        displayName: Use Client Auth
+        path: console.useClientAuth
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Specifies the deployment plan
+        displayName: Deployment Plan
+        path: deploymentPlan
+      - description: The image used for the broker, all upgrades are disabled. Needs
+          a corresponding initImage
+        displayName: Image
+        path: deploymentPlan.image
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: If aio use ASYNCIO, if nio use NIO for journal IO
+        displayName: Journal Type
+        path: deploymentPlan.journalType
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: If true migrate messages on scaledown
+        displayName: Message Migration
+        path: deploymentPlan.messageMigration
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: If true use persistent volume via persistent volume claim for
+          journal storage
+        displayName: Persistence Enabled
+        path: deploymentPlan.persistenceEnabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: If true require user password login credentials for broker protocol
+          ports
+        displayName: Require Login
+        path: deploymentPlan.requireLogin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: The number of broker pods to deploy
+        displayName: Size
+        path: deploymentPlan.size
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podCount
       statusDescriptors:
       - description: Current state of the resource Conditions represent the latest
           available observations of an object's state
@@ -1605,14 +2052,276 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:io.kubernetes.conditions
       version: v2alpha1
-    - description: ActiveMQArtemis is the Schema for the activemqartemises API
-      displayName: Active MQArtemis
+    - description: A stateful deployment of one or more brokers
+      displayName: ActiveMQ Artemis
       kind: ActiveMQArtemis
       name: activemqartemises.broker.amq.io
       resources:
       - kind: Secret
         name: ""
         version: v1
+      specDescriptors:
+      - description: Specifies the acceptor configuration
+        displayName: Acceptors
+        path: acceptors
+      - description: To indicate which kind of routing type to use.
+        displayName: Anycast Prefix
+        path: acceptors[0].anycastPrefix
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Max number of connections allowed to make
+        displayName: Connections Allowed
+        path: acceptors[0].connectionsAllowed
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: Comma separated list of cipher suites used for SSL communication.
+        displayName: Enabled Cipher Suites
+        path: acceptors[0].enabledCipherSuites
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Comma separated list of protocols used for SSL communication.
+        displayName: Enabled Protocols
+        path: acceptors[0].enabledProtocols
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Whether or not to expose this acceptor
+        displayName: Expose
+        path: acceptors[0].expose
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: To indicate which kind of routing type to use
+        displayName: Multicast Prefix
+        path: acceptors[0].multicastPrefix
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The acceptor name
+        displayName: Name
+        path: acceptors[0].name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Tells a client connecting to this acceptor that 2-way SSL is
+          required. This property takes precedence over wantClientAuth.
+        displayName: Need Client Auth
+        path: acceptors[0].needClientAuth
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Port number
+        displayName: Port
+        path: acceptors[0].port
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: The protocols to enable for this acceptor
+        displayName: Protocols
+        path: acceptors[0].protocols
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: A regular expression used to match the server_name extension
+          on incoming SSL connections. If the name doesn't match then the connection
+          to the acceptor will be rejected.
+        displayName: SNI Host
+        path: acceptors[0].sniHost
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Whether or not to enable SSL on this port
+        displayName: SSL Enabled
+        path: acceptors[0].sslEnabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Used to change the SSL Provider between JDK and OPENSSL. The
+          default is JDK.
+        displayName: SSL Provider
+        path: acceptors[0].sslProvider
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Name of the secret to use for ssl information
+        displayName: SSL Secret
+        path: acceptors[0].sslSecret
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The CN of the connecting client's SSL certificate will be compared
+          to its hostname to verify they match. This is useful only for 2-way SSL.
+        displayName: Verify Host
+        path: acceptors[0].verifyHost
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Tells a client connecting to this acceptor that 2-way SSL is
+          requested but not required. Overridden by needClientAuth.
+        displayName: Want Client Auth
+        path: acceptors[0].wantClientAuth
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Password for standard broker user. It is required for connecting
+          to the broker and the web console. If left empty, it will be generated.
+        displayName: Admin Password
+        path: adminPassword
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:password
+      - description: User name for standard broker user. It is required for connecting
+          to the broker and the web console. If left empty, it will be generated.
+        displayName: Admin User
+        path: adminUser
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Specifies connectors and connector configuration
+        displayName: Connectors
+        path: connectors
+      - description: Comma separated list of cipher suites used for SSL communication.
+        displayName: Enabled Cipher Suites
+        path: connectors[0].enabledCipherSuites
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Comma separated list of protocols used for SSL communication.
+        displayName: Enabled Protocols
+        path: connectors[0].enabledProtocols
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Whether or not to expose this connector
+        displayName: Expose
+        path: connectors[0].expose
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Hostname or IP to connect to
+        displayName: Host
+        path: connectors[0].host
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The name of the connector
+        displayName: Name
+        path: connectors[0].name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Tells a client connecting to this connector that 2-way SSL is
+          required. This property takes precedence over wantClientAuth.
+        displayName: Need Client Auth
+        path: connectors[0].needClientAuth
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Port number
+        displayName: Port
+        path: connectors[0].port
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: A regular expression used to match the server_name extension
+          on incoming SSL connections. If the name doesn't match then the connection
+          to the acceptor will be rejected.
+        displayName: SNI Host
+        path: connectors[0].sniHost
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Whether or not to enable SSL on this port
+        displayName: SSL Enabled
+        path: connectors[0].sslEnabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Used to change the SSL Provider between JDK and OPENSSL. The
+          default is JDK.
+        displayName: SSL Provider
+        path: connectors[0].sslProvider
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Name of the secret to use for ssl information
+        displayName: SSL Secret
+        path: connectors[0].sslSecret
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The type either tcp or vm
+        displayName: Type
+        path: connectors[0].type
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The CN of the connecting client's SSL certificate will be compared
+          to its hostname to verify they match. This is useful only for 2-way SSL.
+        displayName: Verify Host
+        path: connectors[0].verifyHost
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Tells a client connecting to this connector that 2-way SSL is
+          requested but not required. Overridden by needClientAuth.
+        displayName: Want Client Auth
+        path: connectors[0].wantClientAuth
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Specifies the console configuration
+        displayName: Console Configurations
+        path: console
+      - description: Whether or not to expose this port
+        displayName: Expose
+        path: console.expose
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Whether or not to enable SSL on this port
+        displayName: SSL Enabled
+        path: console.sslEnabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Name of the secret to use for ssl information
+        displayName: SSL Secret
+        path: console.sslSecret
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: If the embedded server requires client authentication
+        displayName: Use Client Auth
+        path: console.useClientAuth
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Specifies the deployment plan
+        displayName: Deployment Plan
+        path: deploymentPlan
+      - description: The image used for the broker, all upgrades are disabled. Needs
+          a corresponding initImage
+        displayName: Image
+        path: deploymentPlan.image
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: If aio use ASYNCIO, if nio use NIO for journal IO
+        displayName: Journal Type
+        path: deploymentPlan.journalType
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: If true migrate messages on scaledown
+        displayName: Message Migration
+        path: deploymentPlan.messageMigration
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: If true use persistent volume via persistent volume claim for
+          journal storage
+        displayName: Persistence Enabled
+        path: deploymentPlan.persistenceEnabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: If true require user password login credentials for broker protocol
+          ports
+        displayName: Require Login
+        path: deploymentPlan.requireLogin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: The number of broker pods to deploy
+        displayName: Size
+        path: deploymentPlan.size
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podCount
+      - description: Specifies the upgrades (deprecated in favour of Version)
+        displayName: Upgrades
+        path: upgrades
+      - description: Set true to enable automatic micro version product upgrades,
+          it is disabled by default.
+        displayName: Enable Upgrades
+        path: upgrades.enabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:ui:booleanSwitch
+      - description: Set true to enable automatic minor product version upgrades,
+          it is disabled by default. Requires spec.upgrades.enabled to be true.
+        displayName: Include minor version upgrades
+        path: upgrades.minor
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:upgrades.enabled:true
+        - urn:alm:descriptor:com.tectonic.ui:ui:booleanSwitch
+      - description: The desired version of the broker. Can be x, or x.y or x.y.z
+          to configure upgrades
+        displayName: Version
+        path: version
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
       statusDescriptors:
       - description: Current state of the resource Conditions represent the latest
           available observations of an object's state
@@ -1621,14 +2330,652 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:io.kubernetes.conditions
       version: v2alpha2
-    - description: ActiveMQArtemis is the Schema for the activemqartemises API
-      displayName: Active MQArtemis
+    - description: A stateful deployment of one or more brokers
+      displayName: ActiveMQ Artemis
       kind: ActiveMQArtemis
       name: activemqartemises.broker.amq.io
       resources:
       - kind: Secret
         name: ""
         version: v1
+      specDescriptors:
+      - description: Specifies the acceptor configuration
+        displayName: Acceptors
+        path: acceptors
+      - description: AMQP Minimum Large Message Size
+        displayName: AMQP Min Large Message Size
+        path: acceptors[0].amqpMinLargeMessageSize
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: To indicate which kind of routing type to use.
+        displayName: Anycast Prefix
+        path: acceptors[0].anycastPrefix
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Max number of connections allowed to make
+        displayName: Connections Allowed
+        path: acceptors[0].connectionsAllowed
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: Comma separated list of cipher suites used for SSL communication.
+        displayName: Enabled Cipher Suites
+        path: acceptors[0].enabledCipherSuites
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Comma separated list of protocols used for SSL communication.
+        displayName: Enabled Protocols
+        path: acceptors[0].enabledProtocols
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Whether or not to expose this acceptor
+        displayName: Expose
+        path: acceptors[0].expose
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: To indicate which kind of routing type to use
+        displayName: Multicast Prefix
+        path: acceptors[0].multicastPrefix
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The acceptor name
+        displayName: Name
+        path: acceptors[0].name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Tells a client connecting to this acceptor that 2-way SSL is
+          required. This property takes precedence over wantClientAuth.
+        displayName: Need Client Auth
+        path: acceptors[0].needClientAuth
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Port number
+        displayName: Port
+        path: acceptors[0].port
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: The protocols to enable for this acceptor
+        displayName: Protocols
+        path: acceptors[0].protocols
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: A regular expression used to match the server_name extension
+          on incoming SSL connections. If the name doesn't match then the connection
+          to the acceptor will be rejected.
+        displayName: SNI Host
+        path: acceptors[0].sniHost
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Whether or not to enable SSL on this port
+        displayName: SSL Enabled
+        path: acceptors[0].sslEnabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Used to change the SSL Provider between JDK and OPENSSL. The
+          default is JDK.
+        displayName: SSL Provider
+        path: acceptors[0].sslProvider
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Name of the secret to use for ssl information
+        displayName: SSL Secret
+        path: acceptors[0].sslSecret
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The CN of the connecting client's SSL certificate will be compared
+          to its hostname to verify they match. This is useful only for 2-way SSL.
+        displayName: Verify Host
+        path: acceptors[0].verifyHost
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Tells a client connecting to this acceptor that 2-way SSL is
+          requested but not required. Overridden by needClientAuth.
+        displayName: Want Client Auth
+        path: acceptors[0].wantClientAuth
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Specifies the address configurations (deprecated in favour of
+          BrokerProperties)
+        displayName: Address Configurations
+        path: addressSettings
+      - description: Specifies the address settings
+        displayName: Address Settings
+        path: addressSettings.addressSetting
+      - description: what happens when an address where maxSizeBytes is specified
+          becomes full
+        displayName: Address Full Policy
+        path: addressSettings.addressSetting[0].addressFullPolicy
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: whether or not to automatically create addresses when a client
+          sends a message to or attempts to consume a message from a queue mapped
+          to an address that doesnt exist
+        displayName: Auto Create Addresses
+        path: addressSettings.addressSetting[0].autoCreateAddresses
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: whether or not to automatically create the dead-letter-address
+          and/or a corresponding queue on that address when a message found to be
+          undeliverable
+        displayName: AutoCreateDeadLetterResources
+        path: addressSettings.addressSetting[0].autoCreateDeadLetterResources
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: whether or not to automatically create the expiry-address and/or
+          a corresponding queue on that address when a message is sent to a matching
+          queue
+        displayName: Auto Create Expiry Resources
+        path: addressSettings.addressSetting[0].autoCreateExpiryResources
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: DEPRECATED. whether or not to automatically create JMS queues
+          when a producer sends or a consumer connects to a queue
+        displayName: Auto Create Jms Queues
+        path: addressSettings.addressSetting[0].autoCreateJmsQueues
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: DEPRECATED. whether or not to automatically create JMS topics
+          when a producer sends or a consumer subscribes to a topic
+        displayName: Auto Create Jms Topics
+        path: addressSettings.addressSetting[0].autoCreateJmsTopics
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: whether or not to automatically create a queue when a client
+          sends a message to or attempts to consume a message from a queue
+        displayName: Auto Create Queues
+        path: addressSettings.addressSetting[0].autoCreateQueues
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: whether or not to delete auto-created addresses when it no longer
+          has any queues
+        displayName: Auto Delete Addresses
+        path: addressSettings.addressSetting[0].autoDeleteAddresses
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: how long to wait (in milliseconds) before deleting auto-created
+          addresses after they no longer have any queues
+        displayName: Auto Delete Addresses Delay
+        path: addressSettings.addressSetting[0].autoDeleteAddressesDelay
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: whether or not to delete created queues when the queue has 0
+          consumers and 0 messages
+        displayName: Auto Delete Created Queues
+        path: addressSettings.addressSetting[0].autoDeleteCreatedQueues
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: DEPRECATED. whether or not to delete auto-created JMS queues
+          when the queue has 0 consumers and 0 messages
+        displayName: Auto Delete Jms Queues
+        path: addressSettings.addressSetting[0].autoDeleteJmsQueues
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: DEPRECATED. whether or not to delete auto-created JMS topics
+          when the last subscription is closed
+        displayName: Auto Delete Jms Topics
+        path: addressSettings.addressSetting[0].autoDeleteJmsTopics
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: whether or not to delete auto-created queues when the queue has
+          0 consumers and 0 messages
+        displayName: Auto Delete Queues
+        path: addressSettings.addressSetting[0].autoDeleteQueues
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: how long to wait (in milliseconds) before deleting auto-created
+          queues after the queue has 0 consumers.
+        displayName: Auto Delete Queues Delay
+        path: addressSettings.addressSetting[0].autoDeleteQueuesDelay
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: the message count the queue must be at or below before it can
+          be evaluated to be auto deleted, 0 waits until empty queue (default) and
+          -1 disables this check.
+        displayName: Auto Delete Queues Message Count
+        path: addressSettings.addressSetting[0].autoDeleteQueuesMessageCount
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: What to do when an address is no longer in broker.xml.  OFF =
+          will do nothing addresses will remain, FORCE = delete address and its queues
+          even if messages remaining.
+        displayName: Config Delete Addresses
+        path: addressSettings.addressSetting[0].configDeleteAddresses
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: What to do when a queue is no longer in broker.xml.  OFF = will
+          do nothing queues will remain, FORCE = delete queues even if messages remaining.
+        displayName: Config Delete Queues
+        path: addressSettings.addressSetting[0].configDeleteQueues
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: the address to send dead messages to
+        displayName: Dead Letter Address
+        path: addressSettings.addressSetting[0].deadLetterAddress
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: the prefix to use for auto-created dead letter queues
+        displayName: Dead Letter Queue Prefix
+        path: addressSettings.addressSetting[0].deadLetterQueuePrefix
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: the suffix to use for auto-created dead letter queues
+        displayName: Dead Letter Queue Suffix
+        path: addressSettings.addressSetting[0].deadLetterQueueSuffix
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: the routing-type used on auto-created addresses
+        displayName: Default Address Routing Type
+        path: addressSettings.addressSetting[0].defaultAddressRoutingType
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: the default window size for a consumer
+        displayName: Default Consumer Window Size
+        path: addressSettings.addressSetting[0].defaultConsumerWindowSize
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: the default number of consumers needed before dispatch can start
+          for queues under the address.
+        displayName: Default Consumers Before Dispatch
+        path: addressSettings.addressSetting[0].defaultConsumersBeforeDispatch
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: the default delay (in milliseconds) to wait before dispatching
+          if number of consumers before dispatch is not met for queues under the address.
+        displayName: Default Delay Before Dispatch
+        path: addressSettings.addressSetting[0].defaultDelayBeforeDispatch
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: whether to treat the queues under the address as exclusive queues
+          by default
+        displayName: Default Exclusive Queue
+        path: addressSettings.addressSetting[0].defaultExclusiveQueue
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: number of buckets to use for grouping, -1 (default) is unlimited
+          and uses the raw group, 0 disables message groups.
+        displayName: Default Group Buckets
+        path: addressSettings.addressSetting[0].defaultGroupBuckets
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: key used to mark a message is first in a group for a consumer
+        displayName: Default Group First Key
+        path: addressSettings.addressSetting[0].defaultGroupFirstKey
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: whether to rebalance groups when a consumer is added
+        displayName: Default Group Rebalance
+        path: addressSettings.addressSetting[0].defaultGroupRebalance
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: whether to pause dispatch when rebalancing groups
+        displayName: Default Group Rebalance Pause Dispatch
+        path: addressSettings.addressSetting[0].defaultGroupRebalancePauseDispatch
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: the property to use as the key for a last value queue by default
+        displayName: Default Last Value Key
+        path: addressSettings.addressSetting[0].defaultLastValueKey
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: whether to treat the queues under the address as a last value
+          queues by default
+        displayName: Default Last Value Queue
+        path: addressSettings.addressSetting[0].defaultLastValueQueue
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: the maximum number of consumers allowed on this queue at any
+          one time
+        displayName: Default Max Consumers
+        path: addressSettings.addressSetting[0].defaultMaxConsumers
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: whether the queue should be non-destructive by default
+        displayName: Default Non Destructive
+        path: addressSettings.addressSetting[0].defaultNonDestructive
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: purge the contents of the queue once there are no consumers
+        displayName: Default Purge On No Consumers
+        path: addressSettings.addressSetting[0].defaultPurgeOnNoConsumers
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: the routing-type used on auto-created queues
+        displayName: Default Queue Routing Type
+        path: addressSettings.addressSetting[0].defaultQueueRoutingType
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: the default ring-size value for any matching queue which doesnt
+          have ring-size explicitly defined
+        displayName: Default Ring Size
+        path: addressSettings.addressSetting[0].defaultRingSize
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: whether or not to enable metrics for metrics plugins on the matching
+          address
+        displayName: Enable Metrics
+        path: addressSettings.addressSetting[0].enableMetrics
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: the address to send expired messages to
+        displayName: Expiry Address
+        path: addressSettings.addressSetting[0].expiryAddress
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Overrides the expiration time for messages using the default
+          value for expiration time. "-1" disables this setting.
+        displayName: Expiry Delay
+        path: addressSettings.addressSetting[0].expiryDelay
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: the prefix to use for auto-created expiry queues
+        displayName: Expiry Queue Prefix
+        path: addressSettings.addressSetting[0].expiryQueuePrefix
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: the suffix to use for auto-created expiry queues
+        displayName: Expiry Queue Suffix
+        path: addressSettings.addressSetting[0].expiryQueueSuffix
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: This is deprecated please use default-last-value-queue instead.
+        displayName: Last Value Queue
+        path: addressSettings.addressSetting[0].lastValueQueue
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: how many message a management resource can browse
+        displayName: Management Browse Page Size
+        path: addressSettings.addressSetting[0].managementBrowsePageSize
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: pattern for matching settings against addresses; can use wildards
+        displayName: Match
+        path: addressSettings.addressSetting[0].match
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: how many times to attempt to deliver a message before sending
+          to dead letter address
+        displayName: Max Delivery Attempts
+        path: addressSettings.addressSetting[0].maxDeliveryAttempts
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: Overrides the expiration time for messages using a higher value.
+          "-1" disables this setting.
+        displayName: Max Expiry Delay
+        path: addressSettings.addressSetting[0].maxExpiryDelay
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: Maximum value for the redelivery-delay
+        displayName: Max Redelivery Delay
+        path: addressSettings.addressSetting[0].maxRedeliveryDelay
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: the maximum size in bytes for an address. -1 means no limits.
+          This is used in PAGING, BLOCK and FAIL policies. Supports byte notation
+          like K, Mb, GB, etc.
+        displayName: Max Size Bytes
+        path: addressSettings.addressSetting[0].maxSizeBytes
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: used with the address full BLOCK policy, the maximum size in
+          bytes an address can reach before messages start getting rejected. Works
+          in combination with max-size-bytes for AMQP protocol only.  Default = -1
+          (no limit).
+        displayName: Max Size Bytes Reject Threshold
+        path: addressSettings.addressSetting[0].maxSizeBytesRejectThreshold
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: how many days to keep message counter history for this address
+        displayName: Message Counter History Day Limit
+        path: addressSettings.addressSetting[0].messageCounterHistoryDayLimit
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: Overrides the expiration time for messages using a lower value.
+          "-1" disables this setting.
+        displayName: Min Expiry Delay
+        path: addressSettings.addressSetting[0].minExpiryDelay
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: Number of paging files to cache in memory to avoid IO during
+          paging navigation
+        displayName: Page Max Cache Size
+        path: addressSettings.addressSetting[0].pageMaxCacheSize
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: The page size in bytes to use for an address. Supports byte notation
+          like K, Mb, GB, etc.
+        displayName: Page Size Bytes
+        path: addressSettings.addressSetting[0].pageSizeBytes
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: the time (in ms) to wait before redelivering a cancelled message.
+        displayName: Redelivery Delay
+        path: addressSettings.addressSetting[0].redeliveryDelay
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: how long (in ms) to wait after the last consumer is closed on
+          a queue before redistributing messages.
+        displayName: Redistribution Delay
+        path: addressSettings.addressSetting[0].redistributionDelay
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: the number of messages to preserve for future queues created
+          on the matching address
+        displayName: Retroactive Message Count
+        path: addressSettings.addressSetting[0].retroactiveMessageCount
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: if there are no queues matching this address, whether to forward
+          message to DLA (if it exists for this address)
+        displayName: Send To DLA On No Route
+        path: addressSettings.addressSetting[0].sendToDlaOnNoRoute
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: How often to check for slow consumers on a particular queue.
+          Measured in seconds.
+        displayName: Slow Consumer Check Period
+        path: addressSettings.addressSetting[0].slowConsumerCheckPeriod
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: what happens when a slow consumer is identified
+        displayName: Slow Consumer Policy
+        path: addressSettings.addressSetting[0].slowConsumerPolicy
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The minimum rate of message consumption allowed before a consumer
+          is considered "slow." Measured in messages-per-second.
+        displayName: Slow Consumer Threshold
+        path: addressSettings.addressSetting[0].slowConsumerThreshold
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: How to merge the address settings to broker configuration
+        displayName: Apply Rule
+        path: addressSettings.applyRule
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Password for standard broker user. It is required for connecting
+          to the broker and the web console. If left empty, it will be generated.
+        displayName: Admin Password
+        path: adminPassword
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:password
+      - description: User name for standard broker user. It is required for connecting
+          to the broker and the web console. If left empty, it will be generated.
+        displayName: Admin User
+        path: adminUser
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Specifies connectors and connector configuration
+        displayName: Connectors
+        path: connectors
+      - description: Comma separated list of cipher suites used for SSL communication.
+        displayName: Enabled Cipher Suites
+        path: connectors[0].enabledCipherSuites
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Comma separated list of protocols used for SSL communication.
+        displayName: Enabled Protocols
+        path: connectors[0].enabledProtocols
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Whether or not to expose this connector
+        displayName: Expose
+        path: connectors[0].expose
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Hostname or IP to connect to
+        displayName: Host
+        path: connectors[0].host
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The name of the connector
+        displayName: Name
+        path: connectors[0].name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Tells a client connecting to this connector that 2-way SSL is
+          required. This property takes precedence over wantClientAuth.
+        displayName: Need Client Auth
+        path: connectors[0].needClientAuth
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Port number
+        displayName: Port
+        path: connectors[0].port
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: A regular expression used to match the server_name extension
+          on incoming SSL connections. If the name doesn't match then the connection
+          to the acceptor will be rejected.
+        displayName: SNI Host
+        path: connectors[0].sniHost
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Whether or not to enable SSL on this port
+        displayName: SSL Enabled
+        path: connectors[0].sslEnabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Used to change the SSL Provider between JDK and OPENSSL. The
+          default is JDK.
+        displayName: SSL Provider
+        path: connectors[0].sslProvider
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Name of the secret to use for ssl information
+        displayName: SSL Secret
+        path: connectors[0].sslSecret
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The type either tcp or vm
+        displayName: Type
+        path: connectors[0].type
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The CN of the connecting client's SSL certificate will be compared
+          to its hostname to verify they match. This is useful only for 2-way SSL.
+        displayName: Verify Host
+        path: connectors[0].verifyHost
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Tells a client connecting to this connector that 2-way SSL is
+          requested but not required. Overridden by needClientAuth.
+        displayName: Want Client Auth
+        path: connectors[0].wantClientAuth
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Specifies the console configuration
+        displayName: Console Configurations
+        path: console
+      - description: Whether or not to expose this port
+        displayName: Expose
+        path: console.expose
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Whether or not to enable SSL on this port
+        displayName: SSL Enabled
+        path: console.sslEnabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Name of the secret to use for ssl information
+        displayName: SSL Secret
+        path: console.sslSecret
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: If the embedded server requires client authentication
+        displayName: Use Client Auth
+        path: console.useClientAuth
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Specifies the deployment plan
+        displayName: Deployment Plan
+        path: deploymentPlan
+      - description: The image used for the broker, all upgrades are disabled. Needs
+          a corresponding initImage
+        displayName: Image
+        path: deploymentPlan.image
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: If aio use ASYNCIO, if nio use NIO for journal IO
+        displayName: Journal Type
+        path: deploymentPlan.journalType
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: If true migrate messages on scaledown
+        displayName: Message Migration
+        path: deploymentPlan.messageMigration
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: If true use persistent volume via persistent volume claim for
+          journal storage
+        displayName: Persistence Enabled
+        path: deploymentPlan.persistenceEnabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: If true require user password login credentials for broker protocol
+          ports
+        displayName: Require Login
+        path: deploymentPlan.requireLogin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Specifies the minimum/maximum amount of compute resources required/allowed
+        displayName: Resource Requirements
+        path: deploymentPlan.resources
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+      - description: The number of broker pods to deploy
+        displayName: Size
+        path: deploymentPlan.size
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podCount
+      - description: Specifies the storage configurations
+        displayName: Storage Configurations
+        path: deploymentPlan.storage
+      - description: The storage size
+        displayName: Size
+        path: deploymentPlan.storage.size
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Specifies the upgrades (deprecated in favour of Version)
+        displayName: Upgrades
+        path: upgrades
+      - description: Set true to enable automatic micro version product upgrades,
+          it is disabled by default.
+        displayName: Enable Upgrades
+        path: upgrades.enabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:ui:booleanSwitch
+      - description: Set true to enable automatic minor product version upgrades,
+          it is disabled by default. Requires spec.upgrades.enabled to be true.
+        displayName: Include minor version upgrades
+        path: upgrades.minor
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:upgrades.enabled:true
+        - urn:alm:descriptor:com.tectonic.ui:ui:booleanSwitch
+      - description: The desired version of the broker. Can be x, or x.y or x.y.z
+          to configure upgrades
+        displayName: Version
+        path: version
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
       statusDescriptors:
       - description: Current state of the resource Conditions represent the latest
           available observations of an object's state
@@ -1636,15 +2983,674 @@ spec:
         path: conditions
         x-descriptors:
         - urn:alm:descriptor:io.kubernetes.conditions
+      - description: The current pods
+        displayName: Pods Status
+        path: podStatus
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podStatuses
       version: v2alpha3
-    - description: ActiveMQArtemis is the Schema for the activemqartemises API
-      displayName: Active MQArtemis
+    - description: A stateful deployment of one or more brokers
+      displayName: ActiveMQ Artemis
       kind: ActiveMQArtemis
       name: activemqartemises.broker.amq.io
       resources:
       - kind: Secret
         name: ""
         version: v1
+      specDescriptors:
+      - description: Specifies the acceptor configuration
+        displayName: Acceptors
+        path: acceptors
+      - description: AMQP Minimum Large Message Size
+        displayName: AMQP Min Large Message Size
+        path: acceptors[0].amqpMinLargeMessageSize
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: To indicate which kind of routing type to use.
+        displayName: Anycast Prefix
+        path: acceptors[0].anycastPrefix
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Max number of connections allowed to make
+        displayName: Connections Allowed
+        path: acceptors[0].connectionsAllowed
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: Comma separated list of cipher suites used for SSL communication.
+        displayName: Enabled Cipher Suites
+        path: acceptors[0].enabledCipherSuites
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Comma separated list of protocols used for SSL communication.
+        displayName: Enabled Protocols
+        path: acceptors[0].enabledProtocols
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Whether or not to expose this acceptor
+        displayName: Expose
+        path: acceptors[0].expose
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: To indicate which kind of routing type to use
+        displayName: Multicast Prefix
+        path: acceptors[0].multicastPrefix
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The acceptor name
+        displayName: Name
+        path: acceptors[0].name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Tells a client connecting to this acceptor that 2-way SSL is
+          required. This property takes precedence over wantClientAuth.
+        displayName: Need Client Auth
+        path: acceptors[0].needClientAuth
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Port number
+        displayName: Port
+        path: acceptors[0].port
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: The protocols to enable for this acceptor
+        displayName: Protocols
+        path: acceptors[0].protocols
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: A regular expression used to match the server_name extension
+          on incoming SSL connections. If the name doesn't match then the connection
+          to the acceptor will be rejected.
+        displayName: SNI Host
+        path: acceptors[0].sniHost
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Whether or not to enable SSL on this port
+        displayName: SSL Enabled
+        path: acceptors[0].sslEnabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Used to change the SSL Provider between JDK and OPENSSL. The
+          default is JDK.
+        displayName: SSL Provider
+        path: acceptors[0].sslProvider
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Name of the secret to use for ssl information
+        displayName: SSL Secret
+        path: acceptors[0].sslSecret
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The CN of the connecting client's SSL certificate will be compared
+          to its hostname to verify they match. This is useful only for 2-way SSL.
+        displayName: Verify Host
+        path: acceptors[0].verifyHost
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Tells a client connecting to this acceptor that 2-way SSL is
+          requested but not required. Overridden by needClientAuth.
+        displayName: Want Client Auth
+        path: acceptors[0].wantClientAuth
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Specifies the address configurations (deprecated in favour of
+          BrokerProperties)
+        displayName: Address Configurations
+        path: addressSettings
+      - description: Specifies the address settings
+        displayName: Address Settings
+        path: addressSettings.addressSetting
+      - description: what happens when an address where maxSizeBytes is specified
+          becomes full
+        displayName: Address Full Policy
+        path: addressSettings.addressSetting[0].addressFullPolicy
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: whether or not to automatically create addresses when a client
+          sends a message to or attempts to consume a message from a queue mapped
+          to an address that doesnt exist
+        displayName: Auto Create Addresses
+        path: addressSettings.addressSetting[0].autoCreateAddresses
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: whether or not to automatically create the dead-letter-address
+          and/or a corresponding queue on that address when a message found to be
+          undeliverable
+        displayName: AutoCreateDeadLetterResources
+        path: addressSettings.addressSetting[0].autoCreateDeadLetterResources
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: whether or not to automatically create the expiry-address and/or
+          a corresponding queue on that address when a message is sent to a matching
+          queue
+        displayName: Auto Create Expiry Resources
+        path: addressSettings.addressSetting[0].autoCreateExpiryResources
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: DEPRECATED. whether or not to automatically create JMS queues
+          when a producer sends or a consumer connects to a queue
+        displayName: Auto Create Jms Queues
+        path: addressSettings.addressSetting[0].autoCreateJmsQueues
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: DEPRECATED. whether or not to automatically create JMS topics
+          when a producer sends or a consumer subscribes to a topic
+        displayName: Auto Create Jms Topics
+        path: addressSettings.addressSetting[0].autoCreateJmsTopics
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: whether or not to automatically create a queue when a client
+          sends a message to or attempts to consume a message from a queue
+        displayName: Auto Create Queues
+        path: addressSettings.addressSetting[0].autoCreateQueues
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: whether or not to delete auto-created addresses when it no longer
+          has any queues
+        displayName: Auto Delete Addresses
+        path: addressSettings.addressSetting[0].autoDeleteAddresses
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: how long to wait (in milliseconds) before deleting auto-created
+          addresses after they no longer have any queues
+        displayName: Auto Delete Addresses Delay
+        path: addressSettings.addressSetting[0].autoDeleteAddressesDelay
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: whether or not to delete created queues when the queue has 0
+          consumers and 0 messages
+        displayName: Auto Delete Created Queues
+        path: addressSettings.addressSetting[0].autoDeleteCreatedQueues
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: DEPRECATED. whether or not to delete auto-created JMS queues
+          when the queue has 0 consumers and 0 messages
+        displayName: Auto Delete Jms Queues
+        path: addressSettings.addressSetting[0].autoDeleteJmsQueues
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: DEPRECATED. whether or not to delete auto-created JMS topics
+          when the last subscription is closed
+        displayName: Auto Delete Jms Topics
+        path: addressSettings.addressSetting[0].autoDeleteJmsTopics
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: whether or not to delete auto-created queues when the queue has
+          0 consumers and 0 messages
+        displayName: Auto Delete Queues
+        path: addressSettings.addressSetting[0].autoDeleteQueues
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: how long to wait (in milliseconds) before deleting auto-created
+          queues after the queue has 0 consumers.
+        displayName: Auto Delete Queues Delay
+        path: addressSettings.addressSetting[0].autoDeleteQueuesDelay
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: the message count the queue must be at or below before it can
+          be evaluated to be auto deleted, 0 waits until empty queue (default) and
+          -1 disables this check.
+        displayName: Auto Delete Queues Message Count
+        path: addressSettings.addressSetting[0].autoDeleteQueuesMessageCount
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: What to do when an address is no longer in broker.xml.  OFF =
+          will do nothing addresses will remain, FORCE = delete address and its queues
+          even if messages remaining.
+        displayName: Config Delete Addresses
+        path: addressSettings.addressSetting[0].configDeleteAddresses
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: What to do when a queue is no longer in broker.xml.  OFF = will
+          do nothing queues will remain, FORCE = delete queues even if messages remaining.
+        displayName: Config Delete Queues
+        path: addressSettings.addressSetting[0].configDeleteQueues
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: the address to send dead messages to
+        displayName: Dead Letter Address
+        path: addressSettings.addressSetting[0].deadLetterAddress
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: the prefix to use for auto-created dead letter queues
+        displayName: Dead Letter Queue Prefix
+        path: addressSettings.addressSetting[0].deadLetterQueuePrefix
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: the suffix to use for auto-created dead letter queues
+        displayName: Dead Letter Queue Suffix
+        path: addressSettings.addressSetting[0].deadLetterQueueSuffix
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: the routing-type used on auto-created addresses
+        displayName: Default Address Routing Type
+        path: addressSettings.addressSetting[0].defaultAddressRoutingType
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: the default window size for a consumer
+        displayName: Default Consumer Window Size
+        path: addressSettings.addressSetting[0].defaultConsumerWindowSize
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: the default number of consumers needed before dispatch can start
+          for queues under the address.
+        displayName: Default Consumers Before Dispatch
+        path: addressSettings.addressSetting[0].defaultConsumersBeforeDispatch
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: the default delay (in milliseconds) to wait before dispatching
+          if number of consumers before dispatch is not met for queues under the address.
+        displayName: Default Delay Before Dispatch
+        path: addressSettings.addressSetting[0].defaultDelayBeforeDispatch
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: whether to treat the queues under the address as exclusive queues
+          by default
+        displayName: Default Exclusive Queue
+        path: addressSettings.addressSetting[0].defaultExclusiveQueue
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: number of buckets to use for grouping, -1 (default) is unlimited
+          and uses the raw group, 0 disables message groups.
+        displayName: Default Group Buckets
+        path: addressSettings.addressSetting[0].defaultGroupBuckets
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: key used to mark a message is first in a group for a consumer
+        displayName: Default Group First Key
+        path: addressSettings.addressSetting[0].defaultGroupFirstKey
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: whether to rebalance groups when a consumer is added
+        displayName: Default Group Rebalance
+        path: addressSettings.addressSetting[0].defaultGroupRebalance
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: whether to pause dispatch when rebalancing groups
+        displayName: Default Group Rebalance Pause Dispatch
+        path: addressSettings.addressSetting[0].defaultGroupRebalancePauseDispatch
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: the property to use as the key for a last value queue by default
+        displayName: Default Last Value Key
+        path: addressSettings.addressSetting[0].defaultLastValueKey
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: whether to treat the queues under the address as a last value
+          queues by default
+        displayName: Default Last Value Queue
+        path: addressSettings.addressSetting[0].defaultLastValueQueue
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: the maximum number of consumers allowed on this queue at any
+          one time
+        displayName: Default Max Consumers
+        path: addressSettings.addressSetting[0].defaultMaxConsumers
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: whether the queue should be non-destructive by default
+        displayName: Default Non Destructive
+        path: addressSettings.addressSetting[0].defaultNonDestructive
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: purge the contents of the queue once there are no consumers
+        displayName: Default Purge On No Consumers
+        path: addressSettings.addressSetting[0].defaultPurgeOnNoConsumers
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: the routing-type used on auto-created queues
+        displayName: Default Queue Routing Type
+        path: addressSettings.addressSetting[0].defaultQueueRoutingType
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: the default ring-size value for any matching queue which doesnt
+          have ring-size explicitly defined
+        displayName: Default Ring Size
+        path: addressSettings.addressSetting[0].defaultRingSize
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: whether or not to enable metrics for metrics plugins on the matching
+          address
+        displayName: Enable Metrics
+        path: addressSettings.addressSetting[0].enableMetrics
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: the address to send expired messages to
+        displayName: Expiry Address
+        path: addressSettings.addressSetting[0].expiryAddress
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Overrides the expiration time for messages using the default
+          value for expiration time. "-1" disables this setting.
+        displayName: Expiry Delay
+        path: addressSettings.addressSetting[0].expiryDelay
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: the prefix to use for auto-created expiry queues
+        displayName: Expiry Queue Prefix
+        path: addressSettings.addressSetting[0].expiryQueuePrefix
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: the suffix to use for auto-created expiry queues
+        displayName: Expiry Queue Suffix
+        path: addressSettings.addressSetting[0].expiryQueueSuffix
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: This is deprecated please use default-last-value-queue instead.
+        displayName: Last Value Queue
+        path: addressSettings.addressSetting[0].lastValueQueue
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: how many message a management resource can browse
+        displayName: Management Browse Page Size
+        path: addressSettings.addressSetting[0].managementBrowsePageSize
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: pattern for matching settings against addresses; can use wildards
+        displayName: Match
+        path: addressSettings.addressSetting[0].match
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: how many times to attempt to deliver a message before sending
+          to dead letter address
+        displayName: Max Delivery Attempts
+        path: addressSettings.addressSetting[0].maxDeliveryAttempts
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: Overrides the expiration time for messages using a higher value.
+          "-1" disables this setting.
+        displayName: Max Expiry Delay
+        path: addressSettings.addressSetting[0].maxExpiryDelay
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: Maximum value for the redelivery-delay
+        displayName: Max Redelivery Delay
+        path: addressSettings.addressSetting[0].maxRedeliveryDelay
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: the maximum size in bytes for an address. -1 means no limits.
+          This is used in PAGING, BLOCK and FAIL policies. Supports byte notation
+          like K, Mb, GB, etc.
+        displayName: Max Size Bytes
+        path: addressSettings.addressSetting[0].maxSizeBytes
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: used with the address full BLOCK policy, the maximum size in
+          bytes an address can reach before messages start getting rejected. Works
+          in combination with max-size-bytes for AMQP protocol only.  Default = -1
+          (no limit).
+        displayName: Max Size Bytes Reject Threshold
+        path: addressSettings.addressSetting[0].maxSizeBytesRejectThreshold
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: how many days to keep message counter history for this address
+        displayName: Message Counter History Day Limit
+        path: addressSettings.addressSetting[0].messageCounterHistoryDayLimit
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: Overrides the expiration time for messages using a lower value.
+          "-1" disables this setting.
+        displayName: Min Expiry Delay
+        path: addressSettings.addressSetting[0].minExpiryDelay
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: Number of paging files to cache in memory to avoid IO during
+          paging navigation
+        displayName: Page Max Cache Size
+        path: addressSettings.addressSetting[0].pageMaxCacheSize
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: The page size in bytes to use for an address. Supports byte notation
+          like K, Mb, GB, etc.
+        displayName: Page Size Bytes
+        path: addressSettings.addressSetting[0].pageSizeBytes
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: the time (in ms) to wait before redelivering a cancelled message.
+        displayName: Redelivery Delay
+        path: addressSettings.addressSetting[0].redeliveryDelay
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: how long (in ms) to wait after the last consumer is closed on
+          a queue before redistributing messages.
+        displayName: Redistribution Delay
+        path: addressSettings.addressSetting[0].redistributionDelay
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: the number of messages to preserve for future queues created
+          on the matching address
+        displayName: Retroactive Message Count
+        path: addressSettings.addressSetting[0].retroactiveMessageCount
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: if there are no queues matching this address, whether to forward
+          message to DLA (if it exists for this address)
+        displayName: Send To DLA On No Route
+        path: addressSettings.addressSetting[0].sendToDlaOnNoRoute
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: How often to check for slow consumers on a particular queue.
+          Measured in seconds.
+        displayName: Slow Consumer Check Period
+        path: addressSettings.addressSetting[0].slowConsumerCheckPeriod
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: what happens when a slow consumer is identified
+        displayName: Slow Consumer Policy
+        path: addressSettings.addressSetting[0].slowConsumerPolicy
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The minimum rate of message consumption allowed before a consumer
+          is considered "slow." Measured in messages-per-second.
+        displayName: Slow Consumer Threshold
+        path: addressSettings.addressSetting[0].slowConsumerThreshold
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: How to merge the address settings to broker configuration
+        displayName: Apply Rule
+        path: addressSettings.applyRule
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Password for standard broker user. It is required for connecting
+          to the broker and the web console. If left empty, it will be generated.
+        displayName: Admin Password
+        path: adminPassword
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:password
+      - description: User name for standard broker user. It is required for connecting
+          to the broker and the web console. If left empty, it will be generated.
+        displayName: Admin User
+        path: adminUser
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Specifies connectors and connector configuration
+        displayName: Connectors
+        path: connectors
+      - description: Comma separated list of cipher suites used for SSL communication.
+        displayName: Enabled Cipher Suites
+        path: connectors[0].enabledCipherSuites
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Comma separated list of protocols used for SSL communication.
+        displayName: Enabled Protocols
+        path: connectors[0].enabledProtocols
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Whether or not to expose this connector
+        displayName: Expose
+        path: connectors[0].expose
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Hostname or IP to connect to
+        displayName: Host
+        path: connectors[0].host
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The name of the connector
+        displayName: Name
+        path: connectors[0].name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Tells a client connecting to this connector that 2-way SSL is
+          required. This property takes precedence over wantClientAuth.
+        displayName: Need Client Auth
+        path: connectors[0].needClientAuth
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Port number
+        displayName: Port
+        path: connectors[0].port
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: A regular expression used to match the server_name extension
+          on incoming SSL connections. If the name doesn't match then the connection
+          to the acceptor will be rejected.
+        displayName: SNI Host
+        path: connectors[0].sniHost
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Whether or not to enable SSL on this port
+        displayName: SSL Enabled
+        path: connectors[0].sslEnabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Used to change the SSL Provider between JDK and OPENSSL. The
+          default is JDK.
+        displayName: SSL Provider
+        path: connectors[0].sslProvider
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Name of the secret to use for ssl information
+        displayName: SSL Secret
+        path: connectors[0].sslSecret
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The type either tcp or vm
+        displayName: Type
+        path: connectors[0].type
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The CN of the connecting client's SSL certificate will be compared
+          to its hostname to verify they match. This is useful only for 2-way SSL.
+        displayName: Verify Host
+        path: connectors[0].verifyHost
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Tells a client connecting to this connector that 2-way SSL is
+          requested but not required. Overridden by needClientAuth.
+        displayName: Want Client Auth
+        path: connectors[0].wantClientAuth
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Specifies the console configuration
+        displayName: Console Configurations
+        path: console
+      - description: Whether or not to expose this port
+        displayName: Expose
+        path: console.expose
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Whether or not to enable SSL on this port
+        displayName: SSL Enabled
+        path: console.sslEnabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Name of the secret to use for ssl information
+        displayName: SSL Secret
+        path: console.sslSecret
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: If the embedded server requires client authentication
+        displayName: Use Client Auth
+        path: console.useClientAuth
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Specifies the deployment plan
+        displayName: Deployment Plan
+        path: deploymentPlan
+      - description: The image used for the broker, all upgrades are disabled. Needs
+          a corresponding initImage
+        displayName: Image
+        path: deploymentPlan.image
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The init container image used to configure broker, all upgrades
+          are disabled. Needs a corresponding image
+        displayName: Init Image
+        path: deploymentPlan.initImage
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: If true enable the Jolokia JVM Agent
+        displayName: Jolokia Agent Enabled
+        path: deploymentPlan.jolokiaAgentEnabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: If aio use ASYNCIO, if nio use NIO for journal IO
+        displayName: Journal Type
+        path: deploymentPlan.journalType
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: If true enable the management role based access control
+        displayName: Management RBAC Enabled
+        path: deploymentPlan.managementRBACEnabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: If true migrate messages on scaledown
+        displayName: Message Migration
+        path: deploymentPlan.messageMigration
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: If true use persistent volume via persistent volume claim for
+          journal storage
+        displayName: Persistence Enabled
+        path: deploymentPlan.persistenceEnabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: If true require user password login credentials for broker protocol
+          ports
+        displayName: Require Login
+        path: deploymentPlan.requireLogin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Specifies the minimum/maximum amount of compute resources required/allowed
+        displayName: Resource Requirements
+        path: deploymentPlan.resources
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+      - description: The number of broker pods to deploy
+        displayName: Size
+        path: deploymentPlan.size
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podCount
+      - description: Specifies the storage configurations
+        displayName: Storage Configurations
+        path: deploymentPlan.storage
+      - description: The storage size
+        displayName: Size
+        path: deploymentPlan.storage.size
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Specifies the upgrades (deprecated in favour of Version)
+        displayName: Upgrades
+        path: upgrades
+      - description: Set true to enable automatic micro version product upgrades,
+          it is disabled by default.
+        displayName: Enable Upgrades
+        path: upgrades.enabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:ui:booleanSwitch
+      - description: Set true to enable automatic minor product version upgrades,
+          it is disabled by default. Requires spec.upgrades.enabled to be true.
+        displayName: Include minor version upgrades
+        path: upgrades.minor
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:upgrades.enabled:true
+        - urn:alm:descriptor:com.tectonic.ui:ui:booleanSwitch
+      - description: The desired version of the broker. Can be x, or x.y or x.y.z
+          to configure upgrades
+        displayName: Version
+        path: version
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
       statusDescriptors:
       - description: Current state of the resource Conditions represent the latest
           available observations of an object's state
@@ -1652,15 +3658,741 @@ spec:
         path: conditions
         x-descriptors:
         - urn:alm:descriptor:io.kubernetes.conditions
+      - description: The current pods
+        displayName: Pods Status
+        path: podStatus
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podStatuses
       version: v2alpha4
-    - description: ActiveMQArtemis is the Schema for the activemqartemises API
-      displayName: Active MQArtemis
+    - description: A stateful deployment of one or more brokers
+      displayName: ActiveMQ Artemis
       kind: ActiveMQArtemis
       name: activemqartemises.broker.amq.io
       resources:
       - kind: Secret
         name: ""
         version: v1
+      specDescriptors:
+      - description: Specifies the acceptor configuration
+        displayName: Acceptors
+        path: acceptors
+      - description: AMQP Minimum Large Message Size
+        displayName: AMQP Min Large Message Size
+        path: acceptors[0].amqpMinLargeMessageSize
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: To indicate which kind of routing type to use.
+        displayName: Anycast Prefix
+        path: acceptors[0].anycastPrefix
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Max number of connections allowed to make
+        displayName: Connections Allowed
+        path: acceptors[0].connectionsAllowed
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: Comma separated list of cipher suites used for SSL communication.
+        displayName: Enabled Cipher Suites
+        path: acceptors[0].enabledCipherSuites
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Comma separated list of protocols used for SSL communication.
+        displayName: Enabled Protocols
+        path: acceptors[0].enabledProtocols
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Whether or not to expose this acceptor
+        displayName: Expose
+        path: acceptors[0].expose
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: To indicate which kind of routing type to use
+        displayName: Multicast Prefix
+        path: acceptors[0].multicastPrefix
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The acceptor name
+        displayName: Name
+        path: acceptors[0].name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Tells a client connecting to this acceptor that 2-way SSL is
+          required. This property takes precedence over wantClientAuth.
+        displayName: Need Client Auth
+        path: acceptors[0].needClientAuth
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Port number
+        displayName: Port
+        path: acceptors[0].port
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: The protocols to enable for this acceptor
+        displayName: Protocols
+        path: acceptors[0].protocols
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: A regular expression used to match the server_name extension
+          on incoming SSL connections. If the name doesn't match then the connection
+          to the acceptor will be rejected.
+        displayName: SNI Host
+        path: acceptors[0].sniHost
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Whether or not to enable SSL on this port
+        displayName: SSL Enabled
+        path: acceptors[0].sslEnabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Used to change the SSL Provider between JDK and OPENSSL. The
+          default is JDK.
+        displayName: SSL Provider
+        path: acceptors[0].sslProvider
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Name of the secret to use for ssl information
+        displayName: SSL Secret
+        path: acceptors[0].sslSecret
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: For openwire protocol if advisory topics are enabled, default
+          false
+        displayName: Support Advisory
+        path: acceptors[0].supportAdvisory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: If prevents advisory addresses/queues to be registered to management
+          service, default false
+        displayName: Suppress Internal Management Objects
+        path: acceptors[0].suppressInternalManagementObjects
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: The CN of the connecting client's SSL certificate will be compared
+          to its hostname to verify they match. This is useful only for 2-way SSL.
+        displayName: Verify Host
+        path: acceptors[0].verifyHost
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Tells a client connecting to this acceptor that 2-way SSL is
+          requested but not required. Overridden by needClientAuth.
+        displayName: Want Client Auth
+        path: acceptors[0].wantClientAuth
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Specifies the address configurations (deprecated in favour of
+          BrokerProperties)
+        displayName: Address Configurations
+        path: addressSettings
+      - description: Specifies the address settings
+        displayName: Address Settings
+        path: addressSettings.addressSetting
+      - description: what happens when an address where maxSizeBytes is specified
+          becomes full
+        displayName: Address Full Policy
+        path: addressSettings.addressSetting[0].addressFullPolicy
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: whether or not to automatically create addresses when a client
+          sends a message to or attempts to consume a message from a queue mapped
+          to an address that doesnt exist
+        displayName: Auto Create Addresses
+        path: addressSettings.addressSetting[0].autoCreateAddresses
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: whether or not to automatically create the dead-letter-address
+          and/or a corresponding queue on that address when a message found to be
+          undeliverable
+        displayName: AutoCreateDeadLetterResources
+        path: addressSettings.addressSetting[0].autoCreateDeadLetterResources
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: whether or not to automatically create the expiry-address and/or
+          a corresponding queue on that address when a message is sent to a matching
+          queue
+        displayName: Auto Create Expiry Resources
+        path: addressSettings.addressSetting[0].autoCreateExpiryResources
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: DEPRECATED. whether or not to automatically create JMS queues
+          when a producer sends or a consumer connects to a queue
+        displayName: Auto Create Jms Queues
+        path: addressSettings.addressSetting[0].autoCreateJmsQueues
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: DEPRECATED. whether or not to automatically create JMS topics
+          when a producer sends or a consumer subscribes to a topic
+        displayName: Auto Create Jms Topics
+        path: addressSettings.addressSetting[0].autoCreateJmsTopics
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: whether or not to automatically create a queue when a client
+          sends a message to or attempts to consume a message from a queue
+        displayName: Auto Create Queues
+        path: addressSettings.addressSetting[0].autoCreateQueues
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: whether or not to delete auto-created addresses when it no longer
+          has any queues
+        displayName: Auto Delete Addresses
+        path: addressSettings.addressSetting[0].autoDeleteAddresses
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: how long to wait (in milliseconds) before deleting auto-created
+          addresses after they no longer have any queues
+        displayName: Auto Delete Addresses Delay
+        path: addressSettings.addressSetting[0].autoDeleteAddressesDelay
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: whether or not to delete created queues when the queue has 0
+          consumers and 0 messages
+        displayName: Auto Delete Created Queues
+        path: addressSettings.addressSetting[0].autoDeleteCreatedQueues
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: DEPRECATED. whether or not to delete auto-created JMS queues
+          when the queue has 0 consumers and 0 messages
+        displayName: Auto Delete Jms Queues
+        path: addressSettings.addressSetting[0].autoDeleteJmsQueues
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: DEPRECATED. whether or not to delete auto-created JMS topics
+          when the last subscription is closed
+        displayName: Auto Delete Jms Topics
+        path: addressSettings.addressSetting[0].autoDeleteJmsTopics
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: whether or not to delete auto-created queues when the queue has
+          0 consumers and 0 messages
+        displayName: Auto Delete Queues
+        path: addressSettings.addressSetting[0].autoDeleteQueues
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: how long to wait (in milliseconds) before deleting auto-created
+          queues after the queue has 0 consumers.
+        displayName: Auto Delete Queues Delay
+        path: addressSettings.addressSetting[0].autoDeleteQueuesDelay
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: the message count the queue must be at or below before it can
+          be evaluated to be auto deleted, 0 waits until empty queue (default) and
+          -1 disables this check.
+        displayName: Auto Delete Queues Message Count
+        path: addressSettings.addressSetting[0].autoDeleteQueuesMessageCount
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: What to do when an address is no longer in broker.xml.  OFF =
+          will do nothing addresses will remain, FORCE = delete address and its queues
+          even if messages remaining.
+        displayName: Config Delete Addresses
+        path: addressSettings.addressSetting[0].configDeleteAddresses
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: What to do when a queue is no longer in broker.xml.  OFF = will
+          do nothing queues will remain, FORCE = delete queues even if messages remaining.
+        displayName: Config Delete Queues
+        path: addressSettings.addressSetting[0].configDeleteQueues
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: the address to send dead messages to
+        displayName: Dead Letter Address
+        path: addressSettings.addressSetting[0].deadLetterAddress
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: the prefix to use for auto-created dead letter queues
+        displayName: Dead Letter Queue Prefix
+        path: addressSettings.addressSetting[0].deadLetterQueuePrefix
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: the suffix to use for auto-created dead letter queues
+        displayName: Dead Letter Queue Suffix
+        path: addressSettings.addressSetting[0].deadLetterQueueSuffix
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: the routing-type used on auto-created addresses
+        displayName: Default Address Routing Type
+        path: addressSettings.addressSetting[0].defaultAddressRoutingType
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: the default window size for a consumer
+        displayName: Default Consumer Window Size
+        path: addressSettings.addressSetting[0].defaultConsumerWindowSize
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: the default number of consumers needed before dispatch can start
+          for queues under the address.
+        displayName: Default Consumers Before Dispatch
+        path: addressSettings.addressSetting[0].defaultConsumersBeforeDispatch
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: the default delay (in milliseconds) to wait before dispatching
+          if number of consumers before dispatch is not met for queues under the address.
+        displayName: Default Delay Before Dispatch
+        path: addressSettings.addressSetting[0].defaultDelayBeforeDispatch
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: whether to treat the queues under the address as exclusive queues
+          by default
+        displayName: Default Exclusive Queue
+        path: addressSettings.addressSetting[0].defaultExclusiveQueue
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: number of buckets to use for grouping, -1 (default) is unlimited
+          and uses the raw group, 0 disables message groups.
+        displayName: Default Group Buckets
+        path: addressSettings.addressSetting[0].defaultGroupBuckets
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: key used to mark a message is first in a group for a consumer
+        displayName: Default Group First Key
+        path: addressSettings.addressSetting[0].defaultGroupFirstKey
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: whether to rebalance groups when a consumer is added
+        displayName: Default Group Rebalance
+        path: addressSettings.addressSetting[0].defaultGroupRebalance
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: whether to pause dispatch when rebalancing groups
+        displayName: Default Group Rebalance Pause Dispatch
+        path: addressSettings.addressSetting[0].defaultGroupRebalancePauseDispatch
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: the property to use as the key for a last value queue by default
+        displayName: Default Last Value Key
+        path: addressSettings.addressSetting[0].defaultLastValueKey
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: whether to treat the queues under the address as a last value
+          queues by default
+        displayName: Default Last Value Queue
+        path: addressSettings.addressSetting[0].defaultLastValueQueue
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: the maximum number of consumers allowed on this queue at any
+          one time
+        displayName: Default Max Consumers
+        path: addressSettings.addressSetting[0].defaultMaxConsumers
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: whether the queue should be non-destructive by default
+        displayName: Default Non Destructive
+        path: addressSettings.addressSetting[0].defaultNonDestructive
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: purge the contents of the queue once there are no consumers
+        displayName: Default Purge On No Consumers
+        path: addressSettings.addressSetting[0].defaultPurgeOnNoConsumers
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: the routing-type used on auto-created queues
+        displayName: Default Queue Routing Type
+        path: addressSettings.addressSetting[0].defaultQueueRoutingType
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: the default ring-size value for any matching queue which doesnt
+          have ring-size explicitly defined
+        displayName: Default Ring Size
+        path: addressSettings.addressSetting[0].defaultRingSize
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: Whether or not set the timestamp of arrival on messages. default
+          false
+        displayName: Enable Ingress Timestamp
+        path: addressSettings.addressSetting[0].enableIngressTimestamp
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: whether or not to enable metrics for metrics plugins on the matching
+          address
+        displayName: Enable Metrics
+        path: addressSettings.addressSetting[0].enableMetrics
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: the address to send expired messages to
+        displayName: Expiry Address
+        path: addressSettings.addressSetting[0].expiryAddress
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Overrides the expiration time for messages using the default
+          value for expiration time. "-1" disables this setting.
+        displayName: Expiry Delay
+        path: addressSettings.addressSetting[0].expiryDelay
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: the prefix to use for auto-created expiry queues
+        displayName: Expiry Queue Prefix
+        path: addressSettings.addressSetting[0].expiryQueuePrefix
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: the suffix to use for auto-created expiry queues
+        displayName: Expiry Queue Suffix
+        path: addressSettings.addressSetting[0].expiryQueueSuffix
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: This is deprecated please use default-last-value-queue instead.
+        displayName: Last Value Queue
+        path: addressSettings.addressSetting[0].lastValueQueue
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: how many message a management resource can browse
+        displayName: Management Browse Page Size
+        path: addressSettings.addressSetting[0].managementBrowsePageSize
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: max size of the message returned from management API, default
+          256
+        displayName: Max Management Message Size Limit
+        path: addressSettings.addressSetting[0].managementMessageAttributeSizeLimit
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: pattern for matching settings against addresses; can use wildards
+        displayName: Match
+        path: addressSettings.addressSetting[0].match
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: how many times to attempt to deliver a message before sending
+          to dead letter address
+        displayName: Max Delivery Attempts
+        path: addressSettings.addressSetting[0].maxDeliveryAttempts
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: Overrides the expiration time for messages using a higher value.
+          "-1" disables this setting.
+        displayName: Max Expiry Delay
+        path: addressSettings.addressSetting[0].maxExpiryDelay
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: Maximum value for the redelivery-delay
+        displayName: Max Redelivery Delay
+        path: addressSettings.addressSetting[0].maxRedeliveryDelay
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: the maximum size in bytes for an address. -1 means no limits.
+          This is used in PAGING, BLOCK and FAIL policies. Supports byte notation
+          like K, Mb, GB, etc.
+        displayName: Max Size Bytes
+        path: addressSettings.addressSetting[0].maxSizeBytes
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: used with the address full BLOCK policy, the maximum size in
+          bytes an address can reach before messages start getting rejected. Works
+          in combination with max-size-bytes for AMQP protocol only.  Default = -1
+          (no limit).
+        displayName: Max Size Bytes Reject Threshold
+        path: addressSettings.addressSetting[0].maxSizeBytesRejectThreshold
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: how many days to keep message counter history for this address
+        displayName: Message Counter History Day Limit
+        path: addressSettings.addressSetting[0].messageCounterHistoryDayLimit
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: Overrides the expiration time for messages using a lower value.
+          "-1" disables this setting.
+        displayName: Min Expiry Delay
+        path: addressSettings.addressSetting[0].minExpiryDelay
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: Number of paging files to cache in memory to avoid IO during
+          paging navigation
+        displayName: Page Max Cache Size
+        path: addressSettings.addressSetting[0].pageMaxCacheSize
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: The page size in bytes to use for an address. Supports byte notation
+          like K, Mb, GB, etc.
+        displayName: Page Size Bytes
+        path: addressSettings.addressSetting[0].pageSizeBytes
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: the time (in ms) to wait before redelivering a cancelled message.
+        displayName: Redelivery Delay
+        path: addressSettings.addressSetting[0].redeliveryDelay
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: how long (in ms) to wait after the last consumer is closed on
+          a queue before redistributing messages.
+        displayName: Redistribution Delay
+        path: addressSettings.addressSetting[0].redistributionDelay
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: the number of messages to preserve for future queues created
+          on the matching address
+        displayName: Retroactive Message Count
+        path: addressSettings.addressSetting[0].retroactiveMessageCount
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: if there are no queues matching this address, whether to forward
+          message to DLA (if it exists for this address)
+        displayName: Send To DLA On No Route
+        path: addressSettings.addressSetting[0].sendToDlaOnNoRoute
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: How often to check for slow consumers on a particular queue.
+          Measured in seconds.
+        displayName: Slow Consumer Check Period
+        path: addressSettings.addressSetting[0].slowConsumerCheckPeriod
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: what happens when a slow consumer is identified
+        displayName: Slow Consumer Policy
+        path: addressSettings.addressSetting[0].slowConsumerPolicy
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The minimum rate of message consumption allowed before a consumer
+          is considered "slow." Measured in messages-per-second.
+        displayName: Slow Consumer Threshold
+        path: addressSettings.addressSetting[0].slowConsumerThreshold
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: Unit used in specifying slow consumer threshold, default is MESSAGE_PER_SECOND
+        displayName: Slow Consumer Threshold Measurement Unit
+        path: addressSettings.addressSetting[0].slowConsumerThresholdMeasurementUnit
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: How to merge the address settings to broker configuration
+        displayName: Apply Rule
+        path: addressSettings.applyRule
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Password for standard broker user. It is required for connecting
+          to the broker and the web console. If left empty, it will be generated.
+        displayName: Admin Password
+        path: adminPassword
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:password
+      - description: User name for standard broker user. It is required for connecting
+          to the broker and the web console. If left empty, it will be generated.
+        displayName: Admin User
+        path: adminUser
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Specifies connectors and connector configuration
+        displayName: Connectors
+        path: connectors
+      - description: Comma separated list of cipher suites used for SSL communication.
+        displayName: Enabled Cipher Suites
+        path: connectors[0].enabledCipherSuites
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Comma separated list of protocols used for SSL communication.
+        displayName: Enabled Protocols
+        path: connectors[0].enabledProtocols
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Whether or not to expose this connector
+        displayName: Expose
+        path: connectors[0].expose
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Hostname or IP to connect to
+        displayName: Host
+        path: connectors[0].host
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The name of the connector
+        displayName: Name
+        path: connectors[0].name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Tells a client connecting to this connector that 2-way SSL is
+          required. This property takes precedence over wantClientAuth.
+        displayName: Need Client Auth
+        path: connectors[0].needClientAuth
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Port number
+        displayName: Port
+        path: connectors[0].port
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: A regular expression used to match the server_name extension
+          on incoming SSL connections. If the name doesn't match then the connection
+          to the acceptor will be rejected.
+        displayName: SNI Host
+        path: connectors[0].sniHost
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Whether or not to enable SSL on this port
+        displayName: SSL Enabled
+        path: connectors[0].sslEnabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Used to change the SSL Provider between JDK and OPENSSL. The
+          default is JDK.
+        displayName: SSL Provider
+        path: connectors[0].sslProvider
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Name of the secret to use for ssl information
+        displayName: SSL Secret
+        path: connectors[0].sslSecret
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The type either tcp or vm
+        displayName: Type
+        path: connectors[0].type
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The CN of the connecting client's SSL certificate will be compared
+          to its hostname to verify they match. This is useful only for 2-way SSL.
+        displayName: Verify Host
+        path: connectors[0].verifyHost
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Tells a client connecting to this connector that 2-way SSL is
+          requested but not required. Overridden by needClientAuth.
+        displayName: Want Client Auth
+        path: connectors[0].wantClientAuth
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Specifies the console configuration
+        displayName: Console Configurations
+        path: console
+      - description: Whether or not to expose this port
+        displayName: Expose
+        path: console.expose
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Whether or not to enable SSL on this port
+        displayName: SSL Enabled
+        path: console.sslEnabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Name of the secret to use for ssl information
+        displayName: SSL Secret
+        path: console.sslSecret
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: If the embedded server requires client authentication
+        displayName: Use Client Auth
+        path: console.useClientAuth
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Specifies the deployment plan
+        displayName: Deployment Plan
+        path: deploymentPlan
+      - description: Whether broker is clustered
+        displayName: Clustered
+        path: deploymentPlan.clustered
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Whether or not to install the artemis metrics plugin
+        displayName: Enable Metrics Plugin
+        path: deploymentPlan.enableMetricsPlugin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Specifies extra mounts
+        displayName: Extra Mounts
+        path: deploymentPlan.extraMounts
+      - description: Specifies ConfigMap names
+        displayName: ConfigMap Names
+        path: deploymentPlan.extraMounts.configMaps
+      - description: Specifies Secret names
+        displayName: Secret Names
+        path: deploymentPlan.extraMounts.secrets
+      - description: The image used for the broker, all upgrades are disabled. Needs
+          a corresponding initImage
+        displayName: Image
+        path: deploymentPlan.image
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The init container image used to configure broker, all upgrades
+          are disabled. Needs a corresponding image
+        displayName: Init Image
+        path: deploymentPlan.initImage
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: If true enable the Jolokia JVM Agent
+        displayName: Jolokia Agent Enabled
+        path: deploymentPlan.jolokiaAgentEnabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: If aio use ASYNCIO, if nio use NIO for journal IO
+        displayName: Journal Type
+        path: deploymentPlan.journalType
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Specifies the liveness probe configuration
+        displayName: Liveness Probe Configurations
+        path: deploymentPlan.livenessProbe
+      - description: If true enable the management role based access control
+        displayName: Management RBAC Enabled
+        path: deploymentPlan.managementRBACEnabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: If true migrate messages on scaledown
+        displayName: Message Migration
+        path: deploymentPlan.messageMigration
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: If true use persistent volume via persistent volume claim for
+          journal storage
+        displayName: Persistence Enabled
+        path: deploymentPlan.persistenceEnabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Specifies the pod security configurations
+        displayName: Pod Security Configurations
+        path: deploymentPlan.podSecurity
+      - description: runAsUser as defined in PodSecurityContext for the pod
+        displayName: Run As User
+        path: deploymentPlan.podSecurity.runAsUser
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: ServiceAccount Name of the pod
+        displayName: Service Account Name
+        path: deploymentPlan.podSecurity.serviceAccountName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Specifies the readiness probe configuration
+        displayName: Readiness Probe Configurations
+        path: deploymentPlan.readinessProbe
+      - description: If true require user password login credentials for broker protocol
+          ports
+        displayName: Require Login
+        path: deploymentPlan.requireLogin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Specifies the minimum/maximum amount of compute resources required/allowed
+        displayName: Resource Requirements
+        path: deploymentPlan.resources
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+      - description: The number of broker pods to deploy
+        displayName: Size
+        path: deploymentPlan.size
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podCount
+      - description: Specifies the storage configurations
+        displayName: Storage Configurations
+        path: deploymentPlan.storage
+      - description: The storage size
+        displayName: Size
+        path: deploymentPlan.storage.size
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Specifies the upgrades (deprecated in favour of Version)
+        displayName: Upgrades
+        path: upgrades
+      - description: Set true to enable automatic micro version product upgrades,
+          it is disabled by default.
+        displayName: Enable Upgrades
+        path: upgrades.enabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:ui:booleanSwitch
+      - description: Set true to enable automatic minor product version upgrades,
+          it is disabled by default. Requires spec.upgrades.enabled to be true.
+        displayName: Include minor version upgrades
+        path: upgrades.minor
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:upgrades.enabled:true
+        - urn:alm:descriptor:com.tectonic.ui:ui:booleanSwitch
+      - description: The desired version of the broker. Can be x, or x.y or x.y.z
+          to configure upgrades
+        displayName: Version
+        path: version
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
       statusDescriptors:
       - description: Current state of the resource Conditions represent the latest
           available observations of an object's state
@@ -1668,6 +4400,11 @@ spec:
         path: conditions
         x-descriptors:
         - urn:alm:descriptor:io.kubernetes.conditions
+      - description: The current pods
+        displayName: Pods Status
+        path: podStatus
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podStatuses
       version: v2alpha5
     - description: Provides internal message migration on clustered broker scaledown
       displayName: ActiveMQ Artemis Scaledown

--- a/bundle/manifests/broker.amq.io_activemqartemisaddresses.yaml
+++ b/bundle/manifests/broker.amq.io_activemqartemisaddresses.yaml
@@ -239,8 +239,7 @@ spec:
     name: v2alpha1
     schema:
       openAPIV3Schema:
-        description: ActiveMQArtemisAddress is the Schema for the activemqartemisaddresses
-          API
+        description: Adding and removing addresses using custom resource definitions
         properties:
           apiVersion:
             description: |-
@@ -263,10 +262,13 @@ spec:
             description: ActiveMQArtemisAddressSpec defines the desired state of ActiveMQArtemisAddress
             properties:
               addressName:
+                description: The Address Name
                 type: string
               queueName:
+                description: The Queue Name
                 type: string
               routingType:
+                description: The Routing Type
                 type: string
             type: object
           status:
@@ -344,8 +346,7 @@ spec:
     name: v2alpha2
     schema:
       openAPIV3Schema:
-        description: ActiveMQArtemisAddress is the Schema for the activemqartemisaddresses
-          API
+        description: Adding and removing addresses using custom resource definitions
         properties:
           apiVersion:
             description: |-
@@ -368,12 +369,17 @@ spec:
             description: ActiveMQArtemisAddressSpec defines the desired state of ActiveMQArtemisAddress
             properties:
               addressName:
+                description: The Address Name
                 type: string
               queueName:
+                description: The Queue Name
                 type: string
               removeFromBrokerOnDelete:
+                description: Whether or not delete the queue from broker when CR is
+                  undeployed(default false)
                 type: boolean
               routingType:
+                description: The Routing Type
                 type: string
             type: object
           status:
@@ -451,8 +457,7 @@ spec:
     name: v2alpha3
     schema:
       openAPIV3Schema:
-        description: ActiveMQArtemisAddress is the Schema for the activemqartemisaddresses
-          API
+        description: Adding and removing addresses using custom resource definitions
         properties:
           apiVersion:
             description: |-
@@ -475,83 +480,124 @@ spec:
             description: ActiveMQArtemisAddressSpec defines the desired state of ActiveMQArtemisAddress
             properties:
               addressName:
+                description: The Address Name
                 type: string
               applyToCrNames:
+                description: Apply to the broker crs in the current namespace. A value
+                  of * or empty string means applying to all broker crs. Default apply
+                  to all broker crs
                 items:
                   type: string
                 type: array
               password:
+                description: The password for the user
                 type: string
               queueConfiguration:
+                description: Specify the queue configuration
                 properties:
                   autoCreateAddress:
+                    description: Whether auto create address
                     type: boolean
                   autoDelete:
+                    description: Auto-delete the queue
                     type: boolean
                   autoDeleteDelay:
+                    description: Delay (Milliseconds) before auto-delete the queue
                     format: int64
                     type: integer
                   autoDeleteMessageCount:
+                    description: Message count of the queue to allow auto delete
                     format: int64
                     type: integer
                   configurationManaged:
+                    description: ' If the queue is configuration managed'
                     type: boolean
                   consumerPriority:
+                    description: Consumer Priority
                     format: int32
                     type: integer
                   consumersBeforeDispatch:
+                    description: Number of consumers required before dispatching messages
                     format: int32
                     type: integer
                   delayBeforeDispatch:
+                    description: Milliseconds to wait for `consumers-before-dispatch`
+                      to be met before dispatching messages anyway
                     format: int64
                     type: integer
                   durable:
+                    description: If the queue is durable or not
                     type: boolean
                   enabled:
+                    description: If the queue is enabled
                     type: boolean
                   exclusive:
+                    description: If the queue is exclusive
                     type: boolean
                   filterString:
+                    description: The filter string for the queue
                     type: string
                   groupBuckets:
+                    description: Number of messaging group buckets
                     format: int32
                     type: integer
                   groupFirstKey:
+                    description: Header set on the first group message
                     type: string
                   groupRebalance:
+                    description: If rebalance the message group
                     type: boolean
                   groupRebalancePauseDispatch:
+                    description: If pause message dispatch when rebalancing groups
                     type: boolean
                   ignoreIfExists:
+                    description: If ignore if the target queue already exists
                     type: boolean
                   lastValue:
+                    description: If it is a last value queue
                     type: boolean
                   lastValueKey:
+                    description: The property used for last value queue to identify
+                      last values
                     type: string
                   maxConsumers:
+                    description: Max number of consumers allowed on this queue
                     format: int32
                     type: integer
                   nonDestructive:
+                    description: If force non-destructive consumers on the queue
                     type: boolean
                   purgeOnNoConsumers:
+                    description: Whether to delete all messages when no consumers
+                      connected to the queue
                     type: boolean
                   ringSize:
+                    description: The size the queue should maintain according to ring
+                      semantics
                     format: int64
                     type: integer
                   routingType:
+                    description: The routing type of the queue
                     type: string
                   temporary:
+                    description: If the queue is temporary
                     type: boolean
                   user:
+                    description: The user associated with the queue
                     type: string
                 type: object
               queueName:
+                description: The Queue Name
                 type: string
               removeFromBrokerOnDelete:
+                description: Whether or not delete the queue from broker when CR is
+                  undeployed(default false)
                 type: boolean
               routingType:
+                description: The Routing Type
                 type: string
               user:
+                description: User name for creating the queue or address
                 type: string
             type: object
           status:

--- a/bundle/manifests/broker.amq.io_activemqartemises.yaml
+++ b/bundle/manifests/broker.amq.io_activemqartemises.yaml
@@ -5051,7 +5051,7 @@ spec:
   - name: v2alpha1
     schema:
       openAPIV3Schema:
-        description: ActiveMQArtemis is the Schema for the activemqartemises API
+        description: A stateful deployment of one or more brokers
         properties:
           apiVersion:
             description: |-
@@ -5074,80 +5074,138 @@ spec:
             description: ActiveMQArtemisSpec defines the desired state of ActiveMQArtemis
             properties:
               acceptors:
+                description: Specifies the acceptor configuration
                 items:
                   properties:
                     anycastPrefix:
+                      description: To indicate which kind of routing type to use.
                       type: string
                     connectionsAllowed:
+                      description: Max number of connections allowed to make
                       type: integer
                     enabledCipherSuites:
+                      description: Comma separated list of cipher suites used for
+                        SSL communication.
                       type: string
                     enabledProtocols:
+                      description: Comma separated list of protocols used for SSL
+                        communication.
                       type: string
                     expose:
+                      description: Whether or not to expose this acceptor
                       type: boolean
                     multicastPrefix:
+                      description: To indicate which kind of routing type to use
                       type: string
                     name:
+                      description: The acceptor name
                       type: string
                     needClientAuth:
+                      description: Tells a client connecting to this acceptor that
+                        2-way SSL is required. This property takes precedence over
+                        wantClientAuth.
                       type: boolean
                     port:
+                      description: Port number
                       format: int32
                       type: integer
                     protocols:
+                      description: The protocols to enable for this acceptor
                       type: string
                     sniHost:
+                      description: A regular expression used to match the server_name
+                        extension on incoming SSL connections. If the name doesn't
+                        match then the connection to the acceptor will be rejected.
                       type: string
                     sslEnabled:
+                      description: Whether or not to enable SSL on this port
                       type: boolean
                     sslProvider:
+                      description: Used to change the SSL Provider between JDK and
+                        OPENSSL. The default is JDK.
                       type: string
                     sslSecret:
+                      description: Name of the secret to use for ssl information
                       type: string
                     verifyHost:
+                      description: The CN of the connecting client's SSL certificate
+                        will be compared to its hostname to verify they match. This
+                        is useful only for 2-way SSL.
                       type: boolean
                     wantClientAuth:
+                      description: Tells a client connecting to this acceptor that
+                        2-way SSL is requested but not required. Overridden by needClientAuth.
                       type: boolean
                   required:
                   - name
                   type: object
                 type: array
               adminPassword:
+                description: Password for standard broker user. It is required for
+                  connecting to the broker and the web console. If left empty, it
+                  will be generated.
                 type: string
               adminUser:
+                description: User name for standard broker user. It is required for
+                  connecting to the broker and the web console. If left empty, it
+                  will be generated.
                 type: string
               connectors:
+                description: Specifies connectors and connector configuration
                 items:
                   properties:
                     enabledCipherSuites:
+                      description: Comma separated list of cipher suites used for
+                        SSL communication.
                       type: string
                     enabledProtocols:
+                      description: Comma separated list of protocols used for SSL
+                        communication.
                       type: string
                     expose:
+                      description: Whether or not to expose this connector
                       type: boolean
                     host:
+                      description: Hostname or IP to connect to
                       type: string
                     name:
+                      description: The name of the connector
                       type: string
                     needClientAuth:
+                      description: Tells a client connecting to this connector that
+                        2-way SSL is required. This property takes precedence over
+                        wantClientAuth.
                       type: boolean
                     port:
+                      description: Port number
                       format: int32
                       type: integer
                     sniHost:
+                      description: A regular expression used to match the server_name
+                        extension on incoming SSL connections. If the name doesn't
+                        match then the connection to the acceptor will be rejected.
                       type: string
                     sslEnabled:
+                      description: ' Whether or not to enable SSL on this port'
                       type: boolean
                     sslProvider:
+                      description: Used to change the SSL Provider between JDK and
+                        OPENSSL. The default is JDK.
                       type: string
                     sslSecret:
+                      description: Name of the secret to use for ssl information
                       type: string
                     type:
+                      description: The type either tcp or vm
                       type: string
                     verifyHost:
+                      description: The CN of the connecting client's SSL certificate
+                        will be compared to its hostname to verify they match. This
+                        is useful only for 2-way SSL.
                       type: boolean
                     wantClientAuth:
+                      description: Tells a client connecting to this connector that
+                        2-way SSL is requested but not required. Overridden by needClientAuth.
                       type: boolean
                   required:
                   - host
@@ -5156,29 +5214,44 @@ spec:
                   type: object
                 type: array
               console:
+                description: Specifies the console configuration
                 properties:
                   expose:
+                    description: Whether or not to expose this port
                     type: boolean
                   sslEnabled:
+                    description: Whether or not to enable SSL on this port
                     type: boolean
                   sslSecret:
+                    description: Name of the secret to use for ssl information
                     type: string
                   useClientAuth:
+                    description: If the embedded server requires client authentication
                     type: boolean
                 type: object
               deploymentPlan:
+                description: Specifies the deployment plan
                 properties:
                   image:
+                    description: The image used for the broker, all upgrades are disabled.
+                      Needs a corresponding initImage
                     type: string
                   journalType:
+                    description: If aio use ASYNCIO, if nio use NIO for journal IO
                     type: string
                   messageMigration:
+                    description: If true migrate messages on scaledown
                     type: boolean
                   persistenceEnabled:
+                    description: If true use persistent volume via persistent volume
+                      claim for journal storage
                     type: boolean
                   requireLogin:
+                    description: If true require user password login credentials for
+                      broker protocol ports
                     type: boolean
                   size:
+                    description: The number of broker pods to deploy
                     format: int32
                     type: integer
                 type: object
@@ -5275,7 +5348,7 @@ spec:
   - name: v2alpha2
     schema:
       openAPIV3Schema:
-        description: ActiveMQArtemis is the Schema for the activemqartemises API
+        description: A stateful deployment of one or more brokers
         properties:
           apiVersion:
             description: |-
@@ -5298,80 +5371,138 @@ spec:
             description: ActiveMQArtemisSpec defines the desired state of ActiveMQArtemis
             properties:
               acceptors:
+                description: Specifies the acceptor configuration
                 items:
                   properties:
                     anycastPrefix:
+                      description: To indicate which kind of routing type to use.
                       type: string
                     connectionsAllowed:
+                      description: Max number of connections allowed to make
                       type: integer
                     enabledCipherSuites:
+                      description: Comma separated list of cipher suites used for
+                        SSL communication.
                       type: string
                     enabledProtocols:
+                      description: Comma separated list of protocols used for SSL
+                        communication.
                       type: string
                     expose:
+                      description: Whether or not to expose this acceptor
                       type: boolean
                     multicastPrefix:
+                      description: To indicate which kind of routing type to use
                       type: string
                     name:
+                      description: The acceptor name
                       type: string
                     needClientAuth:
+                      description: Tells a client connecting to this acceptor that
+                        2-way SSL is required. This property takes precedence over
+                        wantClientAuth.
                       type: boolean
                     port:
+                      description: Port number
                       format: int32
                       type: integer
                     protocols:
+                      description: The protocols to enable for this acceptor
                       type: string
                     sniHost:
+                      description: A regular expression used to match the server_name
+                        extension on incoming SSL connections. If the name doesn't
+                        match then the connection to the acceptor will be rejected.
                       type: string
                     sslEnabled:
+                      description: Whether or not to enable SSL on this port
                       type: boolean
                     sslProvider:
+                      description: Used to change the SSL Provider between JDK and
+                        OPENSSL. The default is JDK.
                       type: string
                     sslSecret:
+                      description: Name of the secret to use for ssl information
                       type: string
                     verifyHost:
+                      description: The CN of the connecting client's SSL certificate
+                        will be compared to its hostname to verify they match. This
+                        is useful only for 2-way SSL.
                       type: boolean
                     wantClientAuth:
+                      description: Tells a client connecting to this acceptor that
+                        2-way SSL is requested but not required. Overridden by needClientAuth.
                       type: boolean
                   required:
                   - name
                   type: object
                 type: array
               adminPassword:
+                description: Password for standard broker user. It is required for
+                  connecting to the broker and the web console. If left empty, it
+                  will be generated.
                 type: string
               adminUser:
+                description: User name for standard broker user. It is required for
+                  connecting to the broker and the web console. If left empty, it
+                  will be generated.
                 type: string
               connectors:
+                description: Specifies connectors and connector configuration
                 items:
                   properties:
                     enabledCipherSuites:
+                      description: Comma separated list of cipher suites used for
+                        SSL communication.
                       type: string
                     enabledProtocols:
+                      description: Comma separated list of protocols used for SSL
+                        communication.
                       type: string
                     expose:
+                      description: Whether or not to expose this connector
                       type: boolean
                     host:
+                      description: Hostname or IP to connect to
                       type: string
                     name:
+                      description: The name of the connector
                       type: string
                     needClientAuth:
+                      description: Tells a client connecting to this connector that
+                        2-way SSL is required. This property takes precedence over
+                        wantClientAuth.
                       type: boolean
                     port:
+                      description: Port number
                       format: int32
                       type: integer
                     sniHost:
+                      description: A regular expression used to match the server_name
+                        extension on incoming SSL connections. If the name doesn't
+                        match then the connection to the acceptor will be rejected.
                       type: string
                     sslEnabled:
+                      description: ' Whether or not to enable SSL on this port'
                       type: boolean
                     sslProvider:
+                      description: Used to change the SSL Provider between JDK and
+                        OPENSSL. The default is JDK.
                       type: string
                     sslSecret:
+                      description: Name of the secret to use for ssl information
                       type: string
                     type:
+                      description: The type either tcp or vm
                       type: string
                     verifyHost:
+                      description: The CN of the connecting client's SSL certificate
+                        will be compared to its hostname to verify they match. This
+                        is useful only for 2-way SSL.
                       type: boolean
                     wantClientAuth:
+                      description: Tells a client connecting to this connector that
+                        2-way SSL is requested but not required. Overridden by needClientAuth.
                       type: boolean
                   required:
                   - host
@@ -5380,44 +5511,66 @@ spec:
                   type: object
                 type: array
               console:
+                description: Specifies the console configuration
                 properties:
                   expose:
+                    description: Whether or not to expose this port
                     type: boolean
                   sslEnabled:
+                    description: Whether or not to enable SSL on this port
                     type: boolean
                   sslSecret:
+                    description: Name of the secret to use for ssl information
                     type: string
                   useClientAuth:
+                    description: If the embedded server requires client authentication
                     type: boolean
                 type: object
               deploymentPlan:
+                description: Specifies the deployment plan
                 properties:
                   image:
+                    description: The image used for the broker, all upgrades are disabled.
+                      Needs a corresponding initImage
                     type: string
                   journalType:
+                    description: If aio use ASYNCIO, if nio use NIO for journal IO
                     type: string
                   messageMigration:
+                    description: If true migrate messages on scaledown
                     type: boolean
                   persistenceEnabled:
+                    description: If true use persistent volume via persistent volume
+                      claim for journal storage
                     type: boolean
                   requireLogin:
+                    description: If true require user password login credentials for
+                      broker protocol ports
                     type: boolean
                   size:
+                    description: The number of broker pods to deploy
                     format: int32
                     type: integer
                 type: object
               upgrades:
-                description: ActiveMQArtemis App product upgrade flags
+                description: Specifies the upgrades (deprecated in favour of Version)
                 properties:
                   enabled:
+                    description: Set true to enable automatic micro version product
+                      upgrades, it is disabled by default.
                     type: boolean
                   minor:
+                    description: Set true to enable automatic minor product version
+                      upgrades, it is disabled by default. Requires spec.upgrades.enabled
+                      to be true.
                     type: boolean
                 required:
                 - enabled
                 - minor
                 type: object
               version:
+                description: The desired version of the broker. Can be x, or x.y or
+                  x.y.z to configure upgrades
                 type: string
             type: object
           status:
@@ -5512,7 +5665,7 @@ spec:
   - name: v2alpha3
     schema:
       openAPIV3Schema:
-        description: ActiveMQArtemis is the Schema for the activemqartemises API
+        description: A stateful deployment of one or more brokers
         properties:
           apiVersion:
             description: |-
@@ -5535,240 +5688,432 @@ spec:
             description: ActiveMQArtemisSpec defines the desired state of ActiveMQArtemis
             properties:
               acceptors:
+                description: Specifies the acceptor configuration
                 items:
                   properties:
                     amqpMinLargeMessageSize:
+                      description: AMQP Minimum Large Message Size
                       type: integer
                     anycastPrefix:
+                      description: To indicate which kind of routing type to use.
                       type: string
                     connectionsAllowed:
+                      description: Max number of connections allowed to make
                       type: integer
                     enabledCipherSuites:
+                      description: Comma separated list of cipher suites used for
+                        SSL communication.
                       type: string
                     enabledProtocols:
+                      description: Comma separated list of protocols used for SSL
+                        communication.
                       type: string
                     expose:
+                      description: Whether or not to expose this acceptor
                       type: boolean
                     multicastPrefix:
+                      description: To indicate which kind of routing type to use
                       type: string
                     name:
+                      description: The acceptor name
                       type: string
                     needClientAuth:
+                      description: Tells a client connecting to this acceptor that
+                        2-way SSL is required. This property takes precedence over
+                        wantClientAuth.
                       type: boolean
                     port:
+                      description: Port number
                       format: int32
                       type: integer
                     protocols:
+                      description: The protocols to enable for this acceptor
                       type: string
                     sniHost:
+                      description: A regular expression used to match the server_name
+                        extension on incoming SSL connections. If the name doesn't
+                        match then the connection to the acceptor will be rejected.
                       type: string
                     sslEnabled:
+                      description: Whether or not to enable SSL on this port
                       type: boolean
                     sslProvider:
+                      description: Used to change the SSL Provider between JDK and
+                        OPENSSL. The default is JDK.
                       type: string
                     sslSecret:
+                      description: Name of the secret to use for ssl information
                       type: string
                     verifyHost:
+                      description: The CN of the connecting client's SSL certificate
+                        will be compared to its hostname to verify they match. This
+                        is useful only for 2-way SSL.
                       type: boolean
                     wantClientAuth:
+                      description: Tells a client connecting to this acceptor that
+                        2-way SSL is requested but not required. Overridden by needClientAuth.
                       type: boolean
                   required:
                   - name
                   type: object
                 type: array
               addressSettings:
+                description: Specifies the address configurations (deprecated in favour
+                  of BrokerProperties)
                 properties:
                   addressSetting:
+                    description: Specifies the address settings
                     items:
                       properties:
                         addressFullPolicy:
+                          description: what happens when an address where maxSizeBytes
+                            is specified becomes full
                           type: string
                         autoCreateAddresses:
+                          description: whether or not to automatically create addresses
+                            when a client sends a message to or attempts to consume
+                            a message from a queue mapped to an address that doesnt
+                            exist
                           type: boolean
                         autoCreateDeadLetterResources:
+                          description: whether or not to automatically create the
+                            dead-letter-address and/or a corresponding queue on that
+                            address when a message found to be undeliverable
                           type: boolean
                         autoCreateExpiryResources:
+                          description: whether or not to automatically create the
+                            expiry-address and/or a corresponding queue on that address
+                            when a message is sent to a matching queue
                           type: boolean
                         autoCreateJmsQueues:
+                          description: DEPRECATED. whether or not to automatically
+                            create JMS queues when a producer sends or a consumer
+                            connects to a queue
                           type: boolean
                         autoCreateJmsTopics:
+                          description: DEPRECATED. whether or not to automatically
+                            create JMS topics when a producer sends or a consumer
+                            subscribes to a topic
                           type: boolean
                         autoCreateQueues:
+                          description: whether or not to automatically create a queue
+                            when a client sends a message to or attempts to consume
+                            a message from a queue
                           type: boolean
                         autoDeleteAddresses:
+                          description: whether or not to delete auto-created addresses
+                            when it no longer has any queues
                           type: boolean
                         autoDeleteAddressesDelay:
+                          description: how long to wait (in milliseconds) before deleting
+                            auto-created addresses after they no longer have any queues
                           format: int32
                           type: integer
                         autoDeleteCreatedQueues:
+                          description: whether or not to delete created queues when
+                            the queue has 0 consumers and 0 messages
                           type: boolean
                         autoDeleteJmsQueues:
+                          description: DEPRECATED. whether or not to delete auto-created
+                            JMS queues when the queue has 0 consumers and 0 messages
                           type: boolean
                         autoDeleteJmsTopics:
+                          description: DEPRECATED. whether or not to delete auto-created
+                            JMS topics when the last subscription is closed
                           type: boolean
                         autoDeleteQueues:
+                          description: whether or not to delete auto-created queues
+                            when the queue has 0 consumers and 0 messages
                           type: boolean
                         autoDeleteQueuesDelay:
+                          description: how long to wait (in milliseconds) before deleting
+                            auto-created queues after the queue has 0 consumers.
                           format: int32
                           type: integer
                         autoDeleteQueuesMessageCount:
+                          description: the message count the queue must be at or below
+                            before it can be evaluated to be auto deleted, 0 waits
+                            until empty queue (default) and -1 disables this check.
                           format: int32
                           type: integer
                         configDeleteAddresses:
+                          description: What to do when an address is no longer in
+                            broker.xml.  OFF = will do nothing addresses will remain,
+                            FORCE = delete address and its queues even if messages
+                            remaining.
                           type: string
                         configDeleteQueues:
+                          description: What to do when a queue is no longer in broker.xml.  OFF
+                            = will do nothing queues will remain, FORCE = delete queues
+                            even if messages remaining.
                           type: string
                         deadLetterAddress:
+                          description: the address to send dead messages to
                           type: string
                         deadLetterQueuePrefix:
+                          description: the prefix to use for auto-created dead letter
+                            queues
                           type: string
                         deadLetterQueueSuffix:
+                          description: the suffix to use for auto-created dead letter
+                            queues
                           type: string
                         defaultAddressRoutingType:
+                          description: the routing-type used on auto-created addresses
                           type: string
                         defaultConsumerWindowSize:
+                          description: the default window size for a consumer
                           format: int32
                           type: integer
                         defaultConsumersBeforeDispatch:
+                          description: the default number of consumers needed before
+                            dispatch can start for queues under the address.
                           format: int32
                           type: integer
                         defaultDelayBeforeDispatch:
+                          description: the default delay (in milliseconds) to wait
+                            before dispatching if number of consumers before dispatch
+                            is not met for queues under the address.
                           format: int32
                           type: integer
                         defaultExclusiveQueue:
+                          description: whether to treat the queues under the address
+                            as exclusive queues by default
                           type: boolean
                         defaultGroupBuckets:
+                          description: number of buckets to use for grouping, -1 (default)
+                            is unlimited and uses the raw group, 0 disables message
+                            groups.
                           format: int32
                           type: integer
                         defaultGroupFirstKey:
+                          description: key used to mark a message is first in a group
+                            for a consumer
                           type: string
                         defaultGroupRebalance:
+                          description: whether to rebalance groups when a consumer
+                            is added
                           type: boolean
                         defaultGroupRebalancePauseDispatch:
+                          description: whether to pause dispatch when rebalancing
+                            groups
                           type: boolean
                         defaultLastValueKey:
+                          description: the property to use as the key for a last value
+                            queue by default
                           type: string
                         defaultLastValueQueue:
+                          description: whether to treat the queues under the address
+                            as a last value queues by default
                           type: boolean
                         defaultMaxConsumers:
+                          description: the maximum number of consumers allowed on
+                            this queue at any one time
                           format: int32
                           type: integer
                         defaultNonDestructive:
+                          description: whether the queue should be non-destructive
+                            by default
                           type: boolean
                         defaultPurgeOnNoConsumers:
+                          description: purge the contents of the queue once there
+                            are no consumers
                           type: boolean
                         defaultQueueRoutingType:
+                          description: the routing-type used on auto-created queues
                           type: string
                         defaultRingSize:
+                          description: the default ring-size value for any matching
+                            queue which doesnt have ring-size explicitly defined
                           format: int32
                           type: integer
                         enableMetrics:
+                          description: whether or not to enable metrics for metrics
+                            plugins on the matching address
                           type: boolean
                         expiryAddress:
+                          description: the address to send expired messages to
                           type: string
                         expiryDelay:
+                          description: Overrides the expiration time for messages
+                            using the default value for expiration time. "-1" disables
+                            this setting.
                           format: int32
                           type: integer
                         expiryQueuePrefix:
+                          description: the prefix to use for auto-created expiry queues
                           type: string
                         expiryQueueSuffix:
+                          description: the suffix to use for auto-created expiry queues
                           type: string
                         lastValueQueue:
+                          description: This is deprecated please use default-last-value-queue
+                            instead.
                           type: boolean
                         managementBrowsePageSize:
+                          description: how many message a management resource can
+                            browse
                           format: int32
                           type: integer
                         match:
+                          description: pattern for matching settings against addresses;
+                            can use wildards
                           type: string
                         maxDeliveryAttempts:
+                          description: how many times to attempt to deliver a message
+                            before sending to dead letter address
                           format: int32
                           type: integer
                         maxExpiryDelay:
+                          description: Overrides the expiration time for messages
+                            using a higher value. "-1" disables this setting.
                           format: int32
                           type: integer
                         maxRedeliveryDelay:
+                          description: Maximum value for the redelivery-delay
                           format: int32
                           type: integer
                         maxSizeBytes:
+                          description: the maximum size in bytes for an address. -1
+                            means no limits. This is used in PAGING, BLOCK and FAIL
+                            policies. Supports byte notation like K, Mb, GB, etc.
                           type: string
                         maxSizeBytesRejectThreshold:
+                          description: used with the address full BLOCK policy, the
+                            maximum size in bytes an address can reach before messages
+                            start getting rejected. Works in combination with max-size-bytes
+                            for AMQP protocol only.  Default = -1 (no limit).
                           format: int32
                           type: integer
                         messageCounterHistoryDayLimit:
+                          description: how many days to keep message counter history
+                            for this address
                           format: int32
                           type: integer
                         minExpiryDelay:
+                          description: Overrides the expiration time for messages
+                            using a lower value. "-1" disables this setting.
                           format: int32
                           type: integer
                         pageMaxCacheSize:
+                          description: Number of paging files to cache in memory to
+                            avoid IO during paging navigation
                           format: int32
                           type: integer
                         pageSizeBytes:
+                          description: The page size in bytes to use for an address.
+                            Supports byte notation like K, Mb, GB, etc.
                           type: string
                         redeliveryCollisionAvoidanceFactor:
                           type: number
                         redeliveryDelay:
+                          description: the time (in ms) to wait before redelivering
+                            a cancelled message.
                           format: int32
                           type: integer
                         redeliveryDelayMultiplier:
                           format: int32
                           type: integer
                         redistributionDelay:
+                          description: how long (in ms) to wait after the last consumer
+                            is closed on a queue before redistributing messages.
                           format: int32
                           type: integer
                         retroactiveMessageCount:
+                          description: the number of messages to preserve for future
+                            queues created on the matching address
                           format: int32
                           type: integer
                         sendToDlaOnNoRoute:
+                          description: if there are no queues matching this address,
+                            whether to forward message to DLA (if it exists for this
+                            address)
                           type: boolean
                         slowConsumerCheckPeriod:
+                          description: How often to check for slow consumers on a
+                            particular queue. Measured in seconds.
                           format: int32
                           type: integer
                         slowConsumerPolicy:
+                          description: what happens when a slow consumer is identified
                           type: string
                         slowConsumerThreshold:
+                          description: The minimum rate of message consumption allowed
+                            before a consumer is considered "slow." Measured in messages-per-second.
                           format: int32
                           type: integer
                       type: object
                     type: array
                   applyRule:
+                    description: How to merge the address settings to broker configuration
                     type: string
                 type: object
               adminPassword:
+                description: Password for standard broker user. It is required for
+                  connecting to the broker and the web console. If left empty, it
+                  will be generated.
                 type: string
               adminUser:
+                description: User name for standard broker user. It is required for
+                  connecting to the broker and the web console. If left empty, it
+                  will be generated.
                 type: string
               connectors:
+                description: Specifies connectors and connector configuration
                 items:
                   properties:
                     enabledCipherSuites:
+                      description: Comma separated list of cipher suites used for
+                        SSL communication.
                       type: string
                     enabledProtocols:
+                      description: Comma separated list of protocols used for SSL
+                        communication.
                       type: string
                     expose:
+                      description: Whether or not to expose this connector
                       type: boolean
                     host:
+                      description: Hostname or IP to connect to
                       type: string
                     name:
+                      description: The name of the connector
                       type: string
                     needClientAuth:
+                      description: Tells a client connecting to this connector that
+                        2-way SSL is required. This property takes precedence over
+                        wantClientAuth.
                       type: boolean
                     port:
+                      description: Port number
                       format: int32
                       type: integer
                     sniHost:
+                      description: A regular expression used to match the server_name
+                        extension on incoming SSL connections. If the name doesn't
+                        match then the connection to the acceptor will be rejected.
                       type: string
                     sslEnabled:
+                      description: ' Whether or not to enable SSL on this port'
                       type: boolean
                     sslProvider:
+                      description: Used to change the SSL Provider between JDK and
+                        OPENSSL. The default is JDK.
                       type: string
                     sslSecret:
+                      description: Name of the secret to use for ssl information
                       type: string
                     type:
+                      description: The type either tcp or vm
                       type: string
                     verifyHost:
+                      description: The CN of the connecting client's SSL certificate
+                        will be compared to its hostname to verify they match. This
+                        is useful only for 2-way SSL.
                       type: boolean
                     wantClientAuth:
+                      description: Tells a client connecting to this connector that
+                        2-way SSL is requested but not required. Overridden by needClientAuth.
                       type: boolean
                   required:
                   - host
@@ -5777,31 +6122,45 @@ spec:
                   type: object
                 type: array
               console:
+                description: Specifies the console configuration
                 properties:
                   expose:
+                    description: Whether or not to expose this port
                     type: boolean
                   sslEnabled:
+                    description: Whether or not to enable SSL on this port
                     type: boolean
                   sslSecret:
+                    description: Name of the secret to use for ssl information
                     type: string
                   useClientAuth:
+                    description: If the embedded server requires client authentication
                     type: boolean
                 type: object
               deploymentPlan:
+                description: Specifies the deployment plan
                 properties:
                   image:
+                    description: The image used for the broker, all upgrades are disabled.
+                      Needs a corresponding initImage
                     type: string
                   journalType:
+                    description: If aio use ASYNCIO, if nio use NIO for journal IO
                     type: string
                   messageMigration:
+                    description: If true migrate messages on scaledown
                     type: boolean
                   persistenceEnabled:
+                    description: If true use persistent volume via persistent volume
+                      claim for journal storage
                     type: boolean
                   requireLogin:
+                    description: If true require user password login credentials for
+                      broker protocol ports
                     type: boolean
                   resources:
-                    description: ResourceRequirements describes the compute resource
-                      requirements.
+                    description: Specifies the minimum/maximum amount of compute resources
+                      required/allowed
                     properties:
                       claims:
                         description: |-
@@ -5854,26 +6213,36 @@ spec:
                         type: object
                     type: object
                   size:
+                    description: The number of broker pods to deploy
                     format: int32
                     type: integer
                   storage:
+                    description: Specifies the storage configurations
                     properties:
                       size:
+                        description: The storage size
                         type: string
                     type: object
                 type: object
               upgrades:
-                description: ActiveMQArtemis App product upgrade flags
+                description: Specifies the upgrades (deprecated in favour of Version)
                 properties:
                   enabled:
+                    description: Set true to enable automatic micro version product
+                      upgrades, it is disabled by default.
                     type: boolean
                   minor:
+                    description: Set true to enable automatic minor product version
+                      upgrades, it is disabled by default. Requires spec.upgrades.enabled
+                      to be true.
                     type: boolean
                 required:
                 - enabled
                 - minor
                 type: object
               version:
+                description: The desired version of the broker. Can be x, or x.y or
+                  x.y.z to configure upgrades
                 type: string
             type: object
           status:
@@ -5939,6 +6308,7 @@ spec:
                   type: object
                 type: array
               podStatus:
+                description: The current pods
                 properties:
                   ready:
                     description: Deployments are ready to serve requests
@@ -5968,7 +6338,7 @@ spec:
   - name: v2alpha4
     schema:
       openAPIV3Schema:
-        description: ActiveMQArtemis is the Schema for the activemqartemises API
+        description: A stateful deployment of one or more brokers
         properties:
           apiVersion:
             description: |-
@@ -5991,240 +6361,432 @@ spec:
             description: ActiveMQArtemisSpec defines the desired state of ActiveMQArtemis
             properties:
               acceptors:
+                description: Specifies the acceptor configuration
                 items:
                   properties:
                     amqpMinLargeMessageSize:
+                      description: AMQP Minimum Large Message Size
                       type: integer
                     anycastPrefix:
+                      description: To indicate which kind of routing type to use.
                       type: string
                     connectionsAllowed:
+                      description: Max number of connections allowed to make
                       type: integer
                     enabledCipherSuites:
+                      description: Comma separated list of cipher suites used for
+                        SSL communication.
                       type: string
                     enabledProtocols:
+                      description: Comma separated list of protocols used for SSL
+                        communication.
                       type: string
                     expose:
+                      description: Whether or not to expose this acceptor
                       type: boolean
                     multicastPrefix:
+                      description: To indicate which kind of routing type to use
                       type: string
                     name:
+                      description: The acceptor name
                       type: string
                     needClientAuth:
+                      description: Tells a client connecting to this acceptor that
+                        2-way SSL is required. This property takes precedence over
+                        wantClientAuth.
                       type: boolean
                     port:
+                      description: Port number
                       format: int32
                       type: integer
                     protocols:
+                      description: The protocols to enable for this acceptor
                       type: string
                     sniHost:
+                      description: A regular expression used to match the server_name
+                        extension on incoming SSL connections. If the name doesn't
+                        match then the connection to the acceptor will be rejected.
                       type: string
                     sslEnabled:
+                      description: Whether or not to enable SSL on this port
                       type: boolean
                     sslProvider:
+                      description: Used to change the SSL Provider between JDK and
+                        OPENSSL. The default is JDK.
                       type: string
                     sslSecret:
+                      description: Name of the secret to use for ssl information
                       type: string
                     verifyHost:
+                      description: The CN of the connecting client's SSL certificate
+                        will be compared to its hostname to verify they match. This
+                        is useful only for 2-way SSL.
                       type: boolean
                     wantClientAuth:
+                      description: Tells a client connecting to this acceptor that
+                        2-way SSL is requested but not required. Overridden by needClientAuth.
                       type: boolean
                   required:
                   - name
                   type: object
                 type: array
               addressSettings:
+                description: Specifies the address configurations (deprecated in favour
+                  of BrokerProperties)
                 properties:
                   addressSetting:
+                    description: Specifies the address settings
                     items:
                       properties:
                         addressFullPolicy:
+                          description: what happens when an address where maxSizeBytes
+                            is specified becomes full
                           type: string
                         autoCreateAddresses:
+                          description: whether or not to automatically create addresses
+                            when a client sends a message to or attempts to consume
+                            a message from a queue mapped to an address that doesnt
+                            exist
                           type: boolean
                         autoCreateDeadLetterResources:
+                          description: whether or not to automatically create the
+                            dead-letter-address and/or a corresponding queue on that
+                            address when a message found to be undeliverable
                           type: boolean
                         autoCreateExpiryResources:
+                          description: whether or not to automatically create the
+                            expiry-address and/or a corresponding queue on that address
+                            when a message is sent to a matching queue
                           type: boolean
                         autoCreateJmsQueues:
+                          description: DEPRECATED. whether or not to automatically
+                            create JMS queues when a producer sends or a consumer
+                            connects to a queue
                           type: boolean
                         autoCreateJmsTopics:
+                          description: DEPRECATED. whether or not to automatically
+                            create JMS topics when a producer sends or a consumer
+                            subscribes to a topic
                           type: boolean
                         autoCreateQueues:
+                          description: whether or not to automatically create a queue
+                            when a client sends a message to or attempts to consume
+                            a message from a queue
                           type: boolean
                         autoDeleteAddresses:
+                          description: whether or not to delete auto-created addresses
+                            when it no longer has any queues
                           type: boolean
                         autoDeleteAddressesDelay:
+                          description: how long to wait (in milliseconds) before deleting
+                            auto-created addresses after they no longer have any queues
                           format: int32
                           type: integer
                         autoDeleteCreatedQueues:
+                          description: whether or not to delete created queues when
+                            the queue has 0 consumers and 0 messages
                           type: boolean
                         autoDeleteJmsQueues:
+                          description: DEPRECATED. whether or not to delete auto-created
+                            JMS queues when the queue has 0 consumers and 0 messages
                           type: boolean
                         autoDeleteJmsTopics:
+                          description: DEPRECATED. whether or not to delete auto-created
+                            JMS topics when the last subscription is closed
                           type: boolean
                         autoDeleteQueues:
+                          description: whether or not to delete auto-created queues
+                            when the queue has 0 consumers and 0 messages
                           type: boolean
                         autoDeleteQueuesDelay:
+                          description: how long to wait (in milliseconds) before deleting
+                            auto-created queues after the queue has 0 consumers.
                           format: int32
                           type: integer
                         autoDeleteQueuesMessageCount:
+                          description: the message count the queue must be at or below
+                            before it can be evaluated to be auto deleted, 0 waits
+                            until empty queue (default) and -1 disables this check.
                           format: int32
                           type: integer
                         configDeleteAddresses:
+                          description: What to do when an address is no longer in
+                            broker.xml.  OFF = will do nothing addresses will remain,
+                            FORCE = delete address and its queues even if messages
+                            remaining.
                           type: string
                         configDeleteQueues:
+                          description: What to do when a queue is no longer in broker.xml.  OFF
+                            = will do nothing queues will remain, FORCE = delete queues
+                            even if messages remaining.
                           type: string
                         deadLetterAddress:
+                          description: the address to send dead messages to
                           type: string
                         deadLetterQueuePrefix:
+                          description: the prefix to use for auto-created dead letter
+                            queues
                           type: string
                         deadLetterQueueSuffix:
+                          description: the suffix to use for auto-created dead letter
+                            queues
                           type: string
                         defaultAddressRoutingType:
+                          description: the routing-type used on auto-created addresses
                           type: string
                         defaultConsumerWindowSize:
+                          description: the default window size for a consumer
                           format: int32
                           type: integer
                         defaultConsumersBeforeDispatch:
+                          description: the default number of consumers needed before
+                            dispatch can start for queues under the address.
                           format: int32
                           type: integer
                         defaultDelayBeforeDispatch:
+                          description: the default delay (in milliseconds) to wait
+                            before dispatching if number of consumers before dispatch
+                            is not met for queues under the address.
                           format: int32
                           type: integer
                         defaultExclusiveQueue:
+                          description: whether to treat the queues under the address
+                            as exclusive queues by default
                           type: boolean
                         defaultGroupBuckets:
+                          description: number of buckets to use for grouping, -1 (default)
+                            is unlimited and uses the raw group, 0 disables message
+                            groups.
                           format: int32
                           type: integer
                         defaultGroupFirstKey:
+                          description: key used to mark a message is first in a group
+                            for a consumer
                           type: string
                         defaultGroupRebalance:
+                          description: whether to rebalance groups when a consumer
+                            is added
                           type: boolean
                         defaultGroupRebalancePauseDispatch:
+                          description: whether to pause dispatch when rebalancing
+                            groups
                           type: boolean
                         defaultLastValueKey:
+                          description: the property to use as the key for a last value
+                            queue by default
                           type: string
                         defaultLastValueQueue:
+                          description: whether to treat the queues under the address
+                            as a last value queues by default
                           type: boolean
                         defaultMaxConsumers:
+                          description: the maximum number of consumers allowed on
+                            this queue at any one time
                           format: int32
                           type: integer
                         defaultNonDestructive:
+                          description: whether the queue should be non-destructive
+                            by default
                           type: boolean
                         defaultPurgeOnNoConsumers:
+                          description: purge the contents of the queue once there
+                            are no consumers
                           type: boolean
                         defaultQueueRoutingType:
+                          description: the routing-type used on auto-created queues
                           type: string
                         defaultRingSize:
+                          description: the default ring-size value for any matching
+                            queue which doesnt have ring-size explicitly defined
                           format: int32
                           type: integer
                         enableMetrics:
+                          description: whether or not to enable metrics for metrics
+                            plugins on the matching address
                           type: boolean
                         expiryAddress:
+                          description: the address to send expired messages to
                           type: string
                         expiryDelay:
+                          description: Overrides the expiration time for messages
+                            using the default value for expiration time. "-1" disables
+                            this setting.
                           format: int32
                           type: integer
                         expiryQueuePrefix:
+                          description: the prefix to use for auto-created expiry queues
                           type: string
                         expiryQueueSuffix:
+                          description: the suffix to use for auto-created expiry queues
                           type: string
                         lastValueQueue:
+                          description: This is deprecated please use default-last-value-queue
+                            instead.
                           type: boolean
                         managementBrowsePageSize:
+                          description: how many message a management resource can
+                            browse
                           format: int32
                           type: integer
                         match:
+                          description: pattern for matching settings against addresses;
+                            can use wildards
                           type: string
                         maxDeliveryAttempts:
+                          description: how many times to attempt to deliver a message
+                            before sending to dead letter address
                           format: int32
                           type: integer
                         maxExpiryDelay:
+                          description: Overrides the expiration time for messages
+                            using a higher value. "-1" disables this setting.
                           format: int32
                           type: integer
                         maxRedeliveryDelay:
+                          description: Maximum value for the redelivery-delay
                           format: int32
                           type: integer
                         maxSizeBytes:
+                          description: the maximum size in bytes for an address. -1
+                            means no limits. This is used in PAGING, BLOCK and FAIL
+                            policies. Supports byte notation like K, Mb, GB, etc.
                           type: string
                         maxSizeBytesRejectThreshold:
+                          description: used with the address full BLOCK policy, the
+                            maximum size in bytes an address can reach before messages
+                            start getting rejected. Works in combination with max-size-bytes
+                            for AMQP protocol only.  Default = -1 (no limit).
                           format: int32
                           type: integer
                         messageCounterHistoryDayLimit:
+                          description: how many days to keep message counter history
+                            for this address
                           format: int32
                           type: integer
                         minExpiryDelay:
+                          description: Overrides the expiration time for messages
+                            using a lower value. "-1" disables this setting.
                           format: int32
                           type: integer
                         pageMaxCacheSize:
+                          description: Number of paging files to cache in memory to
+                            avoid IO during paging navigation
                           format: int32
                           type: integer
                         pageSizeBytes:
+                          description: The page size in bytes to use for an address.
+                            Supports byte notation like K, Mb, GB, etc.
                           type: string
                         redeliveryCollisionAvoidanceFactor:
                           type: number
                         redeliveryDelay:
+                          description: the time (in ms) to wait before redelivering
+                            a cancelled message.
                           format: int32
                           type: integer
                         redeliveryDelayMultiplier:
                           format: int32
                           type: integer
                         redistributionDelay:
+                          description: how long (in ms) to wait after the last consumer
+                            is closed on a queue before redistributing messages.
                           format: int32
                           type: integer
                         retroactiveMessageCount:
+                          description: the number of messages to preserve for future
+                            queues created on the matching address
                           format: int32
                           type: integer
                         sendToDlaOnNoRoute:
+                          description: if there are no queues matching this address,
+                            whether to forward message to DLA (if it exists for this
+                            address)
                           type: boolean
                         slowConsumerCheckPeriod:
+                          description: How often to check for slow consumers on a
+                            particular queue. Measured in seconds.
                           format: int32
                           type: integer
                         slowConsumerPolicy:
+                          description: what happens when a slow consumer is identified
                           type: string
                         slowConsumerThreshold:
+                          description: The minimum rate of message consumption allowed
+                            before a consumer is considered "slow." Measured in messages-per-second.
                           format: int32
                           type: integer
                       type: object
                     type: array
                   applyRule:
+                    description: How to merge the address settings to broker configuration
                     type: string
                 type: object
               adminPassword:
+                description: Password for standard broker user. It is required for
+                  connecting to the broker and the web console. If left empty, it
+                  will be generated.
                 type: string
               adminUser:
+                description: User name for standard broker user. It is required for
+                  connecting to the broker and the web console. If left empty, it
+                  will be generated.
                 type: string
               connectors:
+                description: Specifies connectors and connector configuration
                 items:
                   properties:
                     enabledCipherSuites:
+                      description: Comma separated list of cipher suites used for
+                        SSL communication.
                       type: string
                     enabledProtocols:
+                      description: Comma separated list of protocols used for SSL
+                        communication.
                       type: string
                     expose:
+                      description: Whether or not to expose this connector
                       type: boolean
                     host:
+                      description: Hostname or IP to connect to
                       type: string
                     name:
+                      description: The name of the connector
                       type: string
                     needClientAuth:
+                      description: Tells a client connecting to this connector that
+                        2-way SSL is required. This property takes precedence over
+                        wantClientAuth.
                       type: boolean
                     port:
+                      description: Port number
                       format: int32
                       type: integer
                     sniHost:
+                      description: A regular expression used to match the server_name
+                        extension on incoming SSL connections. If the name doesn't
+                        match then the connection to the acceptor will be rejected.
                       type: string
                     sslEnabled:
+                      description: ' Whether or not to enable SSL on this port'
                       type: boolean
                     sslProvider:
+                      description: Used to change the SSL Provider between JDK and
+                        OPENSSL. The default is JDK.
                       type: string
                     sslSecret:
+                      description: Name of the secret to use for ssl information
                       type: string
                     type:
+                      description: The type either tcp or vm
                       type: string
                     verifyHost:
+                      description: The CN of the connecting client's SSL certificate
+                        will be compared to its hostname to verify they match. This
+                        is useful only for 2-way SSL.
                       type: boolean
                     wantClientAuth:
+                      description: Tells a client connecting to this connector that
+                        2-way SSL is requested but not required. Overridden by needClientAuth.
                       type: boolean
                   required:
                   - host
@@ -6233,37 +6795,55 @@ spec:
                   type: object
                 type: array
               console:
+                description: Specifies the console configuration
                 properties:
                   expose:
+                    description: Whether or not to expose this port
                     type: boolean
                   sslEnabled:
+                    description: Whether or not to enable SSL on this port
                     type: boolean
                   sslSecret:
+                    description: Name of the secret to use for ssl information
                     type: string
                   useClientAuth:
+                    description: If the embedded server requires client authentication
                     type: boolean
                 type: object
               deploymentPlan:
+                description: Specifies the deployment plan
                 properties:
                   image:
+                    description: The image used for the broker, all upgrades are disabled.
+                      Needs a corresponding initImage
                     type: string
                   initImage:
+                    description: The init container image used to configure broker,
+                      all upgrades are disabled. Needs a corresponding image
                     type: string
                   jolokiaAgentEnabled:
+                    description: If true enable the Jolokia JVM Agent
                     type: boolean
                   journalType:
+                    description: If aio use ASYNCIO, if nio use NIO for journal IO
                     type: string
                   managementRBACEnabled:
+                    description: If true enable the management role based access control
                     type: boolean
                   messageMigration:
+                    description: If true migrate messages on scaledown
                     type: boolean
                   persistenceEnabled:
+                    description: If true use persistent volume via persistent volume
+                      claim for journal storage
                     type: boolean
                   requireLogin:
+                    description: If true require user password login credentials for
+                      broker protocol ports
                     type: boolean
                   resources:
-                    description: ResourceRequirements describes the compute resource
-                      requirements.
+                    description: Specifies the minimum/maximum amount of compute resources
+                      required/allowed
                     properties:
                       claims:
                         description: |-
@@ -6316,26 +6896,36 @@ spec:
                         type: object
                     type: object
                   size:
+                    description: The number of broker pods to deploy
                     format: int32
                     type: integer
                   storage:
+                    description: Specifies the storage configurations
                     properties:
                       size:
+                        description: The storage size
                         type: string
                     type: object
                 type: object
               upgrades:
-                description: ActiveMQArtemis App product upgrade flags
+                description: Specifies the upgrades (deprecated in favour of Version)
                 properties:
                   enabled:
+                    description: Set true to enable automatic micro version product
+                      upgrades, it is disabled by default.
                     type: boolean
                   minor:
+                    description: Set true to enable automatic minor product version
+                      upgrades, it is disabled by default. Requires spec.upgrades.enabled
+                      to be true.
                     type: boolean
                 required:
                 - enabled
                 - minor
                 type: object
               version:
+                description: The desired version of the broker. Can be x, or x.y or
+                  x.y.z to configure upgrades
                 type: string
             type: object
           status:
@@ -6401,6 +6991,7 @@ spec:
                   type: object
                 type: array
               podStatus:
+                description: The current pods
                 properties:
                   ready:
                     description: Deployments are ready to serve requests
@@ -6430,7 +7021,7 @@ spec:
   - name: v2alpha5
     schema:
       openAPIV3Schema:
-        description: ActiveMQArtemis is the Schema for the activemqartemises API
+        description: A stateful deployment of one or more brokers
         properties:
           apiVersion:
             description: |-
@@ -6453,250 +7044,452 @@ spec:
             description: ActiveMQArtemisSpec defines the desired state of ActiveMQArtemis
             properties:
               acceptors:
+                description: Specifies the acceptor configuration
                 items:
                   properties:
                     amqpMinLargeMessageSize:
+                      description: AMQP Minimum Large Message Size
                       type: integer
                     anycastPrefix:
+                      description: To indicate which kind of routing type to use.
                       type: string
                     connectionsAllowed:
+                      description: Max number of connections allowed to make
                       type: integer
                     enabledCipherSuites:
+                      description: Comma separated list of cipher suites used for
+                        SSL communication.
                       type: string
                     enabledProtocols:
+                      description: Comma separated list of protocols used for SSL
+                        communication.
                       type: string
                     expose:
+                      description: Whether or not to expose this acceptor
                       type: boolean
                     multicastPrefix:
+                      description: To indicate which kind of routing type to use
                       type: string
                     name:
+                      description: The acceptor name
                       type: string
                     needClientAuth:
+                      description: Tells a client connecting to this acceptor that
+                        2-way SSL is required. This property takes precedence over
+                        wantClientAuth.
                       type: boolean
                     port:
+                      description: Port number
                       format: int32
                       type: integer
                     protocols:
+                      description: The protocols to enable for this acceptor
                       type: string
                     sniHost:
+                      description: A regular expression used to match the server_name
+                        extension on incoming SSL connections. If the name doesn't
+                        match then the connection to the acceptor will be rejected.
                       type: string
                     sslEnabled:
+                      description: Whether or not to enable SSL on this port
                       type: boolean
                     sslProvider:
+                      description: Used to change the SSL Provider between JDK and
+                        OPENSSL. The default is JDK.
                       type: string
                     sslSecret:
+                      description: Name of the secret to use for ssl information
                       type: string
                     supportAdvisory:
+                      description: For openwire protocol if advisory topics are enabled,
+                        default false
                       type: boolean
                     suppressInternalManagementObjects:
+                      description: If prevents advisory addresses/queues to be registered
+                        to management service, default false
                       type: boolean
                     verifyHost:
+                      description: The CN of the connecting client's SSL certificate
+                        will be compared to its hostname to verify they match. This
+                        is useful only for 2-way SSL.
                       type: boolean
                     wantClientAuth:
+                      description: Tells a client connecting to this acceptor that
+                        2-way SSL is requested but not required. Overridden by needClientAuth.
                       type: boolean
                   required:
                   - name
                   type: object
                 type: array
               addressSettings:
+                description: Specifies the address configurations (deprecated in favour
+                  of BrokerProperties)
                 properties:
                   addressSetting:
+                    description: Specifies the address settings
                     items:
                       properties:
                         addressFullPolicy:
+                          description: what happens when an address where maxSizeBytes
+                            is specified becomes full
                           type: string
                         autoCreateAddresses:
+                          description: whether or not to automatically create addresses
+                            when a client sends a message to or attempts to consume
+                            a message from a queue mapped to an address that doesnt
+                            exist
                           type: boolean
                         autoCreateDeadLetterResources:
+                          description: whether or not to automatically create the
+                            dead-letter-address and/or a corresponding queue on that
+                            address when a message found to be undeliverable
                           type: boolean
                         autoCreateExpiryResources:
+                          description: whether or not to automatically create the
+                            expiry-address and/or a corresponding queue on that address
+                            when a message is sent to a matching queue
                           type: boolean
                         autoCreateJmsQueues:
+                          description: DEPRECATED. whether or not to automatically
+                            create JMS queues when a producer sends or a consumer
+                            connects to a queue
                           type: boolean
                         autoCreateJmsTopics:
+                          description: DEPRECATED. whether or not to automatically
+                            create JMS topics when a producer sends or a consumer
+                            subscribes to a topic
                           type: boolean
                         autoCreateQueues:
+                          description: whether or not to automatically create a queue
+                            when a client sends a message to or attempts to consume
+                            a message from a queue
                           type: boolean
                         autoDeleteAddresses:
+                          description: whether or not to delete auto-created addresses
+                            when it no longer has any queues
                           type: boolean
                         autoDeleteAddressesDelay:
+                          description: how long to wait (in milliseconds) before deleting
+                            auto-created addresses after they no longer have any queues
                           format: int32
                           type: integer
                         autoDeleteCreatedQueues:
+                          description: whether or not to delete created queues when
+                            the queue has 0 consumers and 0 messages
                           type: boolean
                         autoDeleteJmsQueues:
+                          description: DEPRECATED. whether or not to delete auto-created
+                            JMS queues when the queue has 0 consumers and 0 messages
                           type: boolean
                         autoDeleteJmsTopics:
+                          description: DEPRECATED. whether or not to delete auto-created
+                            JMS topics when the last subscription is closed
                           type: boolean
                         autoDeleteQueues:
+                          description: whether or not to delete auto-created queues
+                            when the queue has 0 consumers and 0 messages
                           type: boolean
                         autoDeleteQueuesDelay:
+                          description: how long to wait (in milliseconds) before deleting
+                            auto-created queues after the queue has 0 consumers.
                           format: int32
                           type: integer
                         autoDeleteQueuesMessageCount:
+                          description: the message count the queue must be at or below
+                            before it can be evaluated to be auto deleted, 0 waits
+                            until empty queue (default) and -1 disables this check.
                           format: int32
                           type: integer
                         configDeleteAddresses:
+                          description: What to do when an address is no longer in
+                            broker.xml.  OFF = will do nothing addresses will remain,
+                            FORCE = delete address and its queues even if messages
+                            remaining.
                           type: string
                         configDeleteQueues:
+                          description: What to do when a queue is no longer in broker.xml.  OFF
+                            = will do nothing queues will remain, FORCE = delete queues
+                            even if messages remaining.
                           type: string
                         deadLetterAddress:
+                          description: the address to send dead messages to
                           type: string
                         deadLetterQueuePrefix:
+                          description: the prefix to use for auto-created dead letter
+                            queues
                           type: string
                         deadLetterQueueSuffix:
+                          description: the suffix to use for auto-created dead letter
+                            queues
                           type: string
                         defaultAddressRoutingType:
+                          description: the routing-type used on auto-created addresses
                           type: string
                         defaultConsumerWindowSize:
+                          description: the default window size for a consumer
                           format: int32
                           type: integer
                         defaultConsumersBeforeDispatch:
+                          description: the default number of consumers needed before
+                            dispatch can start for queues under the address.
                           format: int32
                           type: integer
                         defaultDelayBeforeDispatch:
+                          description: the default delay (in milliseconds) to wait
+                            before dispatching if number of consumers before dispatch
+                            is not met for queues under the address.
                           format: int32
                           type: integer
                         defaultExclusiveQueue:
+                          description: whether to treat the queues under the address
+                            as exclusive queues by default
                           type: boolean
                         defaultGroupBuckets:
+                          description: number of buckets to use for grouping, -1 (default)
+                            is unlimited and uses the raw group, 0 disables message
+                            groups.
                           format: int32
                           type: integer
                         defaultGroupFirstKey:
+                          description: key used to mark a message is first in a group
+                            for a consumer
                           type: string
                         defaultGroupRebalance:
+                          description: whether to rebalance groups when a consumer
+                            is added
                           type: boolean
                         defaultGroupRebalancePauseDispatch:
+                          description: whether to pause dispatch when rebalancing
+                            groups
                           type: boolean
                         defaultLastValueKey:
+                          description: the property to use as the key for a last value
+                            queue by default
                           type: string
                         defaultLastValueQueue:
+                          description: whether to treat the queues under the address
+                            as a last value queues by default
                           type: boolean
                         defaultMaxConsumers:
+                          description: the maximum number of consumers allowed on
+                            this queue at any one time
                           format: int32
                           type: integer
                         defaultNonDestructive:
+                          description: whether the queue should be non-destructive
+                            by default
                           type: boolean
                         defaultPurgeOnNoConsumers:
+                          description: purge the contents of the queue once there
+                            are no consumers
                           type: boolean
                         defaultQueueRoutingType:
+                          description: the routing-type used on auto-created queues
                           type: string
                         defaultRingSize:
+                          description: the default ring-size value for any matching
+                            queue which doesnt have ring-size explicitly defined
                           format: int32
                           type: integer
                         enableIngressTimestamp:
+                          description: Whether or not set the timestamp of arrival
+                            on messages. default false
                           type: boolean
                         enableMetrics:
+                          description: whether or not to enable metrics for metrics
+                            plugins on the matching address
                           type: boolean
                         expiryAddress:
+                          description: the address to send expired messages to
                           type: string
                         expiryDelay:
+                          description: Overrides the expiration time for messages
+                            using the default value for expiration time. "-1" disables
+                            this setting.
                           format: int32
                           type: integer
                         expiryQueuePrefix:
+                          description: the prefix to use for auto-created expiry queues
                           type: string
                         expiryQueueSuffix:
+                          description: the suffix to use for auto-created expiry queues
                           type: string
                         lastValueQueue:
+                          description: This is deprecated please use default-last-value-queue
+                            instead.
                           type: boolean
                         managementBrowsePageSize:
+                          description: how many message a management resource can
+                            browse
                           format: int32
                           type: integer
                         managementMessageAttributeSizeLimit:
+                          description: max size of the message returned from management
+                            API, default 256
                           format: int32
                           type: integer
                         match:
+                          description: pattern for matching settings against addresses;
+                            can use wildards
                           type: string
                         maxDeliveryAttempts:
+                          description: how many times to attempt to deliver a message
+                            before sending to dead letter address
                           format: int32
                           type: integer
                         maxExpiryDelay:
+                          description: Overrides the expiration time for messages
+                            using a higher value. "-1" disables this setting.
                           format: int32
                           type: integer
                         maxRedeliveryDelay:
+                          description: Maximum value for the redelivery-delay
                           format: int32
                           type: integer
                         maxSizeBytes:
+                          description: the maximum size in bytes for an address. -1
+                            means no limits. This is used in PAGING, BLOCK and FAIL
+                            policies. Supports byte notation like K, Mb, GB, etc.
                           type: string
                         maxSizeBytesRejectThreshold:
+                          description: used with the address full BLOCK policy, the
+                            maximum size in bytes an address can reach before messages
+                            start getting rejected. Works in combination with max-size-bytes
+                            for AMQP protocol only.  Default = -1 (no limit).
                           format: int32
                           type: integer
                         messageCounterHistoryDayLimit:
+                          description: how many days to keep message counter history
+                            for this address
                           format: int32
                           type: integer
                         minExpiryDelay:
+                          description: Overrides the expiration time for messages
+                            using a lower value. "-1" disables this setting.
                           format: int32
                           type: integer
                         pageMaxCacheSize:
+                          description: Number of paging files to cache in memory to
+                            avoid IO during paging navigation
                           format: int32
                           type: integer
                         pageSizeBytes:
+                          description: The page size in bytes to use for an address.
+                            Supports byte notation like K, Mb, GB, etc.
                           type: string
                         redeliveryCollisionAvoidanceFactor:
                           type: number
                         redeliveryDelay:
+                          description: the time (in ms) to wait before redelivering
+                            a cancelled message.
                           format: int32
                           type: integer
                         redeliveryDelayMultiplier:
                           type: number
                         redistributionDelay:
+                          description: how long (in ms) to wait after the last consumer
+                            is closed on a queue before redistributing messages.
                           format: int32
                           type: integer
                         retroactiveMessageCount:
+                          description: the number of messages to preserve for future
+                            queues created on the matching address
                           format: int32
                           type: integer
                         sendToDlaOnNoRoute:
+                          description: if there are no queues matching this address,
+                            whether to forward message to DLA (if it exists for this
+                            address)
                           type: boolean
                         slowConsumerCheckPeriod:
+                          description: How often to check for slow consumers on a
+                            particular queue. Measured in seconds.
                           format: int32
                           type: integer
                         slowConsumerPolicy:
+                          description: what happens when a slow consumer is identified
                           type: string
                         slowConsumerThreshold:
+                          description: The minimum rate of message consumption allowed
+                            before a consumer is considered "slow." Measured in messages-per-second.
                           format: int32
                           type: integer
                         slowConsumerThresholdMeasurementUnit:
+                          description: Unit used in specifying slow consumer threshold,
+                            default is MESSAGE_PER_SECOND
                           type: string
                       type: object
                     type: array
                   applyRule:
+                    description: How to merge the address settings to broker configuration
                     type: string
                 type: object
               adminPassword:
+                description: Password for standard broker user. It is required for
+                  connecting to the broker and the web console. If left empty, it
+                  will be generated.
                 type: string
               adminUser:
+                description: User name for standard broker user. It is required for
+                  connecting to the broker and the web console. If left empty, it
+                  will be generated.
                 type: string
               connectors:
+                description: Specifies connectors and connector configuration
                 items:
                   properties:
                     enabledCipherSuites:
+                      description: Comma separated list of cipher suites used for
+                        SSL communication.
                       type: string
                     enabledProtocols:
+                      description: Comma separated list of protocols used for SSL
+                        communication.
                       type: string
                     expose:
+                      description: Whether or not to expose this connector
                       type: boolean
                     host:
+                      description: Hostname or IP to connect to
                       type: string
                     name:
+                      description: The name of the connector
                       type: string
                     needClientAuth:
+                      description: Tells a client connecting to this connector that
+                        2-way SSL is required. This property takes precedence over
+                        wantClientAuth.
                       type: boolean
                     port:
+                      description: Port number
                       format: int32
                       type: integer
                     sniHost:
+                      description: A regular expression used to match the server_name
+                        extension on incoming SSL connections. If the name doesn't
+                        match then the connection to the acceptor will be rejected.
                       type: string
                     sslEnabled:
+                      description: ' Whether or not to enable SSL on this port'
                       type: boolean
                     sslProvider:
+                      description: Used to change the SSL Provider between JDK and
+                        OPENSSL. The default is JDK.
                       type: string
                     sslSecret:
+                      description: Name of the secret to use for ssl information
                       type: string
                     type:
+                      description: The type either tcp or vm
                       type: string
                     verifyHost:
+                      description: The CN of the connecting client's SSL certificate
+                        will be compared to its hostname to verify they match. This
+                        is useful only for 2-way SSL.
                       type: boolean
                     wantClientAuth:
+                      description: Tells a client connecting to this connector that
+                        2-way SSL is requested but not required. Overridden by needClientAuth.
                       type: boolean
                   required:
                   - host
@@ -6705,72 +7498,101 @@ spec:
                   type: object
                 type: array
               console:
+                description: Specifies the console configuration
                 properties:
                   expose:
+                    description: Whether or not to expose this port
                     type: boolean
                   sslEnabled:
+                    description: Whether or not to enable SSL on this port
                     type: boolean
                   sslSecret:
+                    description: Name of the secret to use for ssl information
                     type: string
                   useClientAuth:
+                    description: If the embedded server requires client authentication
                     type: boolean
                 type: object
               deploymentPlan:
+                description: Specifies the deployment plan
                 properties:
                   clustered:
+                    description: Whether broker is clustered
                     type: boolean
                   enableMetricsPlugin:
+                    description: Whether or not to install the artemis metrics plugin
                     type: boolean
                   extraMounts:
+                    description: Specifies extra mounts
                     properties:
                       configMaps:
+                        description: Specifies ConfigMap names
                         items:
                           type: string
                         type: array
                       secrets:
+                        description: Specifies Secret names
                         items:
                           type: string
                         type: array
                     type: object
                   image:
+                    description: The image used for the broker, all upgrades are disabled.
+                      Needs a corresponding initImage
                     type: string
                   initImage:
+                    description: The init container image used to configure broker,
+                      all upgrades are disabled. Needs a corresponding image
                     type: string
                   jolokiaAgentEnabled:
+                    description: If true enable the Jolokia JVM Agent
                     type: boolean
                   journalType:
+                    description: If aio use ASYNCIO, if nio use NIO for journal IO
                     type: string
                   livenessProbe:
+                    description: Specifies the liveness probe configuration
                     properties:
                       timeoutSeconds:
                         format: int32
                         type: integer
                     type: object
                   managementRBACEnabled:
+                    description: If true enable the management role based access control
                     type: boolean
                   messageMigration:
+                    description: If true migrate messages on scaledown
                     type: boolean
                   persistenceEnabled:
+                    description: If true use persistent volume via persistent volume
+                      claim for journal storage
                     type: boolean
                   podSecurity:
+                    description: Specifies the pod security configurations
                     properties:
                       runAsUser:
+                        description: runAsUser as defined in PodSecurityContext for
+                          the pod
                         format: int64
                         type: integer
                       serviceAccountName:
+                        description: ServiceAccount Name of the pod
                         type: string
                     type: object
                   readinessProbe:
+                    description: Specifies the readiness probe configuration
                     properties:
                       timeoutSeconds:
                         format: int32
                         type: integer
                     type: object
                   requireLogin:
+                    description: If true require user password login credentials for
+                      broker protocol ports
                     type: boolean
                   resources:
-                    description: ResourceRequirements describes the compute resource
-                      requirements.
+                    description: Specifies the minimum/maximum amount of compute resources
+                      required/allowed
                     properties:
                       claims:
                         description: |-
@@ -6823,26 +7645,36 @@ spec:
                         type: object
                     type: object
                   size:
+                    description: The number of broker pods to deploy
                     format: int32
                     type: integer
                   storage:
+                    description: Specifies the storage configurations
                     properties:
                       size:
+                        description: The storage size
                         type: string
                     type: object
                 type: object
               upgrades:
-                description: ActiveMQArtemis App product upgrade flags
+                description: Specifies the upgrades (deprecated in favour of Version)
                 properties:
                   enabled:
+                    description: Set true to enable automatic micro version product
+                      upgrades, it is disabled by default.
                     type: boolean
                   minor:
+                    description: Set true to enable automatic minor product version
+                      upgrades, it is disabled by default. Requires spec.upgrades.enabled
+                      to be true.
                     type: boolean
                 required:
                 - enabled
                 - minor
                 type: object
               version:
+                description: The desired version of the broker. Can be x, or x.y or
+                  x.y.z to configure upgrades
                 type: string
             type: object
           status:
@@ -6908,9 +7740,7 @@ spec:
                   type: object
                 type: array
               podStatus:
-                description: |-
-                  INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
-                  Important: Run "make" to regenerate code after modifying this file
+                description: The current pods
                 properties:
                   ready:
                     description: Deployments are ready to serve requests

--- a/bundle/tests/scorecard/config.yaml
+++ b/bundle/tests/scorecard/config.yaml
@@ -8,7 +8,7 @@ stages:
   - entrypoint:
     - scorecard-test
     - basic-check-spec
-    image: quay.io/operator-framework/scorecard-test:v1.34
+    image: quay.io/operator-framework/scorecard-test:v1.41
     labels:
       suite: basic
       test: basic-check-spec-test
@@ -18,7 +18,7 @@ stages:
   - entrypoint:
     - scorecard-test
     - olm-bundle-validation
-    image: quay.io/operator-framework/scorecard-test:v1.34
+    image: quay.io/operator-framework/scorecard-test:v1.41
     labels:
       suite: olm
       test: olm-bundle-validation-test
@@ -28,7 +28,7 @@ stages:
   - entrypoint:
     - scorecard-test
     - olm-crds-have-validation
-    image: quay.io/operator-framework/scorecard-test:v1.34
+    image: quay.io/operator-framework/scorecard-test:v1.41
     labels:
       suite: olm
       test: olm-crds-have-validation-test
@@ -38,7 +38,7 @@ stages:
   - entrypoint:
     - scorecard-test
     - olm-crds-have-resources
-    image: quay.io/operator-framework/scorecard-test:v1.34
+    image: quay.io/operator-framework/scorecard-test:v1.41
     labels:
       suite: olm
       test: olm-crds-have-resources-test
@@ -48,7 +48,7 @@ stages:
   - entrypoint:
     - scorecard-test
     - olm-spec-descriptors
-    image: quay.io/operator-framework/scorecard-test:v1.34
+    image: quay.io/operator-framework/scorecard-test:v1.41
     labels:
       suite: olm
       test: olm-spec-descriptors-test
@@ -58,7 +58,7 @@ stages:
   - entrypoint:
     - scorecard-test
     - olm-status-descriptors
-    image: quay.io/operator-framework/scorecard-test:v1.34
+    image: quay.io/operator-framework/scorecard-test:v1.41
     labels:
       suite: olm
       test: olm-status-descriptors-test

--- a/config/crd/bases/broker.amq.io_activemqartemisaddresses.yaml
+++ b/config/crd/bases/broker.amq.io_activemqartemisaddresses.yaml
@@ -240,8 +240,7 @@ spec:
     name: v2alpha1
     schema:
       openAPIV3Schema:
-        description: ActiveMQArtemisAddress is the Schema for the activemqartemisaddresses
-          API
+        description: Adding and removing addresses using custom resource definitions
         properties:
           apiVersion:
             description: |-
@@ -264,10 +263,13 @@ spec:
             description: ActiveMQArtemisAddressSpec defines the desired state of ActiveMQArtemisAddress
             properties:
               addressName:
+                description: The Address Name
                 type: string
               queueName:
+                description: The Queue Name
                 type: string
               routingType:
+                description: The Routing Type
                 type: string
             type: object
           status:
@@ -345,8 +347,7 @@ spec:
     name: v2alpha2
     schema:
       openAPIV3Schema:
-        description: ActiveMQArtemisAddress is the Schema for the activemqartemisaddresses
-          API
+        description: Adding and removing addresses using custom resource definitions
         properties:
           apiVersion:
             description: |-
@@ -369,12 +370,17 @@ spec:
             description: ActiveMQArtemisAddressSpec defines the desired state of ActiveMQArtemisAddress
             properties:
               addressName:
+                description: The Address Name
                 type: string
               queueName:
+                description: The Queue Name
                 type: string
               removeFromBrokerOnDelete:
+                description: Whether or not delete the queue from broker when CR is
+                  undeployed(default false)
                 type: boolean
               routingType:
+                description: The Routing Type
                 type: string
             type: object
           status:
@@ -452,8 +458,7 @@ spec:
     name: v2alpha3
     schema:
       openAPIV3Schema:
-        description: ActiveMQArtemisAddress is the Schema for the activemqartemisaddresses
-          API
+        description: Adding and removing addresses using custom resource definitions
         properties:
           apiVersion:
             description: |-
@@ -476,83 +481,124 @@ spec:
             description: ActiveMQArtemisAddressSpec defines the desired state of ActiveMQArtemisAddress
             properties:
               addressName:
+                description: The Address Name
                 type: string
               applyToCrNames:
+                description: Apply to the broker crs in the current namespace. A value
+                  of * or empty string means applying to all broker crs. Default apply
+                  to all broker crs
                 items:
                   type: string
                 type: array
               password:
+                description: The password for the user
                 type: string
               queueConfiguration:
+                description: Specify the queue configuration
                 properties:
                   autoCreateAddress:
+                    description: Whether auto create address
                     type: boolean
                   autoDelete:
+                    description: Auto-delete the queue
                     type: boolean
                   autoDeleteDelay:
+                    description: Delay (Milliseconds) before auto-delete the queue
                     format: int64
                     type: integer
                   autoDeleteMessageCount:
+                    description: Message count of the queue to allow auto delete
                     format: int64
                     type: integer
                   configurationManaged:
+                    description: ' If the queue is configuration managed'
                     type: boolean
                   consumerPriority:
+                    description: Consumer Priority
                     format: int32
                     type: integer
                   consumersBeforeDispatch:
+                    description: Number of consumers required before dispatching messages
                     format: int32
                     type: integer
                   delayBeforeDispatch:
+                    description: Milliseconds to wait for `consumers-before-dispatch`
+                      to be met before dispatching messages anyway
                     format: int64
                     type: integer
                   durable:
+                    description: If the queue is durable or not
                     type: boolean
                   enabled:
+                    description: If the queue is enabled
                     type: boolean
                   exclusive:
+                    description: If the queue is exclusive
                     type: boolean
                   filterString:
+                    description: The filter string for the queue
                     type: string
                   groupBuckets:
+                    description: Number of messaging group buckets
                     format: int32
                     type: integer
                   groupFirstKey:
+                    description: Header set on the first group message
                     type: string
                   groupRebalance:
+                    description: If rebalance the message group
                     type: boolean
                   groupRebalancePauseDispatch:
+                    description: If pause message dispatch when rebalancing groups
                     type: boolean
                   ignoreIfExists:
+                    description: If ignore if the target queue already exists
                     type: boolean
                   lastValue:
+                    description: If it is a last value queue
                     type: boolean
                   lastValueKey:
+                    description: The property used for last value queue to identify
+                      last values
                     type: string
                   maxConsumers:
+                    description: Max number of consumers allowed on this queue
                     format: int32
                     type: integer
                   nonDestructive:
+                    description: If force non-destructive consumers on the queue
                     type: boolean
                   purgeOnNoConsumers:
+                    description: Whether to delete all messages when no consumers
+                      connected to the queue
                     type: boolean
                   ringSize:
+                    description: The size the queue should maintain according to ring
+                      semantics
                     format: int64
                     type: integer
                   routingType:
+                    description: The routing type of the queue
                     type: string
                   temporary:
+                    description: If the queue is temporary
                     type: boolean
                   user:
+                    description: The user associated with the queue
                     type: string
                 type: object
               queueName:
+                description: The Queue Name
                 type: string
               removeFromBrokerOnDelete:
+                description: Whether or not delete the queue from broker when CR is
+                  undeployed(default false)
                 type: boolean
               routingType:
+                description: The Routing Type
                 type: string
               user:
+                description: User name for creating the queue or address
                 type: string
             type: object
           status:

--- a/config/crd/bases/broker.amq.io_activemqartemises.yaml
+++ b/config/crd/bases/broker.amq.io_activemqartemises.yaml
@@ -5052,7 +5052,7 @@ spec:
   - name: v2alpha1
     schema:
       openAPIV3Schema:
-        description: ActiveMQArtemis is the Schema for the activemqartemises API
+        description: A stateful deployment of one or more brokers
         properties:
           apiVersion:
             description: |-
@@ -5075,80 +5075,138 @@ spec:
             description: ActiveMQArtemisSpec defines the desired state of ActiveMQArtemis
             properties:
               acceptors:
+                description: Specifies the acceptor configuration
                 items:
                   properties:
                     anycastPrefix:
+                      description: To indicate which kind of routing type to use.
                       type: string
                     connectionsAllowed:
+                      description: Max number of connections allowed to make
                       type: integer
                     enabledCipherSuites:
+                      description: Comma separated list of cipher suites used for
+                        SSL communication.
                       type: string
                     enabledProtocols:
+                      description: Comma separated list of protocols used for SSL
+                        communication.
                       type: string
                     expose:
+                      description: Whether or not to expose this acceptor
                       type: boolean
                     multicastPrefix:
+                      description: To indicate which kind of routing type to use
                       type: string
                     name:
+                      description: The acceptor name
                       type: string
                     needClientAuth:
+                      description: Tells a client connecting to this acceptor that
+                        2-way SSL is required. This property takes precedence over
+                        wantClientAuth.
                       type: boolean
                     port:
+                      description: Port number
                       format: int32
                       type: integer
                     protocols:
+                      description: The protocols to enable for this acceptor
                       type: string
                     sniHost:
+                      description: A regular expression used to match the server_name
+                        extension on incoming SSL connections. If the name doesn't
+                        match then the connection to the acceptor will be rejected.
                       type: string
                     sslEnabled:
+                      description: Whether or not to enable SSL on this port
                       type: boolean
                     sslProvider:
+                      description: Used to change the SSL Provider between JDK and
+                        OPENSSL. The default is JDK.
                       type: string
                     sslSecret:
+                      description: Name of the secret to use for ssl information
                       type: string
                     verifyHost:
+                      description: The CN of the connecting client's SSL certificate
+                        will be compared to its hostname to verify they match. This
+                        is useful only for 2-way SSL.
                       type: boolean
                     wantClientAuth:
+                      description: Tells a client connecting to this acceptor that
+                        2-way SSL is requested but not required. Overridden by needClientAuth.
                       type: boolean
                   required:
                   - name
                   type: object
                 type: array
               adminPassword:
+                description: Password for standard broker user. It is required for
+                  connecting to the broker and the web console. If left empty, it
+                  will be generated.
                 type: string
               adminUser:
+                description: User name for standard broker user. It is required for
+                  connecting to the broker and the web console. If left empty, it
+                  will be generated.
                 type: string
               connectors:
+                description: Specifies connectors and connector configuration
                 items:
                   properties:
                     enabledCipherSuites:
+                      description: Comma separated list of cipher suites used for
+                        SSL communication.
                       type: string
                     enabledProtocols:
+                      description: Comma separated list of protocols used for SSL
+                        communication.
                       type: string
                     expose:
+                      description: Whether or not to expose this connector
                       type: boolean
                     host:
+                      description: Hostname or IP to connect to
                       type: string
                     name:
+                      description: The name of the connector
                       type: string
                     needClientAuth:
+                      description: Tells a client connecting to this connector that
+                        2-way SSL is required. This property takes precedence over
+                        wantClientAuth.
                       type: boolean
                     port:
+                      description: Port number
                       format: int32
                       type: integer
                     sniHost:
+                      description: A regular expression used to match the server_name
+                        extension on incoming SSL connections. If the name doesn't
+                        match then the connection to the acceptor will be rejected.
                       type: string
                     sslEnabled:
+                      description: ' Whether or not to enable SSL on this port'
                       type: boolean
                     sslProvider:
+                      description: Used to change the SSL Provider between JDK and
+                        OPENSSL. The default is JDK.
                       type: string
                     sslSecret:
+                      description: Name of the secret to use for ssl information
                       type: string
                     type:
+                      description: The type either tcp or vm
                       type: string
                     verifyHost:
+                      description: The CN of the connecting client's SSL certificate
+                        will be compared to its hostname to verify they match. This
+                        is useful only for 2-way SSL.
                       type: boolean
                     wantClientAuth:
+                      description: Tells a client connecting to this connector that
+                        2-way SSL is requested but not required. Overridden by needClientAuth.
                       type: boolean
                   required:
                   - host
@@ -5157,29 +5215,44 @@ spec:
                   type: object
                 type: array
               console:
+                description: Specifies the console configuration
                 properties:
                   expose:
+                    description: Whether or not to expose this port
                     type: boolean
                   sslEnabled:
+                    description: Whether or not to enable SSL on this port
                     type: boolean
                   sslSecret:
+                    description: Name of the secret to use for ssl information
                     type: string
                   useClientAuth:
+                    description: If the embedded server requires client authentication
                     type: boolean
                 type: object
               deploymentPlan:
+                description: Specifies the deployment plan
                 properties:
                   image:
+                    description: The image used for the broker, all upgrades are disabled.
+                      Needs a corresponding initImage
                     type: string
                   journalType:
+                    description: If aio use ASYNCIO, if nio use NIO for journal IO
                     type: string
                   messageMigration:
+                    description: If true migrate messages on scaledown
                     type: boolean
                   persistenceEnabled:
+                    description: If true use persistent volume via persistent volume
+                      claim for journal storage
                     type: boolean
                   requireLogin:
+                    description: If true require user password login credentials for
+                      broker protocol ports
                     type: boolean
                   size:
+                    description: The number of broker pods to deploy
                     format: int32
                     type: integer
                 type: object
@@ -5276,7 +5349,7 @@ spec:
   - name: v2alpha2
     schema:
       openAPIV3Schema:
-        description: ActiveMQArtemis is the Schema for the activemqartemises API
+        description: A stateful deployment of one or more brokers
         properties:
           apiVersion:
             description: |-
@@ -5299,80 +5372,138 @@ spec:
             description: ActiveMQArtemisSpec defines the desired state of ActiveMQArtemis
             properties:
               acceptors:
+                description: Specifies the acceptor configuration
                 items:
                   properties:
                     anycastPrefix:
+                      description: To indicate which kind of routing type to use.
                       type: string
                     connectionsAllowed:
+                      description: Max number of connections allowed to make
                       type: integer
                     enabledCipherSuites:
+                      description: Comma separated list of cipher suites used for
+                        SSL communication.
                       type: string
                     enabledProtocols:
+                      description: Comma separated list of protocols used for SSL
+                        communication.
                       type: string
                     expose:
+                      description: Whether or not to expose this acceptor
                       type: boolean
                     multicastPrefix:
+                      description: To indicate which kind of routing type to use
                       type: string
                     name:
+                      description: The acceptor name
                       type: string
                     needClientAuth:
+                      description: Tells a client connecting to this acceptor that
+                        2-way SSL is required. This property takes precedence over
+                        wantClientAuth.
                       type: boolean
                     port:
+                      description: Port number
                       format: int32
                       type: integer
                     protocols:
+                      description: The protocols to enable for this acceptor
                       type: string
                     sniHost:
+                      description: A regular expression used to match the server_name
+                        extension on incoming SSL connections. If the name doesn't
+                        match then the connection to the acceptor will be rejected.
                       type: string
                     sslEnabled:
+                      description: Whether or not to enable SSL on this port
                       type: boolean
                     sslProvider:
+                      description: Used to change the SSL Provider between JDK and
+                        OPENSSL. The default is JDK.
                       type: string
                     sslSecret:
+                      description: Name of the secret to use for ssl information
                       type: string
                     verifyHost:
+                      description: The CN of the connecting client's SSL certificate
+                        will be compared to its hostname to verify they match. This
+                        is useful only for 2-way SSL.
                       type: boolean
                     wantClientAuth:
+                      description: Tells a client connecting to this acceptor that
+                        2-way SSL is requested but not required. Overridden by needClientAuth.
                       type: boolean
                   required:
                   - name
                   type: object
                 type: array
               adminPassword:
+                description: Password for standard broker user. It is required for
+                  connecting to the broker and the web console. If left empty, it
+                  will be generated.
                 type: string
               adminUser:
+                description: User name for standard broker user. It is required for
+                  connecting to the broker and the web console. If left empty, it
+                  will be generated.
                 type: string
               connectors:
+                description: Specifies connectors and connector configuration
                 items:
                   properties:
                     enabledCipherSuites:
+                      description: Comma separated list of cipher suites used for
+                        SSL communication.
                       type: string
                     enabledProtocols:
+                      description: Comma separated list of protocols used for SSL
+                        communication.
                       type: string
                     expose:
+                      description: Whether or not to expose this connector
                       type: boolean
                     host:
+                      description: Hostname or IP to connect to
                       type: string
                     name:
+                      description: The name of the connector
                       type: string
                     needClientAuth:
+                      description: Tells a client connecting to this connector that
+                        2-way SSL is required. This property takes precedence over
+                        wantClientAuth.
                       type: boolean
                     port:
+                      description: Port number
                       format: int32
                       type: integer
                     sniHost:
+                      description: A regular expression used to match the server_name
+                        extension on incoming SSL connections. If the name doesn't
+                        match then the connection to the acceptor will be rejected.
                       type: string
                     sslEnabled:
+                      description: ' Whether or not to enable SSL on this port'
                       type: boolean
                     sslProvider:
+                      description: Used to change the SSL Provider between JDK and
+                        OPENSSL. The default is JDK.
                       type: string
                     sslSecret:
+                      description: Name of the secret to use for ssl information
                       type: string
                     type:
+                      description: The type either tcp or vm
                       type: string
                     verifyHost:
+                      description: The CN of the connecting client's SSL certificate
+                        will be compared to its hostname to verify they match. This
+                        is useful only for 2-way SSL.
                       type: boolean
                     wantClientAuth:
+                      description: Tells a client connecting to this connector that
+                        2-way SSL is requested but not required. Overridden by needClientAuth.
                       type: boolean
                   required:
                   - host
@@ -5381,44 +5512,66 @@ spec:
                   type: object
                 type: array
               console:
+                description: Specifies the console configuration
                 properties:
                   expose:
+                    description: Whether or not to expose this port
                     type: boolean
                   sslEnabled:
+                    description: Whether or not to enable SSL on this port
                     type: boolean
                   sslSecret:
+                    description: Name of the secret to use for ssl information
                     type: string
                   useClientAuth:
+                    description: If the embedded server requires client authentication
                     type: boolean
                 type: object
               deploymentPlan:
+                description: Specifies the deployment plan
                 properties:
                   image:
+                    description: The image used for the broker, all upgrades are disabled.
+                      Needs a corresponding initImage
                     type: string
                   journalType:
+                    description: If aio use ASYNCIO, if nio use NIO for journal IO
                     type: string
                   messageMigration:
+                    description: If true migrate messages on scaledown
                     type: boolean
                   persistenceEnabled:
+                    description: If true use persistent volume via persistent volume
+                      claim for journal storage
                     type: boolean
                   requireLogin:
+                    description: If true require user password login credentials for
+                      broker protocol ports
                     type: boolean
                   size:
+                    description: The number of broker pods to deploy
                     format: int32
                     type: integer
                 type: object
               upgrades:
-                description: ActiveMQArtemis App product upgrade flags
+                description: Specifies the upgrades (deprecated in favour of Version)
                 properties:
                   enabled:
+                    description: Set true to enable automatic micro version product
+                      upgrades, it is disabled by default.
                     type: boolean
                   minor:
+                    description: Set true to enable automatic minor product version
+                      upgrades, it is disabled by default. Requires spec.upgrades.enabled
+                      to be true.
                     type: boolean
                 required:
                 - enabled
                 - minor
                 type: object
               version:
+                description: The desired version of the broker. Can be x, or x.y or
+                  x.y.z to configure upgrades
                 type: string
             type: object
           status:
@@ -5513,7 +5666,7 @@ spec:
   - name: v2alpha3
     schema:
       openAPIV3Schema:
-        description: ActiveMQArtemis is the Schema for the activemqartemises API
+        description: A stateful deployment of one or more brokers
         properties:
           apiVersion:
             description: |-
@@ -5536,240 +5689,432 @@ spec:
             description: ActiveMQArtemisSpec defines the desired state of ActiveMQArtemis
             properties:
               acceptors:
+                description: Specifies the acceptor configuration
                 items:
                   properties:
                     amqpMinLargeMessageSize:
+                      description: AMQP Minimum Large Message Size
                       type: integer
                     anycastPrefix:
+                      description: To indicate which kind of routing type to use.
                       type: string
                     connectionsAllowed:
+                      description: Max number of connections allowed to make
                       type: integer
                     enabledCipherSuites:
+                      description: Comma separated list of cipher suites used for
+                        SSL communication.
                       type: string
                     enabledProtocols:
+                      description: Comma separated list of protocols used for SSL
+                        communication.
                       type: string
                     expose:
+                      description: Whether or not to expose this acceptor
                       type: boolean
                     multicastPrefix:
+                      description: To indicate which kind of routing type to use
                       type: string
                     name:
+                      description: The acceptor name
                       type: string
                     needClientAuth:
+                      description: Tells a client connecting to this acceptor that
+                        2-way SSL is required. This property takes precedence over
+                        wantClientAuth.
                       type: boolean
                     port:
+                      description: Port number
                       format: int32
                       type: integer
                     protocols:
+                      description: The protocols to enable for this acceptor
                       type: string
                     sniHost:
+                      description: A regular expression used to match the server_name
+                        extension on incoming SSL connections. If the name doesn't
+                        match then the connection to the acceptor will be rejected.
                       type: string
                     sslEnabled:
+                      description: Whether or not to enable SSL on this port
                       type: boolean
                     sslProvider:
+                      description: Used to change the SSL Provider between JDK and
+                        OPENSSL. The default is JDK.
                       type: string
                     sslSecret:
+                      description: Name of the secret to use for ssl information
                       type: string
                     verifyHost:
+                      description: The CN of the connecting client's SSL certificate
+                        will be compared to its hostname to verify they match. This
+                        is useful only for 2-way SSL.
                       type: boolean
                     wantClientAuth:
+                      description: Tells a client connecting to this acceptor that
+                        2-way SSL is requested but not required. Overridden by needClientAuth.
                       type: boolean
                   required:
                   - name
                   type: object
                 type: array
               addressSettings:
+                description: Specifies the address configurations (deprecated in favour
+                  of BrokerProperties)
                 properties:
                   addressSetting:
+                    description: Specifies the address settings
                     items:
                       properties:
                         addressFullPolicy:
+                          description: what happens when an address where maxSizeBytes
+                            is specified becomes full
                           type: string
                         autoCreateAddresses:
+                          description: whether or not to automatically create addresses
+                            when a client sends a message to or attempts to consume
+                            a message from a queue mapped to an address that doesnt
+                            exist
                           type: boolean
                         autoCreateDeadLetterResources:
+                          description: whether or not to automatically create the
+                            dead-letter-address and/or a corresponding queue on that
+                            address when a message found to be undeliverable
                           type: boolean
                         autoCreateExpiryResources:
+                          description: whether or not to automatically create the
+                            expiry-address and/or a corresponding queue on that address
+                            when a message is sent to a matching queue
                           type: boolean
                         autoCreateJmsQueues:
+                          description: DEPRECATED. whether or not to automatically
+                            create JMS queues when a producer sends or a consumer
+                            connects to a queue
                           type: boolean
                         autoCreateJmsTopics:
+                          description: DEPRECATED. whether or not to automatically
+                            create JMS topics when a producer sends or a consumer
+                            subscribes to a topic
                           type: boolean
                         autoCreateQueues:
+                          description: whether or not to automatically create a queue
+                            when a client sends a message to or attempts to consume
+                            a message from a queue
                           type: boolean
                         autoDeleteAddresses:
+                          description: whether or not to delete auto-created addresses
+                            when it no longer has any queues
                           type: boolean
                         autoDeleteAddressesDelay:
+                          description: how long to wait (in milliseconds) before deleting
+                            auto-created addresses after they no longer have any queues
                           format: int32
                           type: integer
                         autoDeleteCreatedQueues:
+                          description: whether or not to delete created queues when
+                            the queue has 0 consumers and 0 messages
                           type: boolean
                         autoDeleteJmsQueues:
+                          description: DEPRECATED. whether or not to delete auto-created
+                            JMS queues when the queue has 0 consumers and 0 messages
                           type: boolean
                         autoDeleteJmsTopics:
+                          description: DEPRECATED. whether or not to delete auto-created
+                            JMS topics when the last subscription is closed
                           type: boolean
                         autoDeleteQueues:
+                          description: whether or not to delete auto-created queues
+                            when the queue has 0 consumers and 0 messages
                           type: boolean
                         autoDeleteQueuesDelay:
+                          description: how long to wait (in milliseconds) before deleting
+                            auto-created queues after the queue has 0 consumers.
                           format: int32
                           type: integer
                         autoDeleteQueuesMessageCount:
+                          description: the message count the queue must be at or below
+                            before it can be evaluated to be auto deleted, 0 waits
+                            until empty queue (default) and -1 disables this check.
                           format: int32
                           type: integer
                         configDeleteAddresses:
+                          description: What to do when an address is no longer in
+                            broker.xml.  OFF = will do nothing addresses will remain,
+                            FORCE = delete address and its queues even if messages
+                            remaining.
                           type: string
                         configDeleteQueues:
+                          description: What to do when a queue is no longer in broker.xml.  OFF
+                            = will do nothing queues will remain, FORCE = delete queues
+                            even if messages remaining.
                           type: string
                         deadLetterAddress:
+                          description: the address to send dead messages to
                           type: string
                         deadLetterQueuePrefix:
+                          description: the prefix to use for auto-created dead letter
+                            queues
                           type: string
                         deadLetterQueueSuffix:
+                          description: the suffix to use for auto-created dead letter
+                            queues
                           type: string
                         defaultAddressRoutingType:
+                          description: the routing-type used on auto-created addresses
                           type: string
                         defaultConsumerWindowSize:
+                          description: the default window size for a consumer
                           format: int32
                           type: integer
                         defaultConsumersBeforeDispatch:
+                          description: the default number of consumers needed before
+                            dispatch can start for queues under the address.
                           format: int32
                           type: integer
                         defaultDelayBeforeDispatch:
+                          description: the default delay (in milliseconds) to wait
+                            before dispatching if number of consumers before dispatch
+                            is not met for queues under the address.
                           format: int32
                           type: integer
                         defaultExclusiveQueue:
+                          description: whether to treat the queues under the address
+                            as exclusive queues by default
                           type: boolean
                         defaultGroupBuckets:
+                          description: number of buckets to use for grouping, -1 (default)
+                            is unlimited and uses the raw group, 0 disables message
+                            groups.
                           format: int32
                           type: integer
                         defaultGroupFirstKey:
+                          description: key used to mark a message is first in a group
+                            for a consumer
                           type: string
                         defaultGroupRebalance:
+                          description: whether to rebalance groups when a consumer
+                            is added
                           type: boolean
                         defaultGroupRebalancePauseDispatch:
+                          description: whether to pause dispatch when rebalancing
+                            groups
                           type: boolean
                         defaultLastValueKey:
+                          description: the property to use as the key for a last value
+                            queue by default
                           type: string
                         defaultLastValueQueue:
+                          description: whether to treat the queues under the address
+                            as a last value queues by default
                           type: boolean
                         defaultMaxConsumers:
+                          description: the maximum number of consumers allowed on
+                            this queue at any one time
                           format: int32
                           type: integer
                         defaultNonDestructive:
+                          description: whether the queue should be non-destructive
+                            by default
                           type: boolean
                         defaultPurgeOnNoConsumers:
+                          description: purge the contents of the queue once there
+                            are no consumers
                           type: boolean
                         defaultQueueRoutingType:
+                          description: the routing-type used on auto-created queues
                           type: string
                         defaultRingSize:
+                          description: the default ring-size value for any matching
+                            queue which doesnt have ring-size explicitly defined
                           format: int32
                           type: integer
                         enableMetrics:
+                          description: whether or not to enable metrics for metrics
+                            plugins on the matching address
                           type: boolean
                         expiryAddress:
+                          description: the address to send expired messages to
                           type: string
                         expiryDelay:
+                          description: Overrides the expiration time for messages
+                            using the default value for expiration time. "-1" disables
+                            this setting.
                           format: int32
                           type: integer
                         expiryQueuePrefix:
+                          description: the prefix to use for auto-created expiry queues
                           type: string
                         expiryQueueSuffix:
+                          description: the suffix to use for auto-created expiry queues
                           type: string
                         lastValueQueue:
+                          description: This is deprecated please use default-last-value-queue
+                            instead.
                           type: boolean
                         managementBrowsePageSize:
+                          description: how many message a management resource can
+                            browse
                           format: int32
                           type: integer
                         match:
+                          description: pattern for matching settings against addresses;
+                            can use wildards
                           type: string
                         maxDeliveryAttempts:
+                          description: how many times to attempt to deliver a message
+                            before sending to dead letter address
                           format: int32
                           type: integer
                         maxExpiryDelay:
+                          description: Overrides the expiration time for messages
+                            using a higher value. "-1" disables this setting.
                           format: int32
                           type: integer
                         maxRedeliveryDelay:
+                          description: Maximum value for the redelivery-delay
                           format: int32
                           type: integer
                         maxSizeBytes:
+                          description: the maximum size in bytes for an address. -1
+                            means no limits. This is used in PAGING, BLOCK and FAIL
+                            policies. Supports byte notation like K, Mb, GB, etc.
                           type: string
                         maxSizeBytesRejectThreshold:
+                          description: used with the address full BLOCK policy, the
+                            maximum size in bytes an address can reach before messages
+                            start getting rejected. Works in combination with max-size-bytes
+                            for AMQP protocol only.  Default = -1 (no limit).
                           format: int32
                           type: integer
                         messageCounterHistoryDayLimit:
+                          description: how many days to keep message counter history
+                            for this address
                           format: int32
                           type: integer
                         minExpiryDelay:
+                          description: Overrides the expiration time for messages
+                            using a lower value. "-1" disables this setting.
                           format: int32
                           type: integer
                         pageMaxCacheSize:
+                          description: Number of paging files to cache in memory to
+                            avoid IO during paging navigation
                           format: int32
                           type: integer
                         pageSizeBytes:
+                          description: The page size in bytes to use for an address.
+                            Supports byte notation like K, Mb, GB, etc.
                           type: string
                         redeliveryCollisionAvoidanceFactor:
                           type: number
                         redeliveryDelay:
+                          description: the time (in ms) to wait before redelivering
+                            a cancelled message.
                           format: int32
                           type: integer
                         redeliveryDelayMultiplier:
                           format: int32
                           type: integer
                         redistributionDelay:
+                          description: how long (in ms) to wait after the last consumer
+                            is closed on a queue before redistributing messages.
                           format: int32
                           type: integer
                         retroactiveMessageCount:
+                          description: the number of messages to preserve for future
+                            queues created on the matching address
                           format: int32
                           type: integer
                         sendToDlaOnNoRoute:
+                          description: if there are no queues matching this address,
+                            whether to forward message to DLA (if it exists for this
+                            address)
                           type: boolean
                         slowConsumerCheckPeriod:
+                          description: How often to check for slow consumers on a
+                            particular queue. Measured in seconds.
                           format: int32
                           type: integer
                         slowConsumerPolicy:
+                          description: what happens when a slow consumer is identified
                           type: string
                         slowConsumerThreshold:
+                          description: The minimum rate of message consumption allowed
+                            before a consumer is considered "slow." Measured in messages-per-second.
                           format: int32
                           type: integer
                       type: object
                     type: array
                   applyRule:
+                    description: How to merge the address settings to broker configuration
                     type: string
                 type: object
               adminPassword:
+                description: Password for standard broker user. It is required for
+                  connecting to the broker and the web console. If left empty, it
+                  will be generated.
                 type: string
               adminUser:
+                description: User name for standard broker user. It is required for
+                  connecting to the broker and the web console. If left empty, it
+                  will be generated.
                 type: string
               connectors:
+                description: Specifies connectors and connector configuration
                 items:
                   properties:
                     enabledCipherSuites:
+                      description: Comma separated list of cipher suites used for
+                        SSL communication.
                       type: string
                     enabledProtocols:
+                      description: Comma separated list of protocols used for SSL
+                        communication.
                       type: string
                     expose:
+                      description: Whether or not to expose this connector
                       type: boolean
                     host:
+                      description: Hostname or IP to connect to
                       type: string
                     name:
+                      description: The name of the connector
                       type: string
                     needClientAuth:
+                      description: Tells a client connecting to this connector that
+                        2-way SSL is required. This property takes precedence over
+                        wantClientAuth.
                       type: boolean
                     port:
+                      description: Port number
                       format: int32
                       type: integer
                     sniHost:
+                      description: A regular expression used to match the server_name
+                        extension on incoming SSL connections. If the name doesn't
+                        match then the connection to the acceptor will be rejected.
                       type: string
                     sslEnabled:
+                      description: ' Whether or not to enable SSL on this port'
                       type: boolean
                     sslProvider:
+                      description: Used to change the SSL Provider between JDK and
+                        OPENSSL. The default is JDK.
                       type: string
                     sslSecret:
+                      description: Name of the secret to use for ssl information
                       type: string
                     type:
+                      description: The type either tcp or vm
                       type: string
                     verifyHost:
+                      description: The CN of the connecting client's SSL certificate
+                        will be compared to its hostname to verify they match. This
+                        is useful only for 2-way SSL.
                       type: boolean
                     wantClientAuth:
+                      description: Tells a client connecting to this connector that
+                        2-way SSL is requested but not required. Overridden by needClientAuth.
                       type: boolean
                   required:
                   - host
@@ -5778,31 +6123,45 @@ spec:
                   type: object
                 type: array
               console:
+                description: Specifies the console configuration
                 properties:
                   expose:
+                    description: Whether or not to expose this port
                     type: boolean
                   sslEnabled:
+                    description: Whether or not to enable SSL on this port
                     type: boolean
                   sslSecret:
+                    description: Name of the secret to use for ssl information
                     type: string
                   useClientAuth:
+                    description: If the embedded server requires client authentication
                     type: boolean
                 type: object
               deploymentPlan:
+                description: Specifies the deployment plan
                 properties:
                   image:
+                    description: The image used for the broker, all upgrades are disabled.
+                      Needs a corresponding initImage
                     type: string
                   journalType:
+                    description: If aio use ASYNCIO, if nio use NIO for journal IO
                     type: string
                   messageMigration:
+                    description: If true migrate messages on scaledown
                     type: boolean
                   persistenceEnabled:
+                    description: If true use persistent volume via persistent volume
+                      claim for journal storage
                     type: boolean
                   requireLogin:
+                    description: If true require user password login credentials for
+                      broker protocol ports
                     type: boolean
                   resources:
-                    description: ResourceRequirements describes the compute resource
-                      requirements.
+                    description: Specifies the minimum/maximum amount of compute resources
+                      required/allowed
                     properties:
                       claims:
                         description: |-
@@ -5855,26 +6214,36 @@ spec:
                         type: object
                     type: object
                   size:
+                    description: The number of broker pods to deploy
                     format: int32
                     type: integer
                   storage:
+                    description: Specifies the storage configurations
                     properties:
                       size:
+                        description: The storage size
                         type: string
                     type: object
                 type: object
               upgrades:
-                description: ActiveMQArtemis App product upgrade flags
+                description: Specifies the upgrades (deprecated in favour of Version)
                 properties:
                   enabled:
+                    description: Set true to enable automatic micro version product
+                      upgrades, it is disabled by default.
                     type: boolean
                   minor:
+                    description: Set true to enable automatic minor product version
+                      upgrades, it is disabled by default. Requires spec.upgrades.enabled
+                      to be true.
                     type: boolean
                 required:
                 - enabled
                 - minor
                 type: object
               version:
+                description: The desired version of the broker. Can be x, or x.y or
+                  x.y.z to configure upgrades
                 type: string
             type: object
           status:
@@ -5940,6 +6309,7 @@ spec:
                   type: object
                 type: array
               podStatus:
+                description: The current pods
                 properties:
                   ready:
                     description: Deployments are ready to serve requests
@@ -5969,7 +6339,7 @@ spec:
   - name: v2alpha4
     schema:
       openAPIV3Schema:
-        description: ActiveMQArtemis is the Schema for the activemqartemises API
+        description: A stateful deployment of one or more brokers
         properties:
           apiVersion:
             description: |-
@@ -5992,240 +6362,432 @@ spec:
             description: ActiveMQArtemisSpec defines the desired state of ActiveMQArtemis
             properties:
               acceptors:
+                description: Specifies the acceptor configuration
                 items:
                   properties:
                     amqpMinLargeMessageSize:
+                      description: AMQP Minimum Large Message Size
                       type: integer
                     anycastPrefix:
+                      description: To indicate which kind of routing type to use.
                       type: string
                     connectionsAllowed:
+                      description: Max number of connections allowed to make
                       type: integer
                     enabledCipherSuites:
+                      description: Comma separated list of cipher suites used for
+                        SSL communication.
                       type: string
                     enabledProtocols:
+                      description: Comma separated list of protocols used for SSL
+                        communication.
                       type: string
                     expose:
+                      description: Whether or not to expose this acceptor
                       type: boolean
                     multicastPrefix:
+                      description: To indicate which kind of routing type to use
                       type: string
                     name:
+                      description: The acceptor name
                       type: string
                     needClientAuth:
+                      description: Tells a client connecting to this acceptor that
+                        2-way SSL is required. This property takes precedence over
+                        wantClientAuth.
                       type: boolean
                     port:
+                      description: Port number
                       format: int32
                       type: integer
                     protocols:
+                      description: The protocols to enable for this acceptor
                       type: string
                     sniHost:
+                      description: A regular expression used to match the server_name
+                        extension on incoming SSL connections. If the name doesn't
+                        match then the connection to the acceptor will be rejected.
                       type: string
                     sslEnabled:
+                      description: Whether or not to enable SSL on this port
                       type: boolean
                     sslProvider:
+                      description: Used to change the SSL Provider between JDK and
+                        OPENSSL. The default is JDK.
                       type: string
                     sslSecret:
+                      description: Name of the secret to use for ssl information
                       type: string
                     verifyHost:
+                      description: The CN of the connecting client's SSL certificate
+                        will be compared to its hostname to verify they match. This
+                        is useful only for 2-way SSL.
                       type: boolean
                     wantClientAuth:
+                      description: Tells a client connecting to this acceptor that
+                        2-way SSL is requested but not required. Overridden by needClientAuth.
                       type: boolean
                   required:
                   - name
                   type: object
                 type: array
               addressSettings:
+                description: Specifies the address configurations (deprecated in favour
+                  of BrokerProperties)
                 properties:
                   addressSetting:
+                    description: Specifies the address settings
                     items:
                       properties:
                         addressFullPolicy:
+                          description: what happens when an address where maxSizeBytes
+                            is specified becomes full
                           type: string
                         autoCreateAddresses:
+                          description: whether or not to automatically create addresses
+                            when a client sends a message to or attempts to consume
+                            a message from a queue mapped to an address that doesnt
+                            exist
                           type: boolean
                         autoCreateDeadLetterResources:
+                          description: whether or not to automatically create the
+                            dead-letter-address and/or a corresponding queue on that
+                            address when a message found to be undeliverable
                           type: boolean
                         autoCreateExpiryResources:
+                          description: whether or not to automatically create the
+                            expiry-address and/or a corresponding queue on that address
+                            when a message is sent to a matching queue
                           type: boolean
                         autoCreateJmsQueues:
+                          description: DEPRECATED. whether or not to automatically
+                            create JMS queues when a producer sends or a consumer
+                            connects to a queue
                           type: boolean
                         autoCreateJmsTopics:
+                          description: DEPRECATED. whether or not to automatically
+                            create JMS topics when a producer sends or a consumer
+                            subscribes to a topic
                           type: boolean
                         autoCreateQueues:
+                          description: whether or not to automatically create a queue
+                            when a client sends a message to or attempts to consume
+                            a message from a queue
                           type: boolean
                         autoDeleteAddresses:
+                          description: whether or not to delete auto-created addresses
+                            when it no longer has any queues
                           type: boolean
                         autoDeleteAddressesDelay:
+                          description: how long to wait (in milliseconds) before deleting
+                            auto-created addresses after they no longer have any queues
                           format: int32
                           type: integer
                         autoDeleteCreatedQueues:
+                          description: whether or not to delete created queues when
+                            the queue has 0 consumers and 0 messages
                           type: boolean
                         autoDeleteJmsQueues:
+                          description: DEPRECATED. whether or not to delete auto-created
+                            JMS queues when the queue has 0 consumers and 0 messages
                           type: boolean
                         autoDeleteJmsTopics:
+                          description: DEPRECATED. whether or not to delete auto-created
+                            JMS topics when the last subscription is closed
                           type: boolean
                         autoDeleteQueues:
+                          description: whether or not to delete auto-created queues
+                            when the queue has 0 consumers and 0 messages
                           type: boolean
                         autoDeleteQueuesDelay:
+                          description: how long to wait (in milliseconds) before deleting
+                            auto-created queues after the queue has 0 consumers.
                           format: int32
                           type: integer
                         autoDeleteQueuesMessageCount:
+                          description: the message count the queue must be at or below
+                            before it can be evaluated to be auto deleted, 0 waits
+                            until empty queue (default) and -1 disables this check.
                           format: int32
                           type: integer
                         configDeleteAddresses:
+                          description: What to do when an address is no longer in
+                            broker.xml.  OFF = will do nothing addresses will remain,
+                            FORCE = delete address and its queues even if messages
+                            remaining.
                           type: string
                         configDeleteQueues:
+                          description: What to do when a queue is no longer in broker.xml.  OFF
+                            = will do nothing queues will remain, FORCE = delete queues
+                            even if messages remaining.
                           type: string
                         deadLetterAddress:
+                          description: the address to send dead messages to
                           type: string
                         deadLetterQueuePrefix:
+                          description: the prefix to use for auto-created dead letter
+                            queues
                           type: string
                         deadLetterQueueSuffix:
+                          description: the suffix to use for auto-created dead letter
+                            queues
                           type: string
                         defaultAddressRoutingType:
+                          description: the routing-type used on auto-created addresses
                           type: string
                         defaultConsumerWindowSize:
+                          description: the default window size for a consumer
                           format: int32
                           type: integer
                         defaultConsumersBeforeDispatch:
+                          description: the default number of consumers needed before
+                            dispatch can start for queues under the address.
                           format: int32
                           type: integer
                         defaultDelayBeforeDispatch:
+                          description: the default delay (in milliseconds) to wait
+                            before dispatching if number of consumers before dispatch
+                            is not met for queues under the address.
                           format: int32
                           type: integer
                         defaultExclusiveQueue:
+                          description: whether to treat the queues under the address
+                            as exclusive queues by default
                           type: boolean
                         defaultGroupBuckets:
+                          description: number of buckets to use for grouping, -1 (default)
+                            is unlimited and uses the raw group, 0 disables message
+                            groups.
                           format: int32
                           type: integer
                         defaultGroupFirstKey:
+                          description: key used to mark a message is first in a group
+                            for a consumer
                           type: string
                         defaultGroupRebalance:
+                          description: whether to rebalance groups when a consumer
+                            is added
                           type: boolean
                         defaultGroupRebalancePauseDispatch:
+                          description: whether to pause dispatch when rebalancing
+                            groups
                           type: boolean
                         defaultLastValueKey:
+                          description: the property to use as the key for a last value
+                            queue by default
                           type: string
                         defaultLastValueQueue:
+                          description: whether to treat the queues under the address
+                            as a last value queues by default
                           type: boolean
                         defaultMaxConsumers:
+                          description: the maximum number of consumers allowed on
+                            this queue at any one time
                           format: int32
                           type: integer
                         defaultNonDestructive:
+                          description: whether the queue should be non-destructive
+                            by default
                           type: boolean
                         defaultPurgeOnNoConsumers:
+                          description: purge the contents of the queue once there
+                            are no consumers
                           type: boolean
                         defaultQueueRoutingType:
+                          description: the routing-type used on auto-created queues
                           type: string
                         defaultRingSize:
+                          description: the default ring-size value for any matching
+                            queue which doesnt have ring-size explicitly defined
                           format: int32
                           type: integer
                         enableMetrics:
+                          description: whether or not to enable metrics for metrics
+                            plugins on the matching address
                           type: boolean
                         expiryAddress:
+                          description: the address to send expired messages to
                           type: string
                         expiryDelay:
+                          description: Overrides the expiration time for messages
+                            using the default value for expiration time. "-1" disables
+                            this setting.
                           format: int32
                           type: integer
                         expiryQueuePrefix:
+                          description: the prefix to use for auto-created expiry queues
                           type: string
                         expiryQueueSuffix:
+                          description: the suffix to use for auto-created expiry queues
                           type: string
                         lastValueQueue:
+                          description: This is deprecated please use default-last-value-queue
+                            instead.
                           type: boolean
                         managementBrowsePageSize:
+                          description: how many message a management resource can
+                            browse
                           format: int32
                           type: integer
                         match:
+                          description: pattern for matching settings against addresses;
+                            can use wildards
                           type: string
                         maxDeliveryAttempts:
+                          description: how many times to attempt to deliver a message
+                            before sending to dead letter address
                           format: int32
                           type: integer
                         maxExpiryDelay:
+                          description: Overrides the expiration time for messages
+                            using a higher value. "-1" disables this setting.
                           format: int32
                           type: integer
                         maxRedeliveryDelay:
+                          description: Maximum value for the redelivery-delay
                           format: int32
                           type: integer
                         maxSizeBytes:
+                          description: the maximum size in bytes for an address. -1
+                            means no limits. This is used in PAGING, BLOCK and FAIL
+                            policies. Supports byte notation like K, Mb, GB, etc.
                           type: string
                         maxSizeBytesRejectThreshold:
+                          description: used with the address full BLOCK policy, the
+                            maximum size in bytes an address can reach before messages
+                            start getting rejected. Works in combination with max-size-bytes
+                            for AMQP protocol only.  Default = -1 (no limit).
                           format: int32
                           type: integer
                         messageCounterHistoryDayLimit:
+                          description: how many days to keep message counter history
+                            for this address
                           format: int32
                           type: integer
                         minExpiryDelay:
+                          description: Overrides the expiration time for messages
+                            using a lower value. "-1" disables this setting.
                           format: int32
                           type: integer
                         pageMaxCacheSize:
+                          description: Number of paging files to cache in memory to
+                            avoid IO during paging navigation
                           format: int32
                           type: integer
                         pageSizeBytes:
+                          description: The page size in bytes to use for an address.
+                            Supports byte notation like K, Mb, GB, etc.
                           type: string
                         redeliveryCollisionAvoidanceFactor:
                           type: number
                         redeliveryDelay:
+                          description: the time (in ms) to wait before redelivering
+                            a cancelled message.
                           format: int32
                           type: integer
                         redeliveryDelayMultiplier:
                           format: int32
                           type: integer
                         redistributionDelay:
+                          description: how long (in ms) to wait after the last consumer
+                            is closed on a queue before redistributing messages.
                           format: int32
                           type: integer
                         retroactiveMessageCount:
+                          description: the number of messages to preserve for future
+                            queues created on the matching address
                           format: int32
                           type: integer
                         sendToDlaOnNoRoute:
+                          description: if there are no queues matching this address,
+                            whether to forward message to DLA (if it exists for this
+                            address)
                           type: boolean
                         slowConsumerCheckPeriod:
+                          description: How often to check for slow consumers on a
+                            particular queue. Measured in seconds.
                           format: int32
                           type: integer
                         slowConsumerPolicy:
+                          description: what happens when a slow consumer is identified
                           type: string
                         slowConsumerThreshold:
+                          description: The minimum rate of message consumption allowed
+                            before a consumer is considered "slow." Measured in messages-per-second.
                           format: int32
                           type: integer
                       type: object
                     type: array
                   applyRule:
+                    description: How to merge the address settings to broker configuration
                     type: string
                 type: object
               adminPassword:
+                description: Password for standard broker user. It is required for
+                  connecting to the broker and the web console. If left empty, it
+                  will be generated.
                 type: string
               adminUser:
+                description: User name for standard broker user. It is required for
+                  connecting to the broker and the web console. If left empty, it
+                  will be generated.
                 type: string
               connectors:
+                description: Specifies connectors and connector configuration
                 items:
                   properties:
                     enabledCipherSuites:
+                      description: Comma separated list of cipher suites used for
+                        SSL communication.
                       type: string
                     enabledProtocols:
+                      description: Comma separated list of protocols used for SSL
+                        communication.
                       type: string
                     expose:
+                      description: Whether or not to expose this connector
                       type: boolean
                     host:
+                      description: Hostname or IP to connect to
                       type: string
                     name:
+                      description: The name of the connector
                       type: string
                     needClientAuth:
+                      description: Tells a client connecting to this connector that
+                        2-way SSL is required. This property takes precedence over
+                        wantClientAuth.
                       type: boolean
                     port:
+                      description: Port number
                       format: int32
                       type: integer
                     sniHost:
+                      description: A regular expression used to match the server_name
+                        extension on incoming SSL connections. If the name doesn't
+                        match then the connection to the acceptor will be rejected.
                       type: string
                     sslEnabled:
+                      description: ' Whether or not to enable SSL on this port'
                       type: boolean
                     sslProvider:
+                      description: Used to change the SSL Provider between JDK and
+                        OPENSSL. The default is JDK.
                       type: string
                     sslSecret:
+                      description: Name of the secret to use for ssl information
                       type: string
                     type:
+                      description: The type either tcp or vm
                       type: string
                     verifyHost:
+                      description: The CN of the connecting client's SSL certificate
+                        will be compared to its hostname to verify they match. This
+                        is useful only for 2-way SSL.
                       type: boolean
                     wantClientAuth:
+                      description: Tells a client connecting to this connector that
+                        2-way SSL is requested but not required. Overridden by needClientAuth.
                       type: boolean
                   required:
                   - host
@@ -6234,37 +6796,55 @@ spec:
                   type: object
                 type: array
               console:
+                description: Specifies the console configuration
                 properties:
                   expose:
+                    description: Whether or not to expose this port
                     type: boolean
                   sslEnabled:
+                    description: Whether or not to enable SSL on this port
                     type: boolean
                   sslSecret:
+                    description: Name of the secret to use for ssl information
                     type: string
                   useClientAuth:
+                    description: If the embedded server requires client authentication
                     type: boolean
                 type: object
               deploymentPlan:
+                description: Specifies the deployment plan
                 properties:
                   image:
+                    description: The image used for the broker, all upgrades are disabled.
+                      Needs a corresponding initImage
                     type: string
                   initImage:
+                    description: The init container image used to configure broker,
+                      all upgrades are disabled. Needs a corresponding image
                     type: string
                   jolokiaAgentEnabled:
+                    description: If true enable the Jolokia JVM Agent
                     type: boolean
                   journalType:
+                    description: If aio use ASYNCIO, if nio use NIO for journal IO
                     type: string
                   managementRBACEnabled:
+                    description: If true enable the management role based access control
                     type: boolean
                   messageMigration:
+                    description: If true migrate messages on scaledown
                     type: boolean
                   persistenceEnabled:
+                    description: If true use persistent volume via persistent volume
+                      claim for journal storage
                     type: boolean
                   requireLogin:
+                    description: If true require user password login credentials for
+                      broker protocol ports
                     type: boolean
                   resources:
-                    description: ResourceRequirements describes the compute resource
-                      requirements.
+                    description: Specifies the minimum/maximum amount of compute resources
+                      required/allowed
                     properties:
                       claims:
                         description: |-
@@ -6317,26 +6897,36 @@ spec:
                         type: object
                     type: object
                   size:
+                    description: The number of broker pods to deploy
                     format: int32
                     type: integer
                   storage:
+                    description: Specifies the storage configurations
                     properties:
                       size:
+                        description: The storage size
                         type: string
                     type: object
                 type: object
               upgrades:
-                description: ActiveMQArtemis App product upgrade flags
+                description: Specifies the upgrades (deprecated in favour of Version)
                 properties:
                   enabled:
+                    description: Set true to enable automatic micro version product
+                      upgrades, it is disabled by default.
                     type: boolean
                   minor:
+                    description: Set true to enable automatic minor product version
+                      upgrades, it is disabled by default. Requires spec.upgrades.enabled
+                      to be true.
                     type: boolean
                 required:
                 - enabled
                 - minor
                 type: object
               version:
+                description: The desired version of the broker. Can be x, or x.y or
+                  x.y.z to configure upgrades
                 type: string
             type: object
           status:
@@ -6402,6 +6992,7 @@ spec:
                   type: object
                 type: array
               podStatus:
+                description: The current pods
                 properties:
                   ready:
                     description: Deployments are ready to serve requests
@@ -6431,7 +7022,7 @@ spec:
   - name: v2alpha5
     schema:
       openAPIV3Schema:
-        description: ActiveMQArtemis is the Schema for the activemqartemises API
+        description: A stateful deployment of one or more brokers
         properties:
           apiVersion:
             description: |-
@@ -6454,250 +7045,452 @@ spec:
             description: ActiveMQArtemisSpec defines the desired state of ActiveMQArtemis
             properties:
               acceptors:
+                description: Specifies the acceptor configuration
                 items:
                   properties:
                     amqpMinLargeMessageSize:
+                      description: AMQP Minimum Large Message Size
                       type: integer
                     anycastPrefix:
+                      description: To indicate which kind of routing type to use.
                       type: string
                     connectionsAllowed:
+                      description: Max number of connections allowed to make
                       type: integer
                     enabledCipherSuites:
+                      description: Comma separated list of cipher suites used for
+                        SSL communication.
                       type: string
                     enabledProtocols:
+                      description: Comma separated list of protocols used for SSL
+                        communication.
                       type: string
                     expose:
+                      description: Whether or not to expose this acceptor
                       type: boolean
                     multicastPrefix:
+                      description: To indicate which kind of routing type to use
                       type: string
                     name:
+                      description: The acceptor name
                       type: string
                     needClientAuth:
+                      description: Tells a client connecting to this acceptor that
+                        2-way SSL is required. This property takes precedence over
+                        wantClientAuth.
                       type: boolean
                     port:
+                      description: Port number
                       format: int32
                       type: integer
                     protocols:
+                      description: The protocols to enable for this acceptor
                       type: string
                     sniHost:
+                      description: A regular expression used to match the server_name
+                        extension on incoming SSL connections. If the name doesn't
+                        match then the connection to the acceptor will be rejected.
                       type: string
                     sslEnabled:
+                      description: Whether or not to enable SSL on this port
                       type: boolean
                     sslProvider:
+                      description: Used to change the SSL Provider between JDK and
+                        OPENSSL. The default is JDK.
                       type: string
                     sslSecret:
+                      description: Name of the secret to use for ssl information
                       type: string
                     supportAdvisory:
+                      description: For openwire protocol if advisory topics are enabled,
+                        default false
                       type: boolean
                     suppressInternalManagementObjects:
+                      description: If prevents advisory addresses/queues to be registered
+                        to management service, default false
                       type: boolean
                     verifyHost:
+                      description: The CN of the connecting client's SSL certificate
+                        will be compared to its hostname to verify they match. This
+                        is useful only for 2-way SSL.
                       type: boolean
                     wantClientAuth:
+                      description: Tells a client connecting to this acceptor that
+                        2-way SSL is requested but not required. Overridden by needClientAuth.
                       type: boolean
                   required:
                   - name
                   type: object
                 type: array
               addressSettings:
+                description: Specifies the address configurations (deprecated in favour
+                  of BrokerProperties)
                 properties:
                   addressSetting:
+                    description: Specifies the address settings
                     items:
                       properties:
                         addressFullPolicy:
+                          description: what happens when an address where maxSizeBytes
+                            is specified becomes full
                           type: string
                         autoCreateAddresses:
+                          description: whether or not to automatically create addresses
+                            when a client sends a message to or attempts to consume
+                            a message from a queue mapped to an address that doesnt
+                            exist
                           type: boolean
                         autoCreateDeadLetterResources:
+                          description: whether or not to automatically create the
+                            dead-letter-address and/or a corresponding queue on that
+                            address when a message found to be undeliverable
                           type: boolean
                         autoCreateExpiryResources:
+                          description: whether or not to automatically create the
+                            expiry-address and/or a corresponding queue on that address
+                            when a message is sent to a matching queue
                           type: boolean
                         autoCreateJmsQueues:
+                          description: DEPRECATED. whether or not to automatically
+                            create JMS queues when a producer sends or a consumer
+                            connects to a queue
                           type: boolean
                         autoCreateJmsTopics:
+                          description: DEPRECATED. whether or not to automatically
+                            create JMS topics when a producer sends or a consumer
+                            subscribes to a topic
                           type: boolean
                         autoCreateQueues:
+                          description: whether or not to automatically create a queue
+                            when a client sends a message to or attempts to consume
+                            a message from a queue
                           type: boolean
                         autoDeleteAddresses:
+                          description: whether or not to delete auto-created addresses
+                            when it no longer has any queues
                           type: boolean
                         autoDeleteAddressesDelay:
+                          description: how long to wait (in milliseconds) before deleting
+                            auto-created addresses after they no longer have any queues
                           format: int32
                           type: integer
                         autoDeleteCreatedQueues:
+                          description: whether or not to delete created queues when
+                            the queue has 0 consumers and 0 messages
                           type: boolean
                         autoDeleteJmsQueues:
+                          description: DEPRECATED. whether or not to delete auto-created
+                            JMS queues when the queue has 0 consumers and 0 messages
                           type: boolean
                         autoDeleteJmsTopics:
+                          description: DEPRECATED. whether or not to delete auto-created
+                            JMS topics when the last subscription is closed
                           type: boolean
                         autoDeleteQueues:
+                          description: whether or not to delete auto-created queues
+                            when the queue has 0 consumers and 0 messages
                           type: boolean
                         autoDeleteQueuesDelay:
+                          description: how long to wait (in milliseconds) before deleting
+                            auto-created queues after the queue has 0 consumers.
                           format: int32
                           type: integer
                         autoDeleteQueuesMessageCount:
+                          description: the message count the queue must be at or below
+                            before it can be evaluated to be auto deleted, 0 waits
+                            until empty queue (default) and -1 disables this check.
                           format: int32
                           type: integer
                         configDeleteAddresses:
+                          description: What to do when an address is no longer in
+                            broker.xml.  OFF = will do nothing addresses will remain,
+                            FORCE = delete address and its queues even if messages
+                            remaining.
                           type: string
                         configDeleteQueues:
+                          description: What to do when a queue is no longer in broker.xml.  OFF
+                            = will do nothing queues will remain, FORCE = delete queues
+                            even if messages remaining.
                           type: string
                         deadLetterAddress:
+                          description: the address to send dead messages to
                           type: string
                         deadLetterQueuePrefix:
+                          description: the prefix to use for auto-created dead letter
+                            queues
                           type: string
                         deadLetterQueueSuffix:
+                          description: the suffix to use for auto-created dead letter
+                            queues
                           type: string
                         defaultAddressRoutingType:
+                          description: the routing-type used on auto-created addresses
                           type: string
                         defaultConsumerWindowSize:
+                          description: the default window size for a consumer
                           format: int32
                           type: integer
                         defaultConsumersBeforeDispatch:
+                          description: the default number of consumers needed before
+                            dispatch can start for queues under the address.
                           format: int32
                           type: integer
                         defaultDelayBeforeDispatch:
+                          description: the default delay (in milliseconds) to wait
+                            before dispatching if number of consumers before dispatch
+                            is not met for queues under the address.
                           format: int32
                           type: integer
                         defaultExclusiveQueue:
+                          description: whether to treat the queues under the address
+                            as exclusive queues by default
                           type: boolean
                         defaultGroupBuckets:
+                          description: number of buckets to use for grouping, -1 (default)
+                            is unlimited and uses the raw group, 0 disables message
+                            groups.
                           format: int32
                           type: integer
                         defaultGroupFirstKey:
+                          description: key used to mark a message is first in a group
+                            for a consumer
                           type: string
                         defaultGroupRebalance:
+                          description: whether to rebalance groups when a consumer
+                            is added
                           type: boolean
                         defaultGroupRebalancePauseDispatch:
+                          description: whether to pause dispatch when rebalancing
+                            groups
                           type: boolean
                         defaultLastValueKey:
+                          description: the property to use as the key for a last value
+                            queue by default
                           type: string
                         defaultLastValueQueue:
+                          description: whether to treat the queues under the address
+                            as a last value queues by default
                           type: boolean
                         defaultMaxConsumers:
+                          description: the maximum number of consumers allowed on
+                            this queue at any one time
                           format: int32
                           type: integer
                         defaultNonDestructive:
+                          description: whether the queue should be non-destructive
+                            by default
                           type: boolean
                         defaultPurgeOnNoConsumers:
+                          description: purge the contents of the queue once there
+                            are no consumers
                           type: boolean
                         defaultQueueRoutingType:
+                          description: the routing-type used on auto-created queues
                           type: string
                         defaultRingSize:
+                          description: the default ring-size value for any matching
+                            queue which doesnt have ring-size explicitly defined
                           format: int32
                           type: integer
                         enableIngressTimestamp:
+                          description: Whether or not set the timestamp of arrival
+                            on messages. default false
                           type: boolean
                         enableMetrics:
+                          description: whether or not to enable metrics for metrics
+                            plugins on the matching address
                           type: boolean
                         expiryAddress:
+                          description: the address to send expired messages to
                           type: string
                         expiryDelay:
+                          description: Overrides the expiration time for messages
+                            using the default value for expiration time. "-1" disables
+                            this setting.
                           format: int32
                           type: integer
                         expiryQueuePrefix:
+                          description: the prefix to use for auto-created expiry queues
                           type: string
                         expiryQueueSuffix:
+                          description: the suffix to use for auto-created expiry queues
                           type: string
                         lastValueQueue:
+                          description: This is deprecated please use default-last-value-queue
+                            instead.
                           type: boolean
                         managementBrowsePageSize:
+                          description: how many message a management resource can
+                            browse
                           format: int32
                           type: integer
                         managementMessageAttributeSizeLimit:
+                          description: max size of the message returned from management
+                            API, default 256
                           format: int32
                           type: integer
                         match:
+                          description: pattern for matching settings against addresses;
+                            can use wildards
                           type: string
                         maxDeliveryAttempts:
+                          description: how many times to attempt to deliver a message
+                            before sending to dead letter address
                           format: int32
                           type: integer
                         maxExpiryDelay:
+                          description: Overrides the expiration time for messages
+                            using a higher value. "-1" disables this setting.
                           format: int32
                           type: integer
                         maxRedeliveryDelay:
+                          description: Maximum value for the redelivery-delay
                           format: int32
                           type: integer
                         maxSizeBytes:
+                          description: the maximum size in bytes for an address. -1
+                            means no limits. This is used in PAGING, BLOCK and FAIL
+                            policies. Supports byte notation like K, Mb, GB, etc.
                           type: string
                         maxSizeBytesRejectThreshold:
+                          description: used with the address full BLOCK policy, the
+                            maximum size in bytes an address can reach before messages
+                            start getting rejected. Works in combination with max-size-bytes
+                            for AMQP protocol only.  Default = -1 (no limit).
                           format: int32
                           type: integer
                         messageCounterHistoryDayLimit:
+                          description: how many days to keep message counter history
+                            for this address
                           format: int32
                           type: integer
                         minExpiryDelay:
+                          description: Overrides the expiration time for messages
+                            using a lower value. "-1" disables this setting.
                           format: int32
                           type: integer
                         pageMaxCacheSize:
+                          description: Number of paging files to cache in memory to
+                            avoid IO during paging navigation
                           format: int32
                           type: integer
                         pageSizeBytes:
+                          description: The page size in bytes to use for an address.
+                            Supports byte notation like K, Mb, GB, etc.
                           type: string
                         redeliveryCollisionAvoidanceFactor:
                           type: number
                         redeliveryDelay:
+                          description: the time (in ms) to wait before redelivering
+                            a cancelled message.
                           format: int32
                           type: integer
                         redeliveryDelayMultiplier:
                           type: number
                         redistributionDelay:
+                          description: how long (in ms) to wait after the last consumer
+                            is closed on a queue before redistributing messages.
                           format: int32
                           type: integer
                         retroactiveMessageCount:
+                          description: the number of messages to preserve for future
+                            queues created on the matching address
                           format: int32
                           type: integer
                         sendToDlaOnNoRoute:
+                          description: if there are no queues matching this address,
+                            whether to forward message to DLA (if it exists for this
+                            address)
                           type: boolean
                         slowConsumerCheckPeriod:
+                          description: How often to check for slow consumers on a
+                            particular queue. Measured in seconds.
                           format: int32
                           type: integer
                         slowConsumerPolicy:
+                          description: what happens when a slow consumer is identified
                           type: string
                         slowConsumerThreshold:
+                          description: The minimum rate of message consumption allowed
+                            before a consumer is considered "slow." Measured in messages-per-second.
                           format: int32
                           type: integer
                         slowConsumerThresholdMeasurementUnit:
+                          description: Unit used in specifying slow consumer threshold,
+                            default is MESSAGE_PER_SECOND
                           type: string
                       type: object
                     type: array
                   applyRule:
+                    description: How to merge the address settings to broker configuration
                     type: string
                 type: object
               adminPassword:
+                description: Password for standard broker user. It is required for
+                  connecting to the broker and the web console. If left empty, it
+                  will be generated.
                 type: string
               adminUser:
+                description: User name for standard broker user. It is required for
+                  connecting to the broker and the web console. If left empty, it
+                  will be generated.
                 type: string
               connectors:
+                description: Specifies connectors and connector configuration
                 items:
                   properties:
                     enabledCipherSuites:
+                      description: Comma separated list of cipher suites used for
+                        SSL communication.
                       type: string
                     enabledProtocols:
+                      description: Comma separated list of protocols used for SSL
+                        communication.
                       type: string
                     expose:
+                      description: Whether or not to expose this connector
                       type: boolean
                     host:
+                      description: Hostname or IP to connect to
                       type: string
                     name:
+                      description: The name of the connector
                       type: string
                     needClientAuth:
+                      description: Tells a client connecting to this connector that
+                        2-way SSL is required. This property takes precedence over
+                        wantClientAuth.
                       type: boolean
                     port:
+                      description: Port number
                       format: int32
                       type: integer
                     sniHost:
+                      description: A regular expression used to match the server_name
+                        extension on incoming SSL connections. If the name doesn't
+                        match then the connection to the acceptor will be rejected.
                       type: string
                     sslEnabled:
+                      description: ' Whether or not to enable SSL on this port'
                       type: boolean
                     sslProvider:
+                      description: Used to change the SSL Provider between JDK and
+                        OPENSSL. The default is JDK.
                       type: string
                     sslSecret:
+                      description: Name of the secret to use for ssl information
                       type: string
                     type:
+                      description: The type either tcp or vm
                       type: string
                     verifyHost:
+                      description: The CN of the connecting client's SSL certificate
+                        will be compared to its hostname to verify they match. This
+                        is useful only for 2-way SSL.
                       type: boolean
                     wantClientAuth:
+                      description: Tells a client connecting to this connector that
+                        2-way SSL is requested but not required. Overridden by needClientAuth.
                       type: boolean
                   required:
                   - host
@@ -6706,72 +7499,101 @@ spec:
                   type: object
                 type: array
               console:
+                description: Specifies the console configuration
                 properties:
                   expose:
+                    description: Whether or not to expose this port
                     type: boolean
                   sslEnabled:
+                    description: Whether or not to enable SSL on this port
                     type: boolean
                   sslSecret:
+                    description: Name of the secret to use for ssl information
                     type: string
                   useClientAuth:
+                    description: If the embedded server requires client authentication
                     type: boolean
                 type: object
               deploymentPlan:
+                description: Specifies the deployment plan
                 properties:
                   clustered:
+                    description: Whether broker is clustered
                     type: boolean
                   enableMetricsPlugin:
+                    description: Whether or not to install the artemis metrics plugin
                     type: boolean
                   extraMounts:
+                    description: Specifies extra mounts
                     properties:
                       configMaps:
+                        description: Specifies ConfigMap names
                         items:
                           type: string
                         type: array
                       secrets:
+                        description: Specifies Secret names
                         items:
                           type: string
                         type: array
                     type: object
                   image:
+                    description: The image used for the broker, all upgrades are disabled.
+                      Needs a corresponding initImage
                     type: string
                   initImage:
+                    description: The init container image used to configure broker,
+                      all upgrades are disabled. Needs a corresponding image
                     type: string
                   jolokiaAgentEnabled:
+                    description: If true enable the Jolokia JVM Agent
                     type: boolean
                   journalType:
+                    description: If aio use ASYNCIO, if nio use NIO for journal IO
                     type: string
                   livenessProbe:
+                    description: Specifies the liveness probe configuration
                     properties:
                       timeoutSeconds:
                         format: int32
                         type: integer
                     type: object
                   managementRBACEnabled:
+                    description: If true enable the management role based access control
                     type: boolean
                   messageMigration:
+                    description: If true migrate messages on scaledown
                     type: boolean
                   persistenceEnabled:
+                    description: If true use persistent volume via persistent volume
+                      claim for journal storage
                     type: boolean
                   podSecurity:
+                    description: Specifies the pod security configurations
                     properties:
                       runAsUser:
+                        description: runAsUser as defined in PodSecurityContext for
+                          the pod
                         format: int64
                         type: integer
                       serviceAccountName:
+                        description: ServiceAccount Name of the pod
                         type: string
                     type: object
                   readinessProbe:
+                    description: Specifies the readiness probe configuration
                     properties:
                       timeoutSeconds:
                         format: int32
                         type: integer
                     type: object
                   requireLogin:
+                    description: If true require user password login credentials for
+                      broker protocol ports
                     type: boolean
                   resources:
-                    description: ResourceRequirements describes the compute resource
-                      requirements.
+                    description: Specifies the minimum/maximum amount of compute resources
+                      required/allowed
                     properties:
                       claims:
                         description: |-
@@ -6824,26 +7646,36 @@ spec:
                         type: object
                     type: object
                   size:
+                    description: The number of broker pods to deploy
                     format: int32
                     type: integer
                   storage:
+                    description: Specifies the storage configurations
                     properties:
                       size:
+                        description: The storage size
                         type: string
                     type: object
                 type: object
               upgrades:
-                description: ActiveMQArtemis App product upgrade flags
+                description: Specifies the upgrades (deprecated in favour of Version)
                 properties:
                   enabled:
+                    description: Set true to enable automatic micro version product
+                      upgrades, it is disabled by default.
                     type: boolean
                   minor:
+                    description: Set true to enable automatic minor product version
+                      upgrades, it is disabled by default. Requires spec.upgrades.enabled
+                      to be true.
                     type: boolean
                 required:
                 - enabled
                 - minor
                 type: object
               version:
+                description: The desired version of the broker. Can be x, or x.y or
+                  x.y.z to configure upgrades
                 type: string
             type: object
           status:
@@ -6909,9 +7741,7 @@ spec:
                   type: object
                 type: array
               podStatus:
-                description: |-
-                  INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
-                  Important: Run "make" to regenerate code after modifying this file
+                description: The current pods
                 properties:
                   ready:
                     description: Deployments are ready to serve requests

--- a/config/manifests/bases/activemq-artemis-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/activemq-artemis-operator.clusterserviceversion.yaml
@@ -218,15 +218,186 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:io.kubernetes.conditions
       version: v1beta1
-    - description: ActiveMQArtemisAddress is the Schema for the activemqartemisaddresses
-        API
-      displayName: Active MQArtemis Address
+    - description: Adding and removing addresses using custom resource definitions
+      displayName: ActiveMQ Artemis Address
       kind: ActiveMQArtemisAddress
       name: activemqartemisaddresses.broker.amq.io
       resources:
       - kind: Secret
         name: ""
         version: v1
+      specDescriptors:
+      - description: The Address Name
+        displayName: Address Name
+        path: addressName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Apply to the broker crs in the current namespace. A value of
+          * or empty string means applying to all broker crs. Default apply to all
+          broker crs
+        displayName: Apply To Broker CR Names
+        path: applyToCrNames
+      - description: The password for the user
+        displayName: Password
+        path: password
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:password
+      - description: Specify the queue configuration
+        displayName: Queue Configuration
+        path: queueConfiguration
+      - description: Whether auto create address
+        displayName: Auto Create Address
+        path: queueConfiguration.autoCreateAddress
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Auto-delete the queue
+        displayName: Auto Delete
+        path: queueConfiguration.autoDelete
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Delay (Milliseconds) before auto-delete the queue
+        displayName: Auto Delete Delay
+        path: queueConfiguration.autoDeleteDelay
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: Message count of the queue to allow auto delete
+        displayName: Auto Delete Message Count
+        path: queueConfiguration.autoDeleteMessageCount
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: If the queue is configuration managed
+        displayName: Configuration Managed
+        path: queueConfiguration.configurationManaged
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Consumer Priority
+        displayName: Consumer Priority
+        path: queueConfiguration.consumerPriority
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: Number of consumers required before dispatching messages
+        displayName: Consumers Before Dispatch
+        path: queueConfiguration.consumersBeforeDispatch
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: Milliseconds to wait for `consumers-before-dispatch` to be met
+          before dispatching messages anyway
+        displayName: Delay Before Dispatch
+        path: queueConfiguration.delayBeforeDispatch
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: If the queue is durable or not
+        displayName: Durable
+        path: queueConfiguration.durable
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: If the queue is enabled
+        displayName: Enabled
+        path: queueConfiguration.enabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: If the queue is exclusive
+        displayName: Exclusive
+        path: queueConfiguration.exclusive
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: The filter string for the queue
+        displayName: Filter String
+        path: queueConfiguration.filterString
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Number of messaging group buckets
+        displayName: Group Buckets
+        path: queueConfiguration.groupBuckets
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: Header set on the first group message
+        displayName: Group First Key
+        path: queueConfiguration.groupFirstKey
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: If rebalance the message group
+        displayName: Group Rebalance
+        path: queueConfiguration.groupRebalance
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: If pause message dispatch when rebalancing groups
+        displayName: Group Rebalance Pause Dispatch
+        path: queueConfiguration.groupRebalancePauseDispatch
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: If ignore if the target queue already exists
+        displayName: Ignore If Exists
+        path: queueConfiguration.ignoreIfExists
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: If it is a last value queue
+        displayName: Last Value
+        path: queueConfiguration.lastValue
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: The property used for last value queue to identify last values
+        displayName: Last Value Key
+        path: queueConfiguration.lastValueKey
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Max number of consumers allowed on this queue
+        displayName: Max Consumers
+        path: queueConfiguration.maxConsumers
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: If force non-destructive consumers on the queue
+        displayName: Non Destructive
+        path: queueConfiguration.nonDestructive
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Whether to delete all messages when no consumers connected to
+          the queue
+        displayName: Purge On No Consumers
+        path: queueConfiguration.purgeOnNoConsumers
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: The size the queue should maintain according to ring semantics
+        displayName: Ring Size
+        path: queueConfiguration.ringSize
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: The routing type of the queue
+        displayName: Routing Type
+        path: queueConfiguration.routingType
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: If the queue is temporary
+        displayName: Temporary
+        path: queueConfiguration.temporary
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: The user associated with the queue
+        displayName: User
+        path: queueConfiguration.user
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The Queue Name
+        displayName: Queue Name
+        path: queueName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Whether or not delete the queue from broker when CR is undeployed(default
+          false)
+        displayName: Remove From Broker On Delete
+        path: removeFromBrokerOnDelete
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: The Routing Type
+        displayName: Routing Type
+        path: routingType
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: User name for creating the queue or address
+        displayName: User
+        path: user
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
       statusDescriptors:
       - description: Current state of the resource Conditions represent the latest
           available observations of an object's state
@@ -235,15 +406,36 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:io.kubernetes.conditions
       version: v2alpha3
-    - description: ActiveMQArtemisAddress is the Schema for the activemqartemisaddresses
-        API
-      displayName: Active MQArtemis Address
+    - description: Adding and removing addresses using custom resource definitions
+      displayName: ActiveMQ Artemis Address
       kind: ActiveMQArtemisAddress
       name: activemqartemisaddresses.broker.amq.io
       resources:
       - kind: Secret
         name: ""
         version: v1
+      specDescriptors:
+      - description: The Address Name
+        displayName: Address Name
+        path: addressName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The Queue Name
+        displayName: Queue Name
+        path: queueName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Whether or not delete the queue from broker when CR is undeployed(default
+          false)
+        displayName: Remove From Broker On Delete
+        path: removeFromBrokerOnDelete
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: The Routing Type
+        displayName: Routing Type
+        path: routingType
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
       statusDescriptors:
       - description: Current state of the resource Conditions represent the latest
           available observations of an object's state
@@ -252,15 +444,30 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:io.kubernetes.conditions
       version: v2alpha2
-    - description: ActiveMQArtemisAddress is the Schema for the activemqartemisaddresses
-        API
-      displayName: Active MQArtemis Address
+    - description: Adding and removing addresses using custom resource definitions
+      displayName: ActiveMQ Artemis Address
       kind: ActiveMQArtemisAddress
       name: activemqartemisaddresses.broker.amq.io
       resources:
       - kind: Secret
         name: ""
         version: v1
+      specDescriptors:
+      - description: The Address Name
+        displayName: Address Name
+        path: addressName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The Queue Name
+        displayName: Queue Name
+        path: queueName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The Routing Type
+        displayName: Routing Type
+        path: routingType
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
       statusDescriptors:
       - description: Current state of the resource Conditions represent the latest
           available observations of an object's state
@@ -1321,14 +1528,735 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:org.w3:link
       version: v1beta1
-    - description: ActiveMQArtemis is the Schema for the activemqartemises API
-      displayName: Active MQArtemis
+    - description: A stateful deployment of one or more brokers
+      displayName: ActiveMQ Artemis
       kind: ActiveMQArtemis
       name: activemqartemises.broker.amq.io
       resources:
       - kind: Secret
         name: ""
         version: v1
+      specDescriptors:
+      - description: Specifies the acceptor configuration
+        displayName: Acceptors
+        path: acceptors
+      - description: AMQP Minimum Large Message Size
+        displayName: AMQP Min Large Message Size
+        path: acceptors[0].amqpMinLargeMessageSize
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: To indicate which kind of routing type to use.
+        displayName: Anycast Prefix
+        path: acceptors[0].anycastPrefix
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Max number of connections allowed to make
+        displayName: Connections Allowed
+        path: acceptors[0].connectionsAllowed
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: Comma separated list of cipher suites used for SSL communication.
+        displayName: Enabled Cipher Suites
+        path: acceptors[0].enabledCipherSuites
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Comma separated list of protocols used for SSL communication.
+        displayName: Enabled Protocols
+        path: acceptors[0].enabledProtocols
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Whether or not to expose this acceptor
+        displayName: Expose
+        path: acceptors[0].expose
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: To indicate which kind of routing type to use
+        displayName: Multicast Prefix
+        path: acceptors[0].multicastPrefix
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The acceptor name
+        displayName: Name
+        path: acceptors[0].name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Tells a client connecting to this acceptor that 2-way SSL is
+          required. This property takes precedence over wantClientAuth.
+        displayName: Need Client Auth
+        path: acceptors[0].needClientAuth
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Port number
+        displayName: Port
+        path: acceptors[0].port
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: The protocols to enable for this acceptor
+        displayName: Protocols
+        path: acceptors[0].protocols
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: A regular expression used to match the server_name extension
+          on incoming SSL connections. If the name doesn't match then the connection
+          to the acceptor will be rejected.
+        displayName: SNI Host
+        path: acceptors[0].sniHost
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Whether or not to enable SSL on this port
+        displayName: SSL Enabled
+        path: acceptors[0].sslEnabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Used to change the SSL Provider between JDK and OPENSSL. The
+          default is JDK.
+        displayName: SSL Provider
+        path: acceptors[0].sslProvider
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Name of the secret to use for ssl information
+        displayName: SSL Secret
+        path: acceptors[0].sslSecret
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: For openwire protocol if advisory topics are enabled, default
+          false
+        displayName: Support Advisory
+        path: acceptors[0].supportAdvisory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: If prevents advisory addresses/queues to be registered to management
+          service, default false
+        displayName: Suppress Internal Management Objects
+        path: acceptors[0].suppressInternalManagementObjects
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: The CN of the connecting client's SSL certificate will be compared
+          to its hostname to verify they match. This is useful only for 2-way SSL.
+        displayName: Verify Host
+        path: acceptors[0].verifyHost
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Tells a client connecting to this acceptor that 2-way SSL is
+          requested but not required. Overridden by needClientAuth.
+        displayName: Want Client Auth
+        path: acceptors[0].wantClientAuth
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Specifies the address configurations (deprecated in favour of
+          BrokerProperties)
+        displayName: Address Configurations
+        path: addressSettings
+      - description: Specifies the address settings
+        displayName: Address Settings
+        path: addressSettings.addressSetting
+      - description: what happens when an address where maxSizeBytes is specified
+          becomes full
+        displayName: Address Full Policy
+        path: addressSettings.addressSetting[0].addressFullPolicy
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: whether or not to automatically create addresses when a client
+          sends a message to or attempts to consume a message from a queue mapped
+          to an address that doesnt exist
+        displayName: Auto Create Addresses
+        path: addressSettings.addressSetting[0].autoCreateAddresses
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: whether or not to automatically create the dead-letter-address
+          and/or a corresponding queue on that address when a message found to be
+          undeliverable
+        displayName: AutoCreateDeadLetterResources
+        path: addressSettings.addressSetting[0].autoCreateDeadLetterResources
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: whether or not to automatically create the expiry-address and/or
+          a corresponding queue on that address when a message is sent to a matching
+          queue
+        displayName: Auto Create Expiry Resources
+        path: addressSettings.addressSetting[0].autoCreateExpiryResources
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: DEPRECATED. whether or not to automatically create JMS queues
+          when a producer sends or a consumer connects to a queue
+        displayName: Auto Create Jms Queues
+        path: addressSettings.addressSetting[0].autoCreateJmsQueues
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: DEPRECATED. whether or not to automatically create JMS topics
+          when a producer sends or a consumer subscribes to a topic
+        displayName: Auto Create Jms Topics
+        path: addressSettings.addressSetting[0].autoCreateJmsTopics
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: whether or not to automatically create a queue when a client
+          sends a message to or attempts to consume a message from a queue
+        displayName: Auto Create Queues
+        path: addressSettings.addressSetting[0].autoCreateQueues
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: whether or not to delete auto-created addresses when it no longer
+          has any queues
+        displayName: Auto Delete Addresses
+        path: addressSettings.addressSetting[0].autoDeleteAddresses
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: how long to wait (in milliseconds) before deleting auto-created
+          addresses after they no longer have any queues
+        displayName: Auto Delete Addresses Delay
+        path: addressSettings.addressSetting[0].autoDeleteAddressesDelay
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: whether or not to delete created queues when the queue has 0
+          consumers and 0 messages
+        displayName: Auto Delete Created Queues
+        path: addressSettings.addressSetting[0].autoDeleteCreatedQueues
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: DEPRECATED. whether or not to delete auto-created JMS queues
+          when the queue has 0 consumers and 0 messages
+        displayName: Auto Delete Jms Queues
+        path: addressSettings.addressSetting[0].autoDeleteJmsQueues
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: DEPRECATED. whether or not to delete auto-created JMS topics
+          when the last subscription is closed
+        displayName: Auto Delete Jms Topics
+        path: addressSettings.addressSetting[0].autoDeleteJmsTopics
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: whether or not to delete auto-created queues when the queue has
+          0 consumers and 0 messages
+        displayName: Auto Delete Queues
+        path: addressSettings.addressSetting[0].autoDeleteQueues
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: how long to wait (in milliseconds) before deleting auto-created
+          queues after the queue has 0 consumers.
+        displayName: Auto Delete Queues Delay
+        path: addressSettings.addressSetting[0].autoDeleteQueuesDelay
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: the message count the queue must be at or below before it can
+          be evaluated to be auto deleted, 0 waits until empty queue (default) and
+          -1 disables this check.
+        displayName: Auto Delete Queues Message Count
+        path: addressSettings.addressSetting[0].autoDeleteQueuesMessageCount
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: What to do when an address is no longer in broker.xml.  OFF =
+          will do nothing addresses will remain, FORCE = delete address and its queues
+          even if messages remaining.
+        displayName: Config Delete Addresses
+        path: addressSettings.addressSetting[0].configDeleteAddresses
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: What to do when a queue is no longer in broker.xml.  OFF = will
+          do nothing queues will remain, FORCE = delete queues even if messages remaining.
+        displayName: Config Delete Queues
+        path: addressSettings.addressSetting[0].configDeleteQueues
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: the address to send dead messages to
+        displayName: Dead Letter Address
+        path: addressSettings.addressSetting[0].deadLetterAddress
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: the prefix to use for auto-created dead letter queues
+        displayName: Dead Letter Queue Prefix
+        path: addressSettings.addressSetting[0].deadLetterQueuePrefix
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: the suffix to use for auto-created dead letter queues
+        displayName: Dead Letter Queue Suffix
+        path: addressSettings.addressSetting[0].deadLetterQueueSuffix
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: the routing-type used on auto-created addresses
+        displayName: Default Address Routing Type
+        path: addressSettings.addressSetting[0].defaultAddressRoutingType
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: the default window size for a consumer
+        displayName: Default Consumer Window Size
+        path: addressSettings.addressSetting[0].defaultConsumerWindowSize
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: the default number of consumers needed before dispatch can start
+          for queues under the address.
+        displayName: Default Consumers Before Dispatch
+        path: addressSettings.addressSetting[0].defaultConsumersBeforeDispatch
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: the default delay (in milliseconds) to wait before dispatching
+          if number of consumers before dispatch is not met for queues under the address.
+        displayName: Default Delay Before Dispatch
+        path: addressSettings.addressSetting[0].defaultDelayBeforeDispatch
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: whether to treat the queues under the address as exclusive queues
+          by default
+        displayName: Default Exclusive Queue
+        path: addressSettings.addressSetting[0].defaultExclusiveQueue
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: number of buckets to use for grouping, -1 (default) is unlimited
+          and uses the raw group, 0 disables message groups.
+        displayName: Default Group Buckets
+        path: addressSettings.addressSetting[0].defaultGroupBuckets
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: key used to mark a message is first in a group for a consumer
+        displayName: Default Group First Key
+        path: addressSettings.addressSetting[0].defaultGroupFirstKey
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: whether to rebalance groups when a consumer is added
+        displayName: Default Group Rebalance
+        path: addressSettings.addressSetting[0].defaultGroupRebalance
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: whether to pause dispatch when rebalancing groups
+        displayName: Default Group Rebalance Pause Dispatch
+        path: addressSettings.addressSetting[0].defaultGroupRebalancePauseDispatch
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: the property to use as the key for a last value queue by default
+        displayName: Default Last Value Key
+        path: addressSettings.addressSetting[0].defaultLastValueKey
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: whether to treat the queues under the address as a last value
+          queues by default
+        displayName: Default Last Value Queue
+        path: addressSettings.addressSetting[0].defaultLastValueQueue
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: the maximum number of consumers allowed on this queue at any
+          one time
+        displayName: Default Max Consumers
+        path: addressSettings.addressSetting[0].defaultMaxConsumers
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: whether the queue should be non-destructive by default
+        displayName: Default Non Destructive
+        path: addressSettings.addressSetting[0].defaultNonDestructive
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: purge the contents of the queue once there are no consumers
+        displayName: Default Purge On No Consumers
+        path: addressSettings.addressSetting[0].defaultPurgeOnNoConsumers
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: the routing-type used on auto-created queues
+        displayName: Default Queue Routing Type
+        path: addressSettings.addressSetting[0].defaultQueueRoutingType
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: the default ring-size value for any matching queue which doesnt
+          have ring-size explicitly defined
+        displayName: Default Ring Size
+        path: addressSettings.addressSetting[0].defaultRingSize
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: Whether or not set the timestamp of arrival on messages. default
+          false
+        displayName: Enable Ingress Timestamp
+        path: addressSettings.addressSetting[0].enableIngressTimestamp
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: whether or not to enable metrics for metrics plugins on the matching
+          address
+        displayName: Enable Metrics
+        path: addressSettings.addressSetting[0].enableMetrics
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: the address to send expired messages to
+        displayName: Expiry Address
+        path: addressSettings.addressSetting[0].expiryAddress
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Overrides the expiration time for messages using the default
+          value for expiration time. "-1" disables this setting.
+        displayName: Expiry Delay
+        path: addressSettings.addressSetting[0].expiryDelay
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: the prefix to use for auto-created expiry queues
+        displayName: Expiry Queue Prefix
+        path: addressSettings.addressSetting[0].expiryQueuePrefix
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: the suffix to use for auto-created expiry queues
+        displayName: Expiry Queue Suffix
+        path: addressSettings.addressSetting[0].expiryQueueSuffix
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: This is deprecated please use default-last-value-queue instead.
+        displayName: Last Value Queue
+        path: addressSettings.addressSetting[0].lastValueQueue
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: how many message a management resource can browse
+        displayName: Management Browse Page Size
+        path: addressSettings.addressSetting[0].managementBrowsePageSize
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: max size of the message returned from management API, default
+          256
+        displayName: Max Management Message Size Limit
+        path: addressSettings.addressSetting[0].managementMessageAttributeSizeLimit
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: pattern for matching settings against addresses; can use wildards
+        displayName: Match
+        path: addressSettings.addressSetting[0].match
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: how many times to attempt to deliver a message before sending
+          to dead letter address
+        displayName: Max Delivery Attempts
+        path: addressSettings.addressSetting[0].maxDeliveryAttempts
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: Overrides the expiration time for messages using a higher value.
+          "-1" disables this setting.
+        displayName: Max Expiry Delay
+        path: addressSettings.addressSetting[0].maxExpiryDelay
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: Maximum value for the redelivery-delay
+        displayName: Max Redelivery Delay
+        path: addressSettings.addressSetting[0].maxRedeliveryDelay
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: the maximum size in bytes for an address. -1 means no limits.
+          This is used in PAGING, BLOCK and FAIL policies. Supports byte notation
+          like K, Mb, GB, etc.
+        displayName: Max Size Bytes
+        path: addressSettings.addressSetting[0].maxSizeBytes
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: used with the address full BLOCK policy, the maximum size in
+          bytes an address can reach before messages start getting rejected. Works
+          in combination with max-size-bytes for AMQP protocol only.  Default = -1
+          (no limit).
+        displayName: Max Size Bytes Reject Threshold
+        path: addressSettings.addressSetting[0].maxSizeBytesRejectThreshold
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: how many days to keep message counter history for this address
+        displayName: Message Counter History Day Limit
+        path: addressSettings.addressSetting[0].messageCounterHistoryDayLimit
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: Overrides the expiration time for messages using a lower value.
+          "-1" disables this setting.
+        displayName: Min Expiry Delay
+        path: addressSettings.addressSetting[0].minExpiryDelay
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: Number of paging files to cache in memory to avoid IO during
+          paging navigation
+        displayName: Page Max Cache Size
+        path: addressSettings.addressSetting[0].pageMaxCacheSize
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: The page size in bytes to use for an address. Supports byte notation
+          like K, Mb, GB, etc.
+        displayName: Page Size Bytes
+        path: addressSettings.addressSetting[0].pageSizeBytes
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: the time (in ms) to wait before redelivering a cancelled message.
+        displayName: Redelivery Delay
+        path: addressSettings.addressSetting[0].redeliveryDelay
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: how long (in ms) to wait after the last consumer is closed on
+          a queue before redistributing messages.
+        displayName: Redistribution Delay
+        path: addressSettings.addressSetting[0].redistributionDelay
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: the number of messages to preserve for future queues created
+          on the matching address
+        displayName: Retroactive Message Count
+        path: addressSettings.addressSetting[0].retroactiveMessageCount
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: if there are no queues matching this address, whether to forward
+          message to DLA (if it exists for this address)
+        displayName: Send To DLA On No Route
+        path: addressSettings.addressSetting[0].sendToDlaOnNoRoute
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: How often to check for slow consumers on a particular queue.
+          Measured in seconds.
+        displayName: Slow Consumer Check Period
+        path: addressSettings.addressSetting[0].slowConsumerCheckPeriod
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: what happens when a slow consumer is identified
+        displayName: Slow Consumer Policy
+        path: addressSettings.addressSetting[0].slowConsumerPolicy
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The minimum rate of message consumption allowed before a consumer
+          is considered "slow." Measured in messages-per-second.
+        displayName: Slow Consumer Threshold
+        path: addressSettings.addressSetting[0].slowConsumerThreshold
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: Unit used in specifying slow consumer threshold, default is MESSAGE_PER_SECOND
+        displayName: Slow Consumer Threshold Measurement Unit
+        path: addressSettings.addressSetting[0].slowConsumerThresholdMeasurementUnit
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: How to merge the address settings to broker configuration
+        displayName: Apply Rule
+        path: addressSettings.applyRule
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Password for standard broker user. It is required for connecting
+          to the broker and the web console. If left empty, it will be generated.
+        displayName: Admin Password
+        path: adminPassword
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:password
+      - description: User name for standard broker user. It is required for connecting
+          to the broker and the web console. If left empty, it will be generated.
+        displayName: Admin User
+        path: adminUser
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Specifies connectors and connector configuration
+        displayName: Connectors
+        path: connectors
+      - description: Comma separated list of cipher suites used for SSL communication.
+        displayName: Enabled Cipher Suites
+        path: connectors[0].enabledCipherSuites
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Comma separated list of protocols used for SSL communication.
+        displayName: Enabled Protocols
+        path: connectors[0].enabledProtocols
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Whether or not to expose this connector
+        displayName: Expose
+        path: connectors[0].expose
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Hostname or IP to connect to
+        displayName: Host
+        path: connectors[0].host
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The name of the connector
+        displayName: Name
+        path: connectors[0].name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Tells a client connecting to this connector that 2-way SSL is
+          required. This property takes precedence over wantClientAuth.
+        displayName: Need Client Auth
+        path: connectors[0].needClientAuth
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Port number
+        displayName: Port
+        path: connectors[0].port
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: A regular expression used to match the server_name extension
+          on incoming SSL connections. If the name doesn't match then the connection
+          to the acceptor will be rejected.
+        displayName: SNI Host
+        path: connectors[0].sniHost
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Whether or not to enable SSL on this port
+        displayName: SSL Enabled
+        path: connectors[0].sslEnabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Used to change the SSL Provider between JDK and OPENSSL. The
+          default is JDK.
+        displayName: SSL Provider
+        path: connectors[0].sslProvider
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Name of the secret to use for ssl information
+        displayName: SSL Secret
+        path: connectors[0].sslSecret
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The type either tcp or vm
+        displayName: Type
+        path: connectors[0].type
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The CN of the connecting client's SSL certificate will be compared
+          to its hostname to verify they match. This is useful only for 2-way SSL.
+        displayName: Verify Host
+        path: connectors[0].verifyHost
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Tells a client connecting to this connector that 2-way SSL is
+          requested but not required. Overridden by needClientAuth.
+        displayName: Want Client Auth
+        path: connectors[0].wantClientAuth
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Specifies the console configuration
+        displayName: Console Configurations
+        path: console
+      - description: Whether or not to expose this port
+        displayName: Expose
+        path: console.expose
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Whether or not to enable SSL on this port
+        displayName: SSL Enabled
+        path: console.sslEnabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Name of the secret to use for ssl information
+        displayName: SSL Secret
+        path: console.sslSecret
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: If the embedded server requires client authentication
+        displayName: Use Client Auth
+        path: console.useClientAuth
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Specifies the deployment plan
+        displayName: Deployment Plan
+        path: deploymentPlan
+      - description: Whether broker is clustered
+        displayName: Clustered
+        path: deploymentPlan.clustered
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Whether or not to install the artemis metrics plugin
+        displayName: Enable Metrics Plugin
+        path: deploymentPlan.enableMetricsPlugin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Specifies extra mounts
+        displayName: Extra Mounts
+        path: deploymentPlan.extraMounts
+      - description: Specifies ConfigMap names
+        displayName: ConfigMap Names
+        path: deploymentPlan.extraMounts.configMaps
+      - description: Specifies Secret names
+        displayName: Secret Names
+        path: deploymentPlan.extraMounts.secrets
+      - description: The image used for the broker, all upgrades are disabled. Needs
+          a corresponding initImage
+        displayName: Image
+        path: deploymentPlan.image
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The init container image used to configure broker, all upgrades
+          are disabled. Needs a corresponding image
+        displayName: Init Image
+        path: deploymentPlan.initImage
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: If true enable the Jolokia JVM Agent
+        displayName: Jolokia Agent Enabled
+        path: deploymentPlan.jolokiaAgentEnabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: If aio use ASYNCIO, if nio use NIO for journal IO
+        displayName: Journal Type
+        path: deploymentPlan.journalType
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Specifies the liveness probe configuration
+        displayName: Liveness Probe Configurations
+        path: deploymentPlan.livenessProbe
+      - description: If true enable the management role based access control
+        displayName: Management RBAC Enabled
+        path: deploymentPlan.managementRBACEnabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: If true migrate messages on scaledown
+        displayName: Message Migration
+        path: deploymentPlan.messageMigration
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: If true use persistent volume via persistent volume claim for
+          journal storage
+        displayName: Persistence Enabled
+        path: deploymentPlan.persistenceEnabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Specifies the pod security configurations
+        displayName: Pod Security Configurations
+        path: deploymentPlan.podSecurity
+      - description: runAsUser as defined in PodSecurityContext for the pod
+        displayName: Run As User
+        path: deploymentPlan.podSecurity.runAsUser
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: ServiceAccount Name of the pod
+        displayName: Service Account Name
+        path: deploymentPlan.podSecurity.serviceAccountName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Specifies the readiness probe configuration
+        displayName: Readiness Probe Configurations
+        path: deploymentPlan.readinessProbe
+      - description: If true require user password login credentials for broker protocol
+          ports
+        displayName: Require Login
+        path: deploymentPlan.requireLogin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Specifies the minimum/maximum amount of compute resources required/allowed
+        displayName: Resource Requirements
+        path: deploymentPlan.resources
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+      - description: The number of broker pods to deploy
+        displayName: Size
+        path: deploymentPlan.size
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podCount
+      - description: Specifies the storage configurations
+        displayName: Storage Configurations
+        path: deploymentPlan.storage
+      - description: The storage size
+        displayName: Size
+        path: deploymentPlan.storage.size
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Specifies the upgrades (deprecated in favour of Version)
+        displayName: Upgrades
+        path: upgrades
+      - description: Set true to enable automatic micro version product upgrades,
+          it is disabled by default.
+        displayName: Enable Upgrades
+        path: upgrades.enabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:ui:booleanSwitch
+      - description: Set true to enable automatic minor product version upgrades,
+          it is disabled by default. Requires spec.upgrades.enabled to be true.
+        displayName: Include minor version upgrades
+        path: upgrades.minor
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:upgrades.enabled:true
+        - urn:alm:descriptor:com.tectonic.ui:ui:booleanSwitch
+      - description: The desired version of the broker. Can be x, or x.y or x.y.z
+          to configure upgrades
+        displayName: Version
+        path: version
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
       statusDescriptors:
       - description: Current state of the resource Conditions represent the latest
           available observations of an object's state
@@ -1336,15 +2264,674 @@ spec:
         path: conditions
         x-descriptors:
         - urn:alm:descriptor:io.kubernetes.conditions
+      - description: The current pods
+        displayName: Pods Status
+        path: podStatus
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podStatuses
       version: v2alpha5
-    - description: ActiveMQArtemis is the Schema for the activemqartemises API
-      displayName: Active MQArtemis
+    - description: A stateful deployment of one or more brokers
+      displayName: ActiveMQ Artemis
       kind: ActiveMQArtemis
       name: activemqartemises.broker.amq.io
       resources:
       - kind: Secret
         name: ""
         version: v1
+      specDescriptors:
+      - description: Specifies the acceptor configuration
+        displayName: Acceptors
+        path: acceptors
+      - description: AMQP Minimum Large Message Size
+        displayName: AMQP Min Large Message Size
+        path: acceptors[0].amqpMinLargeMessageSize
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: To indicate which kind of routing type to use.
+        displayName: Anycast Prefix
+        path: acceptors[0].anycastPrefix
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Max number of connections allowed to make
+        displayName: Connections Allowed
+        path: acceptors[0].connectionsAllowed
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: Comma separated list of cipher suites used for SSL communication.
+        displayName: Enabled Cipher Suites
+        path: acceptors[0].enabledCipherSuites
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Comma separated list of protocols used for SSL communication.
+        displayName: Enabled Protocols
+        path: acceptors[0].enabledProtocols
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Whether or not to expose this acceptor
+        displayName: Expose
+        path: acceptors[0].expose
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: To indicate which kind of routing type to use
+        displayName: Multicast Prefix
+        path: acceptors[0].multicastPrefix
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The acceptor name
+        displayName: Name
+        path: acceptors[0].name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Tells a client connecting to this acceptor that 2-way SSL is
+          required. This property takes precedence over wantClientAuth.
+        displayName: Need Client Auth
+        path: acceptors[0].needClientAuth
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Port number
+        displayName: Port
+        path: acceptors[0].port
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: The protocols to enable for this acceptor
+        displayName: Protocols
+        path: acceptors[0].protocols
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: A regular expression used to match the server_name extension
+          on incoming SSL connections. If the name doesn't match then the connection
+          to the acceptor will be rejected.
+        displayName: SNI Host
+        path: acceptors[0].sniHost
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Whether or not to enable SSL on this port
+        displayName: SSL Enabled
+        path: acceptors[0].sslEnabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Used to change the SSL Provider between JDK and OPENSSL. The
+          default is JDK.
+        displayName: SSL Provider
+        path: acceptors[0].sslProvider
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Name of the secret to use for ssl information
+        displayName: SSL Secret
+        path: acceptors[0].sslSecret
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The CN of the connecting client's SSL certificate will be compared
+          to its hostname to verify they match. This is useful only for 2-way SSL.
+        displayName: Verify Host
+        path: acceptors[0].verifyHost
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Tells a client connecting to this acceptor that 2-way SSL is
+          requested but not required. Overridden by needClientAuth.
+        displayName: Want Client Auth
+        path: acceptors[0].wantClientAuth
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Specifies the address configurations (deprecated in favour of
+          BrokerProperties)
+        displayName: Address Configurations
+        path: addressSettings
+      - description: Specifies the address settings
+        displayName: Address Settings
+        path: addressSettings.addressSetting
+      - description: what happens when an address where maxSizeBytes is specified
+          becomes full
+        displayName: Address Full Policy
+        path: addressSettings.addressSetting[0].addressFullPolicy
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: whether or not to automatically create addresses when a client
+          sends a message to or attempts to consume a message from a queue mapped
+          to an address that doesnt exist
+        displayName: Auto Create Addresses
+        path: addressSettings.addressSetting[0].autoCreateAddresses
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: whether or not to automatically create the dead-letter-address
+          and/or a corresponding queue on that address when a message found to be
+          undeliverable
+        displayName: AutoCreateDeadLetterResources
+        path: addressSettings.addressSetting[0].autoCreateDeadLetterResources
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: whether or not to automatically create the expiry-address and/or
+          a corresponding queue on that address when a message is sent to a matching
+          queue
+        displayName: Auto Create Expiry Resources
+        path: addressSettings.addressSetting[0].autoCreateExpiryResources
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: DEPRECATED. whether or not to automatically create JMS queues
+          when a producer sends or a consumer connects to a queue
+        displayName: Auto Create Jms Queues
+        path: addressSettings.addressSetting[0].autoCreateJmsQueues
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: DEPRECATED. whether or not to automatically create JMS topics
+          when a producer sends or a consumer subscribes to a topic
+        displayName: Auto Create Jms Topics
+        path: addressSettings.addressSetting[0].autoCreateJmsTopics
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: whether or not to automatically create a queue when a client
+          sends a message to or attempts to consume a message from a queue
+        displayName: Auto Create Queues
+        path: addressSettings.addressSetting[0].autoCreateQueues
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: whether or not to delete auto-created addresses when it no longer
+          has any queues
+        displayName: Auto Delete Addresses
+        path: addressSettings.addressSetting[0].autoDeleteAddresses
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: how long to wait (in milliseconds) before deleting auto-created
+          addresses after they no longer have any queues
+        displayName: Auto Delete Addresses Delay
+        path: addressSettings.addressSetting[0].autoDeleteAddressesDelay
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: whether or not to delete created queues when the queue has 0
+          consumers and 0 messages
+        displayName: Auto Delete Created Queues
+        path: addressSettings.addressSetting[0].autoDeleteCreatedQueues
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: DEPRECATED. whether or not to delete auto-created JMS queues
+          when the queue has 0 consumers and 0 messages
+        displayName: Auto Delete Jms Queues
+        path: addressSettings.addressSetting[0].autoDeleteJmsQueues
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: DEPRECATED. whether or not to delete auto-created JMS topics
+          when the last subscription is closed
+        displayName: Auto Delete Jms Topics
+        path: addressSettings.addressSetting[0].autoDeleteJmsTopics
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: whether or not to delete auto-created queues when the queue has
+          0 consumers and 0 messages
+        displayName: Auto Delete Queues
+        path: addressSettings.addressSetting[0].autoDeleteQueues
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: how long to wait (in milliseconds) before deleting auto-created
+          queues after the queue has 0 consumers.
+        displayName: Auto Delete Queues Delay
+        path: addressSettings.addressSetting[0].autoDeleteQueuesDelay
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: the message count the queue must be at or below before it can
+          be evaluated to be auto deleted, 0 waits until empty queue (default) and
+          -1 disables this check.
+        displayName: Auto Delete Queues Message Count
+        path: addressSettings.addressSetting[0].autoDeleteQueuesMessageCount
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: What to do when an address is no longer in broker.xml.  OFF =
+          will do nothing addresses will remain, FORCE = delete address and its queues
+          even if messages remaining.
+        displayName: Config Delete Addresses
+        path: addressSettings.addressSetting[0].configDeleteAddresses
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: What to do when a queue is no longer in broker.xml.  OFF = will
+          do nothing queues will remain, FORCE = delete queues even if messages remaining.
+        displayName: Config Delete Queues
+        path: addressSettings.addressSetting[0].configDeleteQueues
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: the address to send dead messages to
+        displayName: Dead Letter Address
+        path: addressSettings.addressSetting[0].deadLetterAddress
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: the prefix to use for auto-created dead letter queues
+        displayName: Dead Letter Queue Prefix
+        path: addressSettings.addressSetting[0].deadLetterQueuePrefix
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: the suffix to use for auto-created dead letter queues
+        displayName: Dead Letter Queue Suffix
+        path: addressSettings.addressSetting[0].deadLetterQueueSuffix
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: the routing-type used on auto-created addresses
+        displayName: Default Address Routing Type
+        path: addressSettings.addressSetting[0].defaultAddressRoutingType
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: the default window size for a consumer
+        displayName: Default Consumer Window Size
+        path: addressSettings.addressSetting[0].defaultConsumerWindowSize
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: the default number of consumers needed before dispatch can start
+          for queues under the address.
+        displayName: Default Consumers Before Dispatch
+        path: addressSettings.addressSetting[0].defaultConsumersBeforeDispatch
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: the default delay (in milliseconds) to wait before dispatching
+          if number of consumers before dispatch is not met for queues under the address.
+        displayName: Default Delay Before Dispatch
+        path: addressSettings.addressSetting[0].defaultDelayBeforeDispatch
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: whether to treat the queues under the address as exclusive queues
+          by default
+        displayName: Default Exclusive Queue
+        path: addressSettings.addressSetting[0].defaultExclusiveQueue
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: number of buckets to use for grouping, -1 (default) is unlimited
+          and uses the raw group, 0 disables message groups.
+        displayName: Default Group Buckets
+        path: addressSettings.addressSetting[0].defaultGroupBuckets
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: key used to mark a message is first in a group for a consumer
+        displayName: Default Group First Key
+        path: addressSettings.addressSetting[0].defaultGroupFirstKey
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: whether to rebalance groups when a consumer is added
+        displayName: Default Group Rebalance
+        path: addressSettings.addressSetting[0].defaultGroupRebalance
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: whether to pause dispatch when rebalancing groups
+        displayName: Default Group Rebalance Pause Dispatch
+        path: addressSettings.addressSetting[0].defaultGroupRebalancePauseDispatch
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: the property to use as the key for a last value queue by default
+        displayName: Default Last Value Key
+        path: addressSettings.addressSetting[0].defaultLastValueKey
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: whether to treat the queues under the address as a last value
+          queues by default
+        displayName: Default Last Value Queue
+        path: addressSettings.addressSetting[0].defaultLastValueQueue
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: the maximum number of consumers allowed on this queue at any
+          one time
+        displayName: Default Max Consumers
+        path: addressSettings.addressSetting[0].defaultMaxConsumers
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: whether the queue should be non-destructive by default
+        displayName: Default Non Destructive
+        path: addressSettings.addressSetting[0].defaultNonDestructive
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: purge the contents of the queue once there are no consumers
+        displayName: Default Purge On No Consumers
+        path: addressSettings.addressSetting[0].defaultPurgeOnNoConsumers
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: the routing-type used on auto-created queues
+        displayName: Default Queue Routing Type
+        path: addressSettings.addressSetting[0].defaultQueueRoutingType
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: the default ring-size value for any matching queue which doesnt
+          have ring-size explicitly defined
+        displayName: Default Ring Size
+        path: addressSettings.addressSetting[0].defaultRingSize
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: whether or not to enable metrics for metrics plugins on the matching
+          address
+        displayName: Enable Metrics
+        path: addressSettings.addressSetting[0].enableMetrics
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: the address to send expired messages to
+        displayName: Expiry Address
+        path: addressSettings.addressSetting[0].expiryAddress
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Overrides the expiration time for messages using the default
+          value for expiration time. "-1" disables this setting.
+        displayName: Expiry Delay
+        path: addressSettings.addressSetting[0].expiryDelay
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: the prefix to use for auto-created expiry queues
+        displayName: Expiry Queue Prefix
+        path: addressSettings.addressSetting[0].expiryQueuePrefix
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: the suffix to use for auto-created expiry queues
+        displayName: Expiry Queue Suffix
+        path: addressSettings.addressSetting[0].expiryQueueSuffix
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: This is deprecated please use default-last-value-queue instead.
+        displayName: Last Value Queue
+        path: addressSettings.addressSetting[0].lastValueQueue
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: how many message a management resource can browse
+        displayName: Management Browse Page Size
+        path: addressSettings.addressSetting[0].managementBrowsePageSize
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: pattern for matching settings against addresses; can use wildards
+        displayName: Match
+        path: addressSettings.addressSetting[0].match
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: how many times to attempt to deliver a message before sending
+          to dead letter address
+        displayName: Max Delivery Attempts
+        path: addressSettings.addressSetting[0].maxDeliveryAttempts
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: Overrides the expiration time for messages using a higher value.
+          "-1" disables this setting.
+        displayName: Max Expiry Delay
+        path: addressSettings.addressSetting[0].maxExpiryDelay
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: Maximum value for the redelivery-delay
+        displayName: Max Redelivery Delay
+        path: addressSettings.addressSetting[0].maxRedeliveryDelay
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: the maximum size in bytes for an address. -1 means no limits.
+          This is used in PAGING, BLOCK and FAIL policies. Supports byte notation
+          like K, Mb, GB, etc.
+        displayName: Max Size Bytes
+        path: addressSettings.addressSetting[0].maxSizeBytes
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: used with the address full BLOCK policy, the maximum size in
+          bytes an address can reach before messages start getting rejected. Works
+          in combination with max-size-bytes for AMQP protocol only.  Default = -1
+          (no limit).
+        displayName: Max Size Bytes Reject Threshold
+        path: addressSettings.addressSetting[0].maxSizeBytesRejectThreshold
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: how many days to keep message counter history for this address
+        displayName: Message Counter History Day Limit
+        path: addressSettings.addressSetting[0].messageCounterHistoryDayLimit
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: Overrides the expiration time for messages using a lower value.
+          "-1" disables this setting.
+        displayName: Min Expiry Delay
+        path: addressSettings.addressSetting[0].minExpiryDelay
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: Number of paging files to cache in memory to avoid IO during
+          paging navigation
+        displayName: Page Max Cache Size
+        path: addressSettings.addressSetting[0].pageMaxCacheSize
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: The page size in bytes to use for an address. Supports byte notation
+          like K, Mb, GB, etc.
+        displayName: Page Size Bytes
+        path: addressSettings.addressSetting[0].pageSizeBytes
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: the time (in ms) to wait before redelivering a cancelled message.
+        displayName: Redelivery Delay
+        path: addressSettings.addressSetting[0].redeliveryDelay
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: how long (in ms) to wait after the last consumer is closed on
+          a queue before redistributing messages.
+        displayName: Redistribution Delay
+        path: addressSettings.addressSetting[0].redistributionDelay
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: the number of messages to preserve for future queues created
+          on the matching address
+        displayName: Retroactive Message Count
+        path: addressSettings.addressSetting[0].retroactiveMessageCount
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: if there are no queues matching this address, whether to forward
+          message to DLA (if it exists for this address)
+        displayName: Send To DLA On No Route
+        path: addressSettings.addressSetting[0].sendToDlaOnNoRoute
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: How often to check for slow consumers on a particular queue.
+          Measured in seconds.
+        displayName: Slow Consumer Check Period
+        path: addressSettings.addressSetting[0].slowConsumerCheckPeriod
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: what happens when a slow consumer is identified
+        displayName: Slow Consumer Policy
+        path: addressSettings.addressSetting[0].slowConsumerPolicy
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The minimum rate of message consumption allowed before a consumer
+          is considered "slow." Measured in messages-per-second.
+        displayName: Slow Consumer Threshold
+        path: addressSettings.addressSetting[0].slowConsumerThreshold
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: How to merge the address settings to broker configuration
+        displayName: Apply Rule
+        path: addressSettings.applyRule
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Password for standard broker user. It is required for connecting
+          to the broker and the web console. If left empty, it will be generated.
+        displayName: Admin Password
+        path: adminPassword
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:password
+      - description: User name for standard broker user. It is required for connecting
+          to the broker and the web console. If left empty, it will be generated.
+        displayName: Admin User
+        path: adminUser
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Specifies connectors and connector configuration
+        displayName: Connectors
+        path: connectors
+      - description: Comma separated list of cipher suites used for SSL communication.
+        displayName: Enabled Cipher Suites
+        path: connectors[0].enabledCipherSuites
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Comma separated list of protocols used for SSL communication.
+        displayName: Enabled Protocols
+        path: connectors[0].enabledProtocols
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Whether or not to expose this connector
+        displayName: Expose
+        path: connectors[0].expose
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Hostname or IP to connect to
+        displayName: Host
+        path: connectors[0].host
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The name of the connector
+        displayName: Name
+        path: connectors[0].name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Tells a client connecting to this connector that 2-way SSL is
+          required. This property takes precedence over wantClientAuth.
+        displayName: Need Client Auth
+        path: connectors[0].needClientAuth
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Port number
+        displayName: Port
+        path: connectors[0].port
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: A regular expression used to match the server_name extension
+          on incoming SSL connections. If the name doesn't match then the connection
+          to the acceptor will be rejected.
+        displayName: SNI Host
+        path: connectors[0].sniHost
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Whether or not to enable SSL on this port
+        displayName: SSL Enabled
+        path: connectors[0].sslEnabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Used to change the SSL Provider between JDK and OPENSSL. The
+          default is JDK.
+        displayName: SSL Provider
+        path: connectors[0].sslProvider
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Name of the secret to use for ssl information
+        displayName: SSL Secret
+        path: connectors[0].sslSecret
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The type either tcp or vm
+        displayName: Type
+        path: connectors[0].type
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The CN of the connecting client's SSL certificate will be compared
+          to its hostname to verify they match. This is useful only for 2-way SSL.
+        displayName: Verify Host
+        path: connectors[0].verifyHost
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Tells a client connecting to this connector that 2-way SSL is
+          requested but not required. Overridden by needClientAuth.
+        displayName: Want Client Auth
+        path: connectors[0].wantClientAuth
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Specifies the console configuration
+        displayName: Console Configurations
+        path: console
+      - description: Whether or not to expose this port
+        displayName: Expose
+        path: console.expose
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Whether or not to enable SSL on this port
+        displayName: SSL Enabled
+        path: console.sslEnabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Name of the secret to use for ssl information
+        displayName: SSL Secret
+        path: console.sslSecret
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: If the embedded server requires client authentication
+        displayName: Use Client Auth
+        path: console.useClientAuth
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Specifies the deployment plan
+        displayName: Deployment Plan
+        path: deploymentPlan
+      - description: The image used for the broker, all upgrades are disabled. Needs
+          a corresponding initImage
+        displayName: Image
+        path: deploymentPlan.image
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The init container image used to configure broker, all upgrades
+          are disabled. Needs a corresponding image
+        displayName: Init Image
+        path: deploymentPlan.initImage
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: If true enable the Jolokia JVM Agent
+        displayName: Jolokia Agent Enabled
+        path: deploymentPlan.jolokiaAgentEnabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: If aio use ASYNCIO, if nio use NIO for journal IO
+        displayName: Journal Type
+        path: deploymentPlan.journalType
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: If true enable the management role based access control
+        displayName: Management RBAC Enabled
+        path: deploymentPlan.managementRBACEnabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: If true migrate messages on scaledown
+        displayName: Message Migration
+        path: deploymentPlan.messageMigration
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: If true use persistent volume via persistent volume claim for
+          journal storage
+        displayName: Persistence Enabled
+        path: deploymentPlan.persistenceEnabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: If true require user password login credentials for broker protocol
+          ports
+        displayName: Require Login
+        path: deploymentPlan.requireLogin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Specifies the minimum/maximum amount of compute resources required/allowed
+        displayName: Resource Requirements
+        path: deploymentPlan.resources
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+      - description: The number of broker pods to deploy
+        displayName: Size
+        path: deploymentPlan.size
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podCount
+      - description: Specifies the storage configurations
+        displayName: Storage Configurations
+        path: deploymentPlan.storage
+      - description: The storage size
+        displayName: Size
+        path: deploymentPlan.storage.size
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Specifies the upgrades (deprecated in favour of Version)
+        displayName: Upgrades
+        path: upgrades
+      - description: Set true to enable automatic micro version product upgrades,
+          it is disabled by default.
+        displayName: Enable Upgrades
+        path: upgrades.enabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:ui:booleanSwitch
+      - description: Set true to enable automatic minor product version upgrades,
+          it is disabled by default. Requires spec.upgrades.enabled to be true.
+        displayName: Include minor version upgrades
+        path: upgrades.minor
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:upgrades.enabled:true
+        - urn:alm:descriptor:com.tectonic.ui:ui:booleanSwitch
+      - description: The desired version of the broker. Can be x, or x.y or x.y.z
+          to configure upgrades
+        displayName: Version
+        path: version
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
       statusDescriptors:
       - description: Current state of the resource Conditions represent the latest
           available observations of an object's state
@@ -1352,15 +2939,658 @@ spec:
         path: conditions
         x-descriptors:
         - urn:alm:descriptor:io.kubernetes.conditions
+      - description: The current pods
+        displayName: Pods Status
+        path: podStatus
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podStatuses
       version: v2alpha4
-    - description: ActiveMQArtemis is the Schema for the activemqartemises API
-      displayName: Active MQArtemis
+    - description: A stateful deployment of one or more brokers
+      displayName: ActiveMQ Artemis
       kind: ActiveMQArtemis
       name: activemqartemises.broker.amq.io
       resources:
       - kind: Secret
         name: ""
         version: v1
+      specDescriptors:
+      - description: Specifies the acceptor configuration
+        displayName: Acceptors
+        path: acceptors
+      - description: AMQP Minimum Large Message Size
+        displayName: AMQP Min Large Message Size
+        path: acceptors[0].amqpMinLargeMessageSize
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: To indicate which kind of routing type to use.
+        displayName: Anycast Prefix
+        path: acceptors[0].anycastPrefix
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Max number of connections allowed to make
+        displayName: Connections Allowed
+        path: acceptors[0].connectionsAllowed
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: Comma separated list of cipher suites used for SSL communication.
+        displayName: Enabled Cipher Suites
+        path: acceptors[0].enabledCipherSuites
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Comma separated list of protocols used for SSL communication.
+        displayName: Enabled Protocols
+        path: acceptors[0].enabledProtocols
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Whether or not to expose this acceptor
+        displayName: Expose
+        path: acceptors[0].expose
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: To indicate which kind of routing type to use
+        displayName: Multicast Prefix
+        path: acceptors[0].multicastPrefix
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The acceptor name
+        displayName: Name
+        path: acceptors[0].name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Tells a client connecting to this acceptor that 2-way SSL is
+          required. This property takes precedence over wantClientAuth.
+        displayName: Need Client Auth
+        path: acceptors[0].needClientAuth
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Port number
+        displayName: Port
+        path: acceptors[0].port
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: The protocols to enable for this acceptor
+        displayName: Protocols
+        path: acceptors[0].protocols
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: A regular expression used to match the server_name extension
+          on incoming SSL connections. If the name doesn't match then the connection
+          to the acceptor will be rejected.
+        displayName: SNI Host
+        path: acceptors[0].sniHost
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Whether or not to enable SSL on this port
+        displayName: SSL Enabled
+        path: acceptors[0].sslEnabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Used to change the SSL Provider between JDK and OPENSSL. The
+          default is JDK.
+        displayName: SSL Provider
+        path: acceptors[0].sslProvider
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Name of the secret to use for ssl information
+        displayName: SSL Secret
+        path: acceptors[0].sslSecret
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The CN of the connecting client's SSL certificate will be compared
+          to its hostname to verify they match. This is useful only for 2-way SSL.
+        displayName: Verify Host
+        path: acceptors[0].verifyHost
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Tells a client connecting to this acceptor that 2-way SSL is
+          requested but not required. Overridden by needClientAuth.
+        displayName: Want Client Auth
+        path: acceptors[0].wantClientAuth
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Specifies the address configurations (deprecated in favour of
+          BrokerProperties)
+        displayName: Address Configurations
+        path: addressSettings
+      - description: Specifies the address settings
+        displayName: Address Settings
+        path: addressSettings.addressSetting
+      - description: what happens when an address where maxSizeBytes is specified
+          becomes full
+        displayName: Address Full Policy
+        path: addressSettings.addressSetting[0].addressFullPolicy
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: whether or not to automatically create addresses when a client
+          sends a message to or attempts to consume a message from a queue mapped
+          to an address that doesnt exist
+        displayName: Auto Create Addresses
+        path: addressSettings.addressSetting[0].autoCreateAddresses
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: whether or not to automatically create the dead-letter-address
+          and/or a corresponding queue on that address when a message found to be
+          undeliverable
+        displayName: AutoCreateDeadLetterResources
+        path: addressSettings.addressSetting[0].autoCreateDeadLetterResources
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: whether or not to automatically create the expiry-address and/or
+          a corresponding queue on that address when a message is sent to a matching
+          queue
+        displayName: Auto Create Expiry Resources
+        path: addressSettings.addressSetting[0].autoCreateExpiryResources
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: DEPRECATED. whether or not to automatically create JMS queues
+          when a producer sends or a consumer connects to a queue
+        displayName: Auto Create Jms Queues
+        path: addressSettings.addressSetting[0].autoCreateJmsQueues
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: DEPRECATED. whether or not to automatically create JMS topics
+          when a producer sends or a consumer subscribes to a topic
+        displayName: Auto Create Jms Topics
+        path: addressSettings.addressSetting[0].autoCreateJmsTopics
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: whether or not to automatically create a queue when a client
+          sends a message to or attempts to consume a message from a queue
+        displayName: Auto Create Queues
+        path: addressSettings.addressSetting[0].autoCreateQueues
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: whether or not to delete auto-created addresses when it no longer
+          has any queues
+        displayName: Auto Delete Addresses
+        path: addressSettings.addressSetting[0].autoDeleteAddresses
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: how long to wait (in milliseconds) before deleting auto-created
+          addresses after they no longer have any queues
+        displayName: Auto Delete Addresses Delay
+        path: addressSettings.addressSetting[0].autoDeleteAddressesDelay
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: whether or not to delete created queues when the queue has 0
+          consumers and 0 messages
+        displayName: Auto Delete Created Queues
+        path: addressSettings.addressSetting[0].autoDeleteCreatedQueues
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: DEPRECATED. whether or not to delete auto-created JMS queues
+          when the queue has 0 consumers and 0 messages
+        displayName: Auto Delete Jms Queues
+        path: addressSettings.addressSetting[0].autoDeleteJmsQueues
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: DEPRECATED. whether or not to delete auto-created JMS topics
+          when the last subscription is closed
+        displayName: Auto Delete Jms Topics
+        path: addressSettings.addressSetting[0].autoDeleteJmsTopics
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: whether or not to delete auto-created queues when the queue has
+          0 consumers and 0 messages
+        displayName: Auto Delete Queues
+        path: addressSettings.addressSetting[0].autoDeleteQueues
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: how long to wait (in milliseconds) before deleting auto-created
+          queues after the queue has 0 consumers.
+        displayName: Auto Delete Queues Delay
+        path: addressSettings.addressSetting[0].autoDeleteQueuesDelay
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: the message count the queue must be at or below before it can
+          be evaluated to be auto deleted, 0 waits until empty queue (default) and
+          -1 disables this check.
+        displayName: Auto Delete Queues Message Count
+        path: addressSettings.addressSetting[0].autoDeleteQueuesMessageCount
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: What to do when an address is no longer in broker.xml.  OFF =
+          will do nothing addresses will remain, FORCE = delete address and its queues
+          even if messages remaining.
+        displayName: Config Delete Addresses
+        path: addressSettings.addressSetting[0].configDeleteAddresses
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: What to do when a queue is no longer in broker.xml.  OFF = will
+          do nothing queues will remain, FORCE = delete queues even if messages remaining.
+        displayName: Config Delete Queues
+        path: addressSettings.addressSetting[0].configDeleteQueues
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: the address to send dead messages to
+        displayName: Dead Letter Address
+        path: addressSettings.addressSetting[0].deadLetterAddress
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: the prefix to use for auto-created dead letter queues
+        displayName: Dead Letter Queue Prefix
+        path: addressSettings.addressSetting[0].deadLetterQueuePrefix
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: the suffix to use for auto-created dead letter queues
+        displayName: Dead Letter Queue Suffix
+        path: addressSettings.addressSetting[0].deadLetterQueueSuffix
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: the routing-type used on auto-created addresses
+        displayName: Default Address Routing Type
+        path: addressSettings.addressSetting[0].defaultAddressRoutingType
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: the default window size for a consumer
+        displayName: Default Consumer Window Size
+        path: addressSettings.addressSetting[0].defaultConsumerWindowSize
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: the default number of consumers needed before dispatch can start
+          for queues under the address.
+        displayName: Default Consumers Before Dispatch
+        path: addressSettings.addressSetting[0].defaultConsumersBeforeDispatch
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: the default delay (in milliseconds) to wait before dispatching
+          if number of consumers before dispatch is not met for queues under the address.
+        displayName: Default Delay Before Dispatch
+        path: addressSettings.addressSetting[0].defaultDelayBeforeDispatch
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: whether to treat the queues under the address as exclusive queues
+          by default
+        displayName: Default Exclusive Queue
+        path: addressSettings.addressSetting[0].defaultExclusiveQueue
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: number of buckets to use for grouping, -1 (default) is unlimited
+          and uses the raw group, 0 disables message groups.
+        displayName: Default Group Buckets
+        path: addressSettings.addressSetting[0].defaultGroupBuckets
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: key used to mark a message is first in a group for a consumer
+        displayName: Default Group First Key
+        path: addressSettings.addressSetting[0].defaultGroupFirstKey
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: whether to rebalance groups when a consumer is added
+        displayName: Default Group Rebalance
+        path: addressSettings.addressSetting[0].defaultGroupRebalance
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: whether to pause dispatch when rebalancing groups
+        displayName: Default Group Rebalance Pause Dispatch
+        path: addressSettings.addressSetting[0].defaultGroupRebalancePauseDispatch
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: the property to use as the key for a last value queue by default
+        displayName: Default Last Value Key
+        path: addressSettings.addressSetting[0].defaultLastValueKey
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: whether to treat the queues under the address as a last value
+          queues by default
+        displayName: Default Last Value Queue
+        path: addressSettings.addressSetting[0].defaultLastValueQueue
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: the maximum number of consumers allowed on this queue at any
+          one time
+        displayName: Default Max Consumers
+        path: addressSettings.addressSetting[0].defaultMaxConsumers
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: whether the queue should be non-destructive by default
+        displayName: Default Non Destructive
+        path: addressSettings.addressSetting[0].defaultNonDestructive
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: purge the contents of the queue once there are no consumers
+        displayName: Default Purge On No Consumers
+        path: addressSettings.addressSetting[0].defaultPurgeOnNoConsumers
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: the routing-type used on auto-created queues
+        displayName: Default Queue Routing Type
+        path: addressSettings.addressSetting[0].defaultQueueRoutingType
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: the default ring-size value for any matching queue which doesnt
+          have ring-size explicitly defined
+        displayName: Default Ring Size
+        path: addressSettings.addressSetting[0].defaultRingSize
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: whether or not to enable metrics for metrics plugins on the matching
+          address
+        displayName: Enable Metrics
+        path: addressSettings.addressSetting[0].enableMetrics
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: the address to send expired messages to
+        displayName: Expiry Address
+        path: addressSettings.addressSetting[0].expiryAddress
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Overrides the expiration time for messages using the default
+          value for expiration time. "-1" disables this setting.
+        displayName: Expiry Delay
+        path: addressSettings.addressSetting[0].expiryDelay
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: the prefix to use for auto-created expiry queues
+        displayName: Expiry Queue Prefix
+        path: addressSettings.addressSetting[0].expiryQueuePrefix
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: the suffix to use for auto-created expiry queues
+        displayName: Expiry Queue Suffix
+        path: addressSettings.addressSetting[0].expiryQueueSuffix
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: This is deprecated please use default-last-value-queue instead.
+        displayName: Last Value Queue
+        path: addressSettings.addressSetting[0].lastValueQueue
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: how many message a management resource can browse
+        displayName: Management Browse Page Size
+        path: addressSettings.addressSetting[0].managementBrowsePageSize
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: pattern for matching settings against addresses; can use wildards
+        displayName: Match
+        path: addressSettings.addressSetting[0].match
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: how many times to attempt to deliver a message before sending
+          to dead letter address
+        displayName: Max Delivery Attempts
+        path: addressSettings.addressSetting[0].maxDeliveryAttempts
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: Overrides the expiration time for messages using a higher value.
+          "-1" disables this setting.
+        displayName: Max Expiry Delay
+        path: addressSettings.addressSetting[0].maxExpiryDelay
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: Maximum value for the redelivery-delay
+        displayName: Max Redelivery Delay
+        path: addressSettings.addressSetting[0].maxRedeliveryDelay
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: the maximum size in bytes for an address. -1 means no limits.
+          This is used in PAGING, BLOCK and FAIL policies. Supports byte notation
+          like K, Mb, GB, etc.
+        displayName: Max Size Bytes
+        path: addressSettings.addressSetting[0].maxSizeBytes
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: used with the address full BLOCK policy, the maximum size in
+          bytes an address can reach before messages start getting rejected. Works
+          in combination with max-size-bytes for AMQP protocol only.  Default = -1
+          (no limit).
+        displayName: Max Size Bytes Reject Threshold
+        path: addressSettings.addressSetting[0].maxSizeBytesRejectThreshold
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: how many days to keep message counter history for this address
+        displayName: Message Counter History Day Limit
+        path: addressSettings.addressSetting[0].messageCounterHistoryDayLimit
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: Overrides the expiration time for messages using a lower value.
+          "-1" disables this setting.
+        displayName: Min Expiry Delay
+        path: addressSettings.addressSetting[0].minExpiryDelay
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: Number of paging files to cache in memory to avoid IO during
+          paging navigation
+        displayName: Page Max Cache Size
+        path: addressSettings.addressSetting[0].pageMaxCacheSize
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: The page size in bytes to use for an address. Supports byte notation
+          like K, Mb, GB, etc.
+        displayName: Page Size Bytes
+        path: addressSettings.addressSetting[0].pageSizeBytes
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: the time (in ms) to wait before redelivering a cancelled message.
+        displayName: Redelivery Delay
+        path: addressSettings.addressSetting[0].redeliveryDelay
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: how long (in ms) to wait after the last consumer is closed on
+          a queue before redistributing messages.
+        displayName: Redistribution Delay
+        path: addressSettings.addressSetting[0].redistributionDelay
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: the number of messages to preserve for future queues created
+          on the matching address
+        displayName: Retroactive Message Count
+        path: addressSettings.addressSetting[0].retroactiveMessageCount
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: if there are no queues matching this address, whether to forward
+          message to DLA (if it exists for this address)
+        displayName: Send To DLA On No Route
+        path: addressSettings.addressSetting[0].sendToDlaOnNoRoute
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: How often to check for slow consumers on a particular queue.
+          Measured in seconds.
+        displayName: Slow Consumer Check Period
+        path: addressSettings.addressSetting[0].slowConsumerCheckPeriod
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: what happens when a slow consumer is identified
+        displayName: Slow Consumer Policy
+        path: addressSettings.addressSetting[0].slowConsumerPolicy
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The minimum rate of message consumption allowed before a consumer
+          is considered "slow." Measured in messages-per-second.
+        displayName: Slow Consumer Threshold
+        path: addressSettings.addressSetting[0].slowConsumerThreshold
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: How to merge the address settings to broker configuration
+        displayName: Apply Rule
+        path: addressSettings.applyRule
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Password for standard broker user. It is required for connecting
+          to the broker and the web console. If left empty, it will be generated.
+        displayName: Admin Password
+        path: adminPassword
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:password
+      - description: User name for standard broker user. It is required for connecting
+          to the broker and the web console. If left empty, it will be generated.
+        displayName: Admin User
+        path: adminUser
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Specifies connectors and connector configuration
+        displayName: Connectors
+        path: connectors
+      - description: Comma separated list of cipher suites used for SSL communication.
+        displayName: Enabled Cipher Suites
+        path: connectors[0].enabledCipherSuites
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Comma separated list of protocols used for SSL communication.
+        displayName: Enabled Protocols
+        path: connectors[0].enabledProtocols
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Whether or not to expose this connector
+        displayName: Expose
+        path: connectors[0].expose
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Hostname or IP to connect to
+        displayName: Host
+        path: connectors[0].host
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The name of the connector
+        displayName: Name
+        path: connectors[0].name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Tells a client connecting to this connector that 2-way SSL is
+          required. This property takes precedence over wantClientAuth.
+        displayName: Need Client Auth
+        path: connectors[0].needClientAuth
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Port number
+        displayName: Port
+        path: connectors[0].port
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: A regular expression used to match the server_name extension
+          on incoming SSL connections. If the name doesn't match then the connection
+          to the acceptor will be rejected.
+        displayName: SNI Host
+        path: connectors[0].sniHost
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Whether or not to enable SSL on this port
+        displayName: SSL Enabled
+        path: connectors[0].sslEnabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Used to change the SSL Provider between JDK and OPENSSL. The
+          default is JDK.
+        displayName: SSL Provider
+        path: connectors[0].sslProvider
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Name of the secret to use for ssl information
+        displayName: SSL Secret
+        path: connectors[0].sslSecret
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The type either tcp or vm
+        displayName: Type
+        path: connectors[0].type
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The CN of the connecting client's SSL certificate will be compared
+          to its hostname to verify they match. This is useful only for 2-way SSL.
+        displayName: Verify Host
+        path: connectors[0].verifyHost
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Tells a client connecting to this connector that 2-way SSL is
+          requested but not required. Overridden by needClientAuth.
+        displayName: Want Client Auth
+        path: connectors[0].wantClientAuth
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Specifies the console configuration
+        displayName: Console Configurations
+        path: console
+      - description: Whether or not to expose this port
+        displayName: Expose
+        path: console.expose
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Whether or not to enable SSL on this port
+        displayName: SSL Enabled
+        path: console.sslEnabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Name of the secret to use for ssl information
+        displayName: SSL Secret
+        path: console.sslSecret
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: If the embedded server requires client authentication
+        displayName: Use Client Auth
+        path: console.useClientAuth
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Specifies the deployment plan
+        displayName: Deployment Plan
+        path: deploymentPlan
+      - description: The image used for the broker, all upgrades are disabled. Needs
+          a corresponding initImage
+        displayName: Image
+        path: deploymentPlan.image
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: If aio use ASYNCIO, if nio use NIO for journal IO
+        displayName: Journal Type
+        path: deploymentPlan.journalType
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: If true migrate messages on scaledown
+        displayName: Message Migration
+        path: deploymentPlan.messageMigration
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: If true use persistent volume via persistent volume claim for
+          journal storage
+        displayName: Persistence Enabled
+        path: deploymentPlan.persistenceEnabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: If true require user password login credentials for broker protocol
+          ports
+        displayName: Require Login
+        path: deploymentPlan.requireLogin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Specifies the minimum/maximum amount of compute resources required/allowed
+        displayName: Resource Requirements
+        path: deploymentPlan.resources
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+      - description: The number of broker pods to deploy
+        displayName: Size
+        path: deploymentPlan.size
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podCount
+      - description: Specifies the storage configurations
+        displayName: Storage Configurations
+        path: deploymentPlan.storage
+      - description: The storage size
+        displayName: Size
+        path: deploymentPlan.storage.size
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Specifies the upgrades (deprecated in favour of Version)
+        displayName: Upgrades
+        path: upgrades
+      - description: Set true to enable automatic micro version product upgrades,
+          it is disabled by default.
+        displayName: Enable Upgrades
+        path: upgrades.enabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:ui:booleanSwitch
+      - description: Set true to enable automatic minor product version upgrades,
+          it is disabled by default. Requires spec.upgrades.enabled to be true.
+        displayName: Include minor version upgrades
+        path: upgrades.minor
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:upgrades.enabled:true
+        - urn:alm:descriptor:com.tectonic.ui:ui:booleanSwitch
+      - description: The desired version of the broker. Can be x, or x.y or x.y.z
+          to configure upgrades
+        displayName: Version
+        path: version
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
       statusDescriptors:
       - description: Current state of the resource Conditions represent the latest
           available observations of an object's state
@@ -1368,15 +3598,282 @@ spec:
         path: conditions
         x-descriptors:
         - urn:alm:descriptor:io.kubernetes.conditions
+      - description: The current pods
+        displayName: Pods Status
+        path: podStatus
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podStatuses
       version: v2alpha3
-    - description: ActiveMQArtemis is the Schema for the activemqartemises API
-      displayName: Active MQArtemis
+    - description: A stateful deployment of one or more brokers
+      displayName: ActiveMQ Artemis
       kind: ActiveMQArtemis
       name: activemqartemises.broker.amq.io
       resources:
       - kind: Secret
         name: ""
         version: v1
+      specDescriptors:
+      - description: Specifies the acceptor configuration
+        displayName: Acceptors
+        path: acceptors
+      - description: To indicate which kind of routing type to use.
+        displayName: Anycast Prefix
+        path: acceptors[0].anycastPrefix
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Max number of connections allowed to make
+        displayName: Connections Allowed
+        path: acceptors[0].connectionsAllowed
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: Comma separated list of cipher suites used for SSL communication.
+        displayName: Enabled Cipher Suites
+        path: acceptors[0].enabledCipherSuites
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Comma separated list of protocols used for SSL communication.
+        displayName: Enabled Protocols
+        path: acceptors[0].enabledProtocols
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Whether or not to expose this acceptor
+        displayName: Expose
+        path: acceptors[0].expose
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: To indicate which kind of routing type to use
+        displayName: Multicast Prefix
+        path: acceptors[0].multicastPrefix
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The acceptor name
+        displayName: Name
+        path: acceptors[0].name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Tells a client connecting to this acceptor that 2-way SSL is
+          required. This property takes precedence over wantClientAuth.
+        displayName: Need Client Auth
+        path: acceptors[0].needClientAuth
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Port number
+        displayName: Port
+        path: acceptors[0].port
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: The protocols to enable for this acceptor
+        displayName: Protocols
+        path: acceptors[0].protocols
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: A regular expression used to match the server_name extension
+          on incoming SSL connections. If the name doesn't match then the connection
+          to the acceptor will be rejected.
+        displayName: SNI Host
+        path: acceptors[0].sniHost
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Whether or not to enable SSL on this port
+        displayName: SSL Enabled
+        path: acceptors[0].sslEnabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Used to change the SSL Provider between JDK and OPENSSL. The
+          default is JDK.
+        displayName: SSL Provider
+        path: acceptors[0].sslProvider
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Name of the secret to use for ssl information
+        displayName: SSL Secret
+        path: acceptors[0].sslSecret
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The CN of the connecting client's SSL certificate will be compared
+          to its hostname to verify they match. This is useful only for 2-way SSL.
+        displayName: Verify Host
+        path: acceptors[0].verifyHost
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Tells a client connecting to this acceptor that 2-way SSL is
+          requested but not required. Overridden by needClientAuth.
+        displayName: Want Client Auth
+        path: acceptors[0].wantClientAuth
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Password for standard broker user. It is required for connecting
+          to the broker and the web console. If left empty, it will be generated.
+        displayName: Admin Password
+        path: adminPassword
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:password
+      - description: User name for standard broker user. It is required for connecting
+          to the broker and the web console. If left empty, it will be generated.
+        displayName: Admin User
+        path: adminUser
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Specifies connectors and connector configuration
+        displayName: Connectors
+        path: connectors
+      - description: Comma separated list of cipher suites used for SSL communication.
+        displayName: Enabled Cipher Suites
+        path: connectors[0].enabledCipherSuites
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Comma separated list of protocols used for SSL communication.
+        displayName: Enabled Protocols
+        path: connectors[0].enabledProtocols
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Whether or not to expose this connector
+        displayName: Expose
+        path: connectors[0].expose
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Hostname or IP to connect to
+        displayName: Host
+        path: connectors[0].host
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The name of the connector
+        displayName: Name
+        path: connectors[0].name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Tells a client connecting to this connector that 2-way SSL is
+          required. This property takes precedence over wantClientAuth.
+        displayName: Need Client Auth
+        path: connectors[0].needClientAuth
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Port number
+        displayName: Port
+        path: connectors[0].port
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: A regular expression used to match the server_name extension
+          on incoming SSL connections. If the name doesn't match then the connection
+          to the acceptor will be rejected.
+        displayName: SNI Host
+        path: connectors[0].sniHost
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Whether or not to enable SSL on this port
+        displayName: SSL Enabled
+        path: connectors[0].sslEnabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Used to change the SSL Provider between JDK and OPENSSL. The
+          default is JDK.
+        displayName: SSL Provider
+        path: connectors[0].sslProvider
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Name of the secret to use for ssl information
+        displayName: SSL Secret
+        path: connectors[0].sslSecret
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The type either tcp or vm
+        displayName: Type
+        path: connectors[0].type
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The CN of the connecting client's SSL certificate will be compared
+          to its hostname to verify they match. This is useful only for 2-way SSL.
+        displayName: Verify Host
+        path: connectors[0].verifyHost
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Tells a client connecting to this connector that 2-way SSL is
+          requested but not required. Overridden by needClientAuth.
+        displayName: Want Client Auth
+        path: connectors[0].wantClientAuth
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Specifies the console configuration
+        displayName: Console Configurations
+        path: console
+      - description: Whether or not to expose this port
+        displayName: Expose
+        path: console.expose
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Whether or not to enable SSL on this port
+        displayName: SSL Enabled
+        path: console.sslEnabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Name of the secret to use for ssl information
+        displayName: SSL Secret
+        path: console.sslSecret
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: If the embedded server requires client authentication
+        displayName: Use Client Auth
+        path: console.useClientAuth
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Specifies the deployment plan
+        displayName: Deployment Plan
+        path: deploymentPlan
+      - description: The image used for the broker, all upgrades are disabled. Needs
+          a corresponding initImage
+        displayName: Image
+        path: deploymentPlan.image
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: If aio use ASYNCIO, if nio use NIO for journal IO
+        displayName: Journal Type
+        path: deploymentPlan.journalType
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: If true migrate messages on scaledown
+        displayName: Message Migration
+        path: deploymentPlan.messageMigration
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: If true use persistent volume via persistent volume claim for
+          journal storage
+        displayName: Persistence Enabled
+        path: deploymentPlan.persistenceEnabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: If true require user password login credentials for broker protocol
+          ports
+        displayName: Require Login
+        path: deploymentPlan.requireLogin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: The number of broker pods to deploy
+        displayName: Size
+        path: deploymentPlan.size
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podCount
+      - description: Specifies the upgrades (deprecated in favour of Version)
+        displayName: Upgrades
+        path: upgrades
+      - description: Set true to enable automatic micro version product upgrades,
+          it is disabled by default.
+        displayName: Enable Upgrades
+        path: upgrades.enabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:ui:booleanSwitch
+      - description: Set true to enable automatic minor product version upgrades,
+          it is disabled by default. Requires spec.upgrades.enabled to be true.
+        displayName: Include minor version upgrades
+        path: upgrades.minor
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:upgrades.enabled:true
+        - urn:alm:descriptor:com.tectonic.ui:ui:booleanSwitch
+      - description: The desired version of the broker. Can be x, or x.y or x.y.z
+          to configure upgrades
+        displayName: Version
+        path: version
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
       statusDescriptors:
       - description: Current state of the resource Conditions represent the latest
           available observations of an object's state
@@ -1385,14 +3882,254 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:io.kubernetes.conditions
       version: v2alpha2
-    - description: ActiveMQArtemis is the Schema for the activemqartemises API
-      displayName: Active MQArtemis
+    - description: A stateful deployment of one or more brokers
+      displayName: ActiveMQ Artemis
       kind: ActiveMQArtemis
       name: activemqartemises.broker.amq.io
       resources:
       - kind: Secret
         name: ""
         version: v1
+      specDescriptors:
+      - description: Specifies the acceptor configuration
+        displayName: Acceptors
+        path: acceptors
+      - description: To indicate which kind of routing type to use.
+        displayName: Anycast Prefix
+        path: acceptors[0].anycastPrefix
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Max number of connections allowed to make
+        displayName: Connections Allowed
+        path: acceptors[0].connectionsAllowed
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: Comma separated list of cipher suites used for SSL communication.
+        displayName: Enabled Cipher Suites
+        path: acceptors[0].enabledCipherSuites
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Comma separated list of protocols used for SSL communication.
+        displayName: Enabled Protocols
+        path: acceptors[0].enabledProtocols
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Whether or not to expose this acceptor
+        displayName: Expose
+        path: acceptors[0].expose
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: To indicate which kind of routing type to use
+        displayName: Multicast Prefix
+        path: acceptors[0].multicastPrefix
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The acceptor name
+        displayName: Name
+        path: acceptors[0].name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Tells a client connecting to this acceptor that 2-way SSL is
+          required. This property takes precedence over wantClientAuth.
+        displayName: Need Client Auth
+        path: acceptors[0].needClientAuth
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Port number
+        displayName: Port
+        path: acceptors[0].port
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: The protocols to enable for this acceptor
+        displayName: Protocols
+        path: acceptors[0].protocols
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: A regular expression used to match the server_name extension
+          on incoming SSL connections. If the name doesn't match then the connection
+          to the acceptor will be rejected.
+        displayName: SNI Host
+        path: acceptors[0].sniHost
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Whether or not to enable SSL on this port
+        displayName: SSL Enabled
+        path: acceptors[0].sslEnabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Used to change the SSL Provider between JDK and OPENSSL. The
+          default is JDK.
+        displayName: SSL Provider
+        path: acceptors[0].sslProvider
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Name of the secret to use for ssl information
+        displayName: SSL Secret
+        path: acceptors[0].sslSecret
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The CN of the connecting client's SSL certificate will be compared
+          to its hostname to verify they match. This is useful only for 2-way SSL.
+        displayName: Verify Host
+        path: acceptors[0].verifyHost
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Tells a client connecting to this acceptor that 2-way SSL is
+          requested but not required. Overridden by needClientAuth.
+        displayName: Want Client Auth
+        path: acceptors[0].wantClientAuth
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Password for standard broker user. It is required for connecting
+          to the broker and the web console. If left empty, it will be generated.
+        displayName: Admin Password
+        path: adminPassword
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:password
+      - description: User name for standard broker user. It is required for connecting
+          to the broker and the web console. If left empty, it will be generated.
+        displayName: Admin User
+        path: adminUser
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Specifies connectors and connector configuration
+        displayName: Connectors
+        path: connectors
+      - description: Comma separated list of cipher suites used for SSL communication.
+        displayName: Enabled Cipher Suites
+        path: connectors[0].enabledCipherSuites
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Comma separated list of protocols used for SSL communication.
+        displayName: Enabled Protocols
+        path: connectors[0].enabledProtocols
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Whether or not to expose this connector
+        displayName: Expose
+        path: connectors[0].expose
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Hostname or IP to connect to
+        displayName: Host
+        path: connectors[0].host
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The name of the connector
+        displayName: Name
+        path: connectors[0].name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Tells a client connecting to this connector that 2-way SSL is
+          required. This property takes precedence over wantClientAuth.
+        displayName: Need Client Auth
+        path: connectors[0].needClientAuth
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Port number
+        displayName: Port
+        path: connectors[0].port
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: A regular expression used to match the server_name extension
+          on incoming SSL connections. If the name doesn't match then the connection
+          to the acceptor will be rejected.
+        displayName: SNI Host
+        path: connectors[0].sniHost
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Whether or not to enable SSL on this port
+        displayName: SSL Enabled
+        path: connectors[0].sslEnabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Used to change the SSL Provider between JDK and OPENSSL. The
+          default is JDK.
+        displayName: SSL Provider
+        path: connectors[0].sslProvider
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Name of the secret to use for ssl information
+        displayName: SSL Secret
+        path: connectors[0].sslSecret
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The type either tcp or vm
+        displayName: Type
+        path: connectors[0].type
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The CN of the connecting client's SSL certificate will be compared
+          to its hostname to verify they match. This is useful only for 2-way SSL.
+        displayName: Verify Host
+        path: connectors[0].verifyHost
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Tells a client connecting to this connector that 2-way SSL is
+          requested but not required. Overridden by needClientAuth.
+        displayName: Want Client Auth
+        path: connectors[0].wantClientAuth
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Specifies the console configuration
+        displayName: Console Configurations
+        path: console
+      - description: Whether or not to expose this port
+        displayName: Expose
+        path: console.expose
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Whether or not to enable SSL on this port
+        displayName: SSL Enabled
+        path: console.sslEnabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Name of the secret to use for ssl information
+        displayName: SSL Secret
+        path: console.sslSecret
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: If the embedded server requires client authentication
+        displayName: Use Client Auth
+        path: console.useClientAuth
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Specifies the deployment plan
+        displayName: Deployment Plan
+        path: deploymentPlan
+      - description: The image used for the broker, all upgrades are disabled. Needs
+          a corresponding initImage
+        displayName: Image
+        path: deploymentPlan.image
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: If aio use ASYNCIO, if nio use NIO for journal IO
+        displayName: Journal Type
+        path: deploymentPlan.journalType
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: If true migrate messages on scaledown
+        displayName: Message Migration
+        path: deploymentPlan.messageMigration
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: If true use persistent volume via persistent volume claim for
+          journal storage
+        displayName: Persistence Enabled
+        path: deploymentPlan.persistenceEnabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: If true require user password login credentials for broker protocol
+          ports
+        displayName: Require Login
+        path: deploymentPlan.requireLogin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: The number of broker pods to deploy
+        displayName: Size
+        path: deploymentPlan.size
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podCount
       statusDescriptors:
       - description: Current state of the resource Conditions represent the latest
           available observations of an object's state

--- a/config/scorecard/patches/basic.config.yaml
+++ b/config/scorecard/patches/basic.config.yaml
@@ -4,7 +4,7 @@
     entrypoint:
     - scorecard-test
     - basic-check-spec
-    image: quay.io/operator-framework/scorecard-test:v1.34
+    image: quay.io/operator-framework/scorecard-test:v1.41
     labels:
       suite: basic
       test: basic-check-spec-test

--- a/config/scorecard/patches/olm.config.yaml
+++ b/config/scorecard/patches/olm.config.yaml
@@ -4,7 +4,7 @@
     entrypoint:
     - scorecard-test
     - olm-bundle-validation
-    image: quay.io/operator-framework/scorecard-test:v1.34
+    image: quay.io/operator-framework/scorecard-test:v1.41
     labels:
       suite: olm
       test: olm-bundle-validation-test
@@ -14,7 +14,7 @@
     entrypoint:
     - scorecard-test
     - olm-crds-have-validation
-    image: quay.io/operator-framework/scorecard-test:v1.34
+    image: quay.io/operator-framework/scorecard-test:v1.41
     labels:
       suite: olm
       test: olm-crds-have-validation-test
@@ -24,7 +24,7 @@
     entrypoint:
     - scorecard-test
     - olm-crds-have-resources
-    image: quay.io/operator-framework/scorecard-test:v1.34
+    image: quay.io/operator-framework/scorecard-test:v1.41
     labels:
       suite: olm
       test: olm-crds-have-resources-test
@@ -34,7 +34,7 @@
     entrypoint:
     - scorecard-test
     - olm-spec-descriptors
-    image: quay.io/operator-framework/scorecard-test:v1.34
+    image: quay.io/operator-framework/scorecard-test:v1.41
     labels:
       suite: olm
       test: olm-spec-descriptors-test
@@ -44,7 +44,7 @@
     entrypoint:
     - scorecard-test
     - olm-status-descriptors
-    image: quay.io/operator-framework/scorecard-test:v1.34
+    image: quay.io/operator-framework/scorecard-test:v1.41
     labels:
       suite: olm
       test: olm-status-descriptors-test

--- a/deploy/activemq-artemis-operator.yaml
+++ b/deploy/activemq-artemis-operator.yaml
@@ -235,7 +235,7 @@ spec:
     name: v2alpha1
     schema:
       openAPIV3Schema:
-        description: ActiveMQArtemisAddress is the Schema for the activemqartemisaddresses API
+        description: Adding and removing addresses using custom resource definitions
         properties:
           apiVersion:
             description: |-
@@ -258,10 +258,13 @@ spec:
             description: ActiveMQArtemisAddressSpec defines the desired state of ActiveMQArtemisAddress
             properties:
               addressName:
+                description: The Address Name
                 type: string
               queueName:
+                description: The Queue Name
                 type: string
               routingType:
+                description: The Routing Type
                 type: string
             type: object
           status:
@@ -336,7 +339,7 @@ spec:
     name: v2alpha2
     schema:
       openAPIV3Schema:
-        description: ActiveMQArtemisAddress is the Schema for the activemqartemisaddresses API
+        description: Adding and removing addresses using custom resource definitions
         properties:
           apiVersion:
             description: |-
@@ -359,12 +362,16 @@ spec:
             description: ActiveMQArtemisAddressSpec defines the desired state of ActiveMQArtemisAddress
             properties:
               addressName:
+                description: The Address Name
                 type: string
               queueName:
+                description: The Queue Name
                 type: string
               removeFromBrokerOnDelete:
+                description: Whether or not delete the queue from broker when CR is undeployed(default false)
                 type: boolean
               routingType:
+                description: The Routing Type
                 type: string
             type: object
           status:
@@ -439,7 +446,7 @@ spec:
     name: v2alpha3
     schema:
       openAPIV3Schema:
-        description: ActiveMQArtemisAddress is the Schema for the activemqartemisaddresses API
+        description: Adding and removing addresses using custom resource definitions
         properties:
           apiVersion:
             description: |-
@@ -462,83 +469,117 @@ spec:
             description: ActiveMQArtemisAddressSpec defines the desired state of ActiveMQArtemisAddress
             properties:
               addressName:
+                description: The Address Name
                 type: string
               applyToCrNames:
+                description: Apply to the broker crs in the current namespace. A value of * or empty string means applying to all broker crs. Default apply to all broker crs
                 items:
                   type: string
                 type: array
               password:
+                description: The password for the user
                 type: string
               queueConfiguration:
+                description: Specify the queue configuration
                 properties:
                   autoCreateAddress:
+                    description: Whether auto create address
                     type: boolean
                   autoDelete:
+                    description: Auto-delete the queue
                     type: boolean
                   autoDeleteDelay:
+                    description: Delay (Milliseconds) before auto-delete the queue
                     format: int64
                     type: integer
                   autoDeleteMessageCount:
+                    description: Message count of the queue to allow auto delete
                     format: int64
                     type: integer
                   configurationManaged:
+                    description: ' If the queue is configuration managed'
                     type: boolean
                   consumerPriority:
+                    description: Consumer Priority
                     format: int32
                     type: integer
                   consumersBeforeDispatch:
+                    description: Number of consumers required before dispatching messages
                     format: int32
                     type: integer
                   delayBeforeDispatch:
+                    description: Milliseconds to wait for `consumers-before-dispatch` to be met before dispatching messages anyway
                     format: int64
                     type: integer
                   durable:
+                    description: If the queue is durable or not
                     type: boolean
                   enabled:
+                    description: If the queue is enabled
                     type: boolean
                   exclusive:
+                    description: If the queue is exclusive
                     type: boolean
                   filterString:
+                    description: The filter string for the queue
                     type: string
                   groupBuckets:
+                    description: Number of messaging group buckets
                     format: int32
                     type: integer
                   groupFirstKey:
+                    description: Header set on the first group message
                     type: string
                   groupRebalance:
+                    description: If rebalance the message group
                     type: boolean
                   groupRebalancePauseDispatch:
+                    description: If pause message dispatch when rebalancing groups
                     type: boolean
                   ignoreIfExists:
+                    description: If ignore if the target queue already exists
                     type: boolean
                   lastValue:
+                    description: If it is a last value queue
                     type: boolean
                   lastValueKey:
+                    description: The property used for last value queue to identify last values
                     type: string
                   maxConsumers:
+                    description: Max number of consumers allowed on this queue
                     format: int32
                     type: integer
                   nonDestructive:
+                    description: If force non-destructive consumers on the queue
                     type: boolean
                   purgeOnNoConsumers:
+                    description: Whether to delete all messages when no consumers connected to the queue
                     type: boolean
                   ringSize:
+                    description: The size the queue should maintain according to ring semantics
                     format: int64
                     type: integer
                   routingType:
+                    description: The routing type of the queue
                     type: string
                   temporary:
+                    description: If the queue is temporary
                     type: boolean
                   user:
+                    description: The user associated with the queue
                     type: string
                 type: object
               queueName:
+                description: The Queue Name
                 type: string
               removeFromBrokerOnDelete:
+                description: Whether or not delete the queue from broker when CR is undeployed(default false)
                 type: boolean
               routingType:
+                description: The Routing Type
                 type: string
               user:
+                description: User name for creating the queue or address
                 type: string
             type: object
           status:
@@ -5299,7 +5340,7 @@ spec:
   - name: v2alpha1
     schema:
       openAPIV3Schema:
-        description: ActiveMQArtemis is the Schema for the activemqartemises API
+        description: A stateful deployment of one or more brokers
         properties:
           apiVersion:
             description: |-
@@ -5322,80 +5363,114 @@ spec:
             description: ActiveMQArtemisSpec defines the desired state of ActiveMQArtemis
             properties:
               acceptors:
+                description: Specifies the acceptor configuration
                 items:
                   properties:
                     anycastPrefix:
+                      description: To indicate which kind of routing type to use.
                       type: string
                     connectionsAllowed:
+                      description: Max number of connections allowed to make
                       type: integer
                     enabledCipherSuites:
+                      description: Comma separated list of cipher suites used for SSL communication.
                       type: string
                     enabledProtocols:
+                      description: Comma separated list of protocols used for SSL communication.
                       type: string
                     expose:
+                      description: Whether or not to expose this acceptor
                       type: boolean
                     multicastPrefix:
+                      description: To indicate which kind of routing type to use
                       type: string
                     name:
+                      description: The acceptor name
                       type: string
                     needClientAuth:
+                      description: Tells a client connecting to this acceptor that 2-way SSL is required. This property takes precedence over wantClientAuth.
                       type: boolean
                     port:
+                      description: Port number
                       format: int32
                       type: integer
                     protocols:
+                      description: The protocols to enable for this acceptor
                       type: string
                     sniHost:
+                      description: A regular expression used to match the server_name extension on incoming SSL connections. If the name doesn't match then the connection to the acceptor will be rejected.
                       type: string
                     sslEnabled:
+                      description: Whether or not to enable SSL on this port
                       type: boolean
                     sslProvider:
+                      description: Used to change the SSL Provider between JDK and OPENSSL. The default is JDK.
                       type: string
                     sslSecret:
+                      description: Name of the secret to use for ssl information
                       type: string
                     verifyHost:
+                      description: The CN of the connecting client's SSL certificate will be compared to its hostname to verify they match. This is useful only for 2-way SSL.
                       type: boolean
                     wantClientAuth:
+                      description: Tells a client connecting to this acceptor that 2-way SSL is requested but not required. Overridden by needClientAuth.
                       type: boolean
                   required:
                   - name
                   type: object
                 type: array
               adminPassword:
+                description: Password for standard broker user. It is required for connecting to the broker and the web console. If left empty, it will be generated.
                 type: string
               adminUser:
+                description: User name for standard broker user. It is required for connecting to the broker and the web console. If left empty, it will be generated.
                 type: string
               connectors:
+                description: Specifies connectors and connector configuration
                 items:
                   properties:
                     enabledCipherSuites:
+                      description: Comma separated list of cipher suites used for SSL communication.
                       type: string
                     enabledProtocols:
+                      description: Comma separated list of protocols used for SSL communication.
                       type: string
                     expose:
+                      description: Whether or not to expose this connector
                       type: boolean
                     host:
+                      description: Hostname or IP to connect to
                       type: string
                     name:
+                      description: The name of the connector
                       type: string
                     needClientAuth:
+                      description: Tells a client connecting to this connector that 2-way SSL is required. This property takes precedence over wantClientAuth.
                       type: boolean
                     port:
+                      description: Port number
                       format: int32
                       type: integer
                     sniHost:
+                      description: A regular expression used to match the server_name extension on incoming SSL connections. If the name doesn't match then the connection to the acceptor will be rejected.
                       type: string
                     sslEnabled:
+                      description: ' Whether or not to enable SSL on this port'
                       type: boolean
                     sslProvider:
+                      description: Used to change the SSL Provider between JDK and OPENSSL. The default is JDK.
                       type: string
                     sslSecret:
+                      description: Name of the secret to use for ssl information
                       type: string
                     type:
+                      description: The type either tcp or vm
                       type: string
                     verifyHost:
+                      description: The CN of the connecting client's SSL certificate will be compared to its hostname to verify they match. This is useful only for 2-way SSL.
                       type: boolean
                     wantClientAuth:
+                      description: Tells a client connecting to this connector that 2-way SSL is requested but not required. Overridden by needClientAuth.
                       type: boolean
                   required:
                   - host
@@ -5404,29 +5479,41 @@ spec:
                   type: object
                 type: array
               console:
+                description: Specifies the console configuration
                 properties:
                   expose:
+                    description: Whether or not to expose this port
                     type: boolean
                   sslEnabled:
+                    description: Whether or not to enable SSL on this port
                     type: boolean
                   sslSecret:
+                    description: Name of the secret to use for ssl information
                     type: string
                   useClientAuth:
+                    description: If the embedded server requires client authentication
                     type: boolean
                 type: object
               deploymentPlan:
+                description: Specifies the deployment plan
                 properties:
                   image:
+                    description: The image used for the broker, all upgrades are disabled. Needs a corresponding initImage
                     type: string
                   journalType:
+                    description: If aio use ASYNCIO, if nio use NIO for journal IO
                     type: string
                   messageMigration:
+                    description: If true migrate messages on scaledown
                     type: boolean
                   persistenceEnabled:
+                    description: If true use persistent volume via persistent volume claim for journal storage
                     type: boolean
                   requireLogin:
+                    description: If true require user password login credentials for broker protocol ports
                     type: boolean
                   size:
+                    description: The number of broker pods to deploy
                     format: int32
                     type: integer
                 type: object
@@ -5521,7 +5608,7 @@ spec:
   - name: v2alpha2
     schema:
       openAPIV3Schema:
-        description: ActiveMQArtemis is the Schema for the activemqartemises API
+        description: A stateful deployment of one or more brokers
         properties:
           apiVersion:
             description: |-
@@ -5544,80 +5631,114 @@ spec:
             description: ActiveMQArtemisSpec defines the desired state of ActiveMQArtemis
             properties:
               acceptors:
+                description: Specifies the acceptor configuration
                 items:
                   properties:
                     anycastPrefix:
+                      description: To indicate which kind of routing type to use.
                       type: string
                     connectionsAllowed:
+                      description: Max number of connections allowed to make
                       type: integer
                     enabledCipherSuites:
+                      description: Comma separated list of cipher suites used for SSL communication.
                       type: string
                     enabledProtocols:
+                      description: Comma separated list of protocols used for SSL communication.
                       type: string
                     expose:
+                      description: Whether or not to expose this acceptor
                       type: boolean
                     multicastPrefix:
+                      description: To indicate which kind of routing type to use
                       type: string
                     name:
+                      description: The acceptor name
                       type: string
                     needClientAuth:
+                      description: Tells a client connecting to this acceptor that 2-way SSL is required. This property takes precedence over wantClientAuth.
                       type: boolean
                     port:
+                      description: Port number
                       format: int32
                       type: integer
                     protocols:
+                      description: The protocols to enable for this acceptor
                       type: string
                     sniHost:
+                      description: A regular expression used to match the server_name extension on incoming SSL connections. If the name doesn't match then the connection to the acceptor will be rejected.
                       type: string
                     sslEnabled:
+                      description: Whether or not to enable SSL on this port
                       type: boolean
                     sslProvider:
+                      description: Used to change the SSL Provider between JDK and OPENSSL. The default is JDK.
                       type: string
                     sslSecret:
+                      description: Name of the secret to use for ssl information
                       type: string
                     verifyHost:
+                      description: The CN of the connecting client's SSL certificate will be compared to its hostname to verify they match. This is useful only for 2-way SSL.
                       type: boolean
                     wantClientAuth:
+                      description: Tells a client connecting to this acceptor that 2-way SSL is requested but not required. Overridden by needClientAuth.
                       type: boolean
                   required:
                   - name
                   type: object
                 type: array
               adminPassword:
+                description: Password for standard broker user. It is required for connecting to the broker and the web console. If left empty, it will be generated.
                 type: string
               adminUser:
+                description: User name for standard broker user. It is required for connecting to the broker and the web console. If left empty, it will be generated.
                 type: string
               connectors:
+                description: Specifies connectors and connector configuration
                 items:
                   properties:
                     enabledCipherSuites:
+                      description: Comma separated list of cipher suites used for SSL communication.
                       type: string
                     enabledProtocols:
+                      description: Comma separated list of protocols used for SSL communication.
                       type: string
                     expose:
+                      description: Whether or not to expose this connector
                       type: boolean
                     host:
+                      description: Hostname or IP to connect to
                       type: string
                     name:
+                      description: The name of the connector
                       type: string
                     needClientAuth:
+                      description: Tells a client connecting to this connector that 2-way SSL is required. This property takes precedence over wantClientAuth.
                       type: boolean
                     port:
+                      description: Port number
                       format: int32
                       type: integer
                     sniHost:
+                      description: A regular expression used to match the server_name extension on incoming SSL connections. If the name doesn't match then the connection to the acceptor will be rejected.
                       type: string
                     sslEnabled:
+                      description: ' Whether or not to enable SSL on this port'
                       type: boolean
                     sslProvider:
+                      description: Used to change the SSL Provider between JDK and OPENSSL. The default is JDK.
                       type: string
                     sslSecret:
+                      description: Name of the secret to use for ssl information
                       type: string
                     type:
+                      description: The type either tcp or vm
                       type: string
                     verifyHost:
+                      description: The CN of the connecting client's SSL certificate will be compared to its hostname to verify they match. This is useful only for 2-way SSL.
                       type: boolean
                     wantClientAuth:
+                      description: Tells a client connecting to this connector that 2-way SSL is requested but not required. Overridden by needClientAuth.
                       type: boolean
                   required:
                   - host
@@ -5626,44 +5747,59 @@ spec:
                   type: object
                 type: array
               console:
+                description: Specifies the console configuration
                 properties:
                   expose:
+                    description: Whether or not to expose this port
                     type: boolean
                   sslEnabled:
+                    description: Whether or not to enable SSL on this port
                     type: boolean
                   sslSecret:
+                    description: Name of the secret to use for ssl information
                     type: string
                   useClientAuth:
+                    description: If the embedded server requires client authentication
                     type: boolean
                 type: object
               deploymentPlan:
+                description: Specifies the deployment plan
                 properties:
                   image:
+                    description: The image used for the broker, all upgrades are disabled. Needs a corresponding initImage
                     type: string
                   journalType:
+                    description: If aio use ASYNCIO, if nio use NIO for journal IO
                     type: string
                   messageMigration:
+                    description: If true migrate messages on scaledown
                     type: boolean
                   persistenceEnabled:
+                    description: If true use persistent volume via persistent volume claim for journal storage
                     type: boolean
                   requireLogin:
+                    description: If true require user password login credentials for broker protocol ports
                     type: boolean
                   size:
+                    description: The number of broker pods to deploy
                     format: int32
                     type: integer
                 type: object
               upgrades:
-                description: ActiveMQArtemis App product upgrade flags
+                description: Specifies the upgrades (deprecated in favour of Version)
                 properties:
                   enabled:
+                    description: Set true to enable automatic micro version product upgrades, it is disabled by default.
                     type: boolean
                   minor:
+                    description: Set true to enable automatic minor product version upgrades, it is disabled by default. Requires spec.upgrades.enabled to be true.
                     type: boolean
                 required:
                 - enabled
                 - minor
                 type: object
               version:
+                description: The desired version of the broker. Can be x, or x.y or x.y.z to configure upgrades
                 type: string
             type: object
           status:
@@ -5756,7 +5892,7 @@ spec:
   - name: v2alpha3
     schema:
       openAPIV3Schema:
-        description: ActiveMQArtemis is the Schema for the activemqartemises API
+        description: A stateful deployment of one or more brokers
         properties:
           apiVersion:
             description: |-
@@ -5779,240 +5915,338 @@ spec:
             description: ActiveMQArtemisSpec defines the desired state of ActiveMQArtemis
             properties:
               acceptors:
+                description: Specifies the acceptor configuration
                 items:
                   properties:
                     amqpMinLargeMessageSize:
+                      description: AMQP Minimum Large Message Size
                       type: integer
                     anycastPrefix:
+                      description: To indicate which kind of routing type to use.
                       type: string
                     connectionsAllowed:
+                      description: Max number of connections allowed to make
                       type: integer
                     enabledCipherSuites:
+                      description: Comma separated list of cipher suites used for SSL communication.
                       type: string
                     enabledProtocols:
+                      description: Comma separated list of protocols used for SSL communication.
                       type: string
                     expose:
+                      description: Whether or not to expose this acceptor
                       type: boolean
                     multicastPrefix:
+                      description: To indicate which kind of routing type to use
                       type: string
                     name:
+                      description: The acceptor name
                       type: string
                     needClientAuth:
+                      description: Tells a client connecting to this acceptor that 2-way SSL is required. This property takes precedence over wantClientAuth.
                       type: boolean
                     port:
+                      description: Port number
                       format: int32
                       type: integer
                     protocols:
+                      description: The protocols to enable for this acceptor
                       type: string
                     sniHost:
+                      description: A regular expression used to match the server_name extension on incoming SSL connections. If the name doesn't match then the connection to the acceptor will be rejected.
                       type: string
                     sslEnabled:
+                      description: Whether or not to enable SSL on this port
                       type: boolean
                     sslProvider:
+                      description: Used to change the SSL Provider between JDK and OPENSSL. The default is JDK.
                       type: string
                     sslSecret:
+                      description: Name of the secret to use for ssl information
                       type: string
                     verifyHost:
+                      description: The CN of the connecting client's SSL certificate will be compared to its hostname to verify they match. This is useful only for 2-way SSL.
                       type: boolean
                     wantClientAuth:
+                      description: Tells a client connecting to this acceptor that 2-way SSL is requested but not required. Overridden by needClientAuth.
                       type: boolean
                   required:
                   - name
                   type: object
                 type: array
               addressSettings:
+                description: Specifies the address configurations (deprecated in favour of BrokerProperties)
                 properties:
                   addressSetting:
+                    description: Specifies the address settings
                     items:
                       properties:
                         addressFullPolicy:
+                          description: what happens when an address where maxSizeBytes is specified becomes full
                           type: string
                         autoCreateAddresses:
+                          description: whether or not to automatically create addresses when a client sends a message to or attempts to consume a message from a queue mapped to an address that doesnt exist
                           type: boolean
                         autoCreateDeadLetterResources:
+                          description: whether or not to automatically create the dead-letter-address and/or a corresponding queue on that address when a message found to be undeliverable
                           type: boolean
                         autoCreateExpiryResources:
+                          description: whether or not to automatically create the expiry-address and/or a corresponding queue on that address when a message is sent to a matching queue
                           type: boolean
                         autoCreateJmsQueues:
+                          description: DEPRECATED. whether or not to automatically create JMS queues when a producer sends or a consumer connects to a queue
                           type: boolean
                         autoCreateJmsTopics:
+                          description: DEPRECATED. whether or not to automatically create JMS topics when a producer sends or a consumer subscribes to a topic
                           type: boolean
                         autoCreateQueues:
+                          description: whether or not to automatically create a queue when a client sends a message to or attempts to consume a message from a queue
                           type: boolean
                         autoDeleteAddresses:
+                          description: whether or not to delete auto-created addresses when it no longer has any queues
                           type: boolean
                         autoDeleteAddressesDelay:
+                          description: how long to wait (in milliseconds) before deleting auto-created addresses after they no longer have any queues
                           format: int32
                           type: integer
                         autoDeleteCreatedQueues:
+                          description: whether or not to delete created queues when the queue has 0 consumers and 0 messages
                           type: boolean
                         autoDeleteJmsQueues:
+                          description: DEPRECATED. whether or not to delete auto-created JMS queues when the queue has 0 consumers and 0 messages
                           type: boolean
                         autoDeleteJmsTopics:
+                          description: DEPRECATED. whether or not to delete auto-created JMS topics when the last subscription is closed
                           type: boolean
                         autoDeleteQueues:
+                          description: whether or not to delete auto-created queues when the queue has 0 consumers and 0 messages
                           type: boolean
                         autoDeleteQueuesDelay:
+                          description: how long to wait (in milliseconds) before deleting auto-created queues after the queue has 0 consumers.
                           format: int32
                           type: integer
                         autoDeleteQueuesMessageCount:
+                          description: the message count the queue must be at or below before it can be evaluated to be auto deleted, 0 waits until empty queue (default) and -1 disables this check.
                           format: int32
                           type: integer
                         configDeleteAddresses:
+                          description: What to do when an address is no longer in broker.xml.  OFF = will do nothing addresses will remain, FORCE = delete address and its queues even if messages remaining.
                           type: string
                         configDeleteQueues:
+                          description: What to do when a queue is no longer in broker.xml.  OFF = will do nothing queues will remain, FORCE = delete queues even if messages remaining.
                           type: string
                         deadLetterAddress:
+                          description: the address to send dead messages to
                           type: string
                         deadLetterQueuePrefix:
+                          description: the prefix to use for auto-created dead letter queues
                           type: string
                         deadLetterQueueSuffix:
+                          description: the suffix to use for auto-created dead letter queues
                           type: string
                         defaultAddressRoutingType:
+                          description: the routing-type used on auto-created addresses
                           type: string
                         defaultConsumerWindowSize:
+                          description: the default window size for a consumer
                           format: int32
                           type: integer
                         defaultConsumersBeforeDispatch:
+                          description: the default number of consumers needed before dispatch can start for queues under the address.
                           format: int32
                           type: integer
                         defaultDelayBeforeDispatch:
+                          description: the default delay (in milliseconds) to wait before dispatching if number of consumers before dispatch is not met for queues under the address.
                           format: int32
                           type: integer
                         defaultExclusiveQueue:
+                          description: whether to treat the queues under the address as exclusive queues by default
                           type: boolean
                         defaultGroupBuckets:
+                          description: number of buckets to use for grouping, -1 (default) is unlimited and uses the raw group, 0 disables message groups.
                           format: int32
                           type: integer
                         defaultGroupFirstKey:
+                          description: key used to mark a message is first in a group for a consumer
                           type: string
                         defaultGroupRebalance:
+                          description: whether to rebalance groups when a consumer is added
                           type: boolean
                         defaultGroupRebalancePauseDispatch:
+                          description: whether to pause dispatch when rebalancing groups
                           type: boolean
                         defaultLastValueKey:
+                          description: the property to use as the key for a last value queue by default
                           type: string
                         defaultLastValueQueue:
+                          description: whether to treat the queues under the address as a last value queues by default
                           type: boolean
                         defaultMaxConsumers:
+                          description: the maximum number of consumers allowed on this queue at any one time
                           format: int32
                           type: integer
                         defaultNonDestructive:
+                          description: whether the queue should be non-destructive by default
                           type: boolean
                         defaultPurgeOnNoConsumers:
+                          description: purge the contents of the queue once there are no consumers
                           type: boolean
                         defaultQueueRoutingType:
+                          description: the routing-type used on auto-created queues
                           type: string
                         defaultRingSize:
+                          description: the default ring-size value for any matching queue which doesnt have ring-size explicitly defined
                           format: int32
                           type: integer
                         enableMetrics:
+                          description: whether or not to enable metrics for metrics plugins on the matching address
                           type: boolean
                         expiryAddress:
+                          description: the address to send expired messages to
                           type: string
                         expiryDelay:
+                          description: Overrides the expiration time for messages using the default value for expiration time. "-1" disables this setting.
                           format: int32
                           type: integer
                         expiryQueuePrefix:
+                          description: the prefix to use for auto-created expiry queues
                           type: string
                         expiryQueueSuffix:
+                          description: the suffix to use for auto-created expiry queues
                           type: string
                         lastValueQueue:
+                          description: This is deprecated please use default-last-value-queue instead.
                           type: boolean
                         managementBrowsePageSize:
+                          description: how many message a management resource can browse
                           format: int32
                           type: integer
                         match:
+                          description: pattern for matching settings against addresses; can use wildards
                           type: string
                         maxDeliveryAttempts:
+                          description: how many times to attempt to deliver a message before sending to dead letter address
                           format: int32
                           type: integer
                         maxExpiryDelay:
+                          description: Overrides the expiration time for messages using a higher value. "-1" disables this setting.
                           format: int32
                           type: integer
                         maxRedeliveryDelay:
+                          description: Maximum value for the redelivery-delay
                           format: int32
                           type: integer
                         maxSizeBytes:
+                          description: the maximum size in bytes for an address. -1 means no limits. This is used in PAGING, BLOCK and FAIL policies. Supports byte notation like K, Mb, GB, etc.
                           type: string
                         maxSizeBytesRejectThreshold:
+                          description: used with the address full BLOCK policy, the maximum size in bytes an address can reach before messages start getting rejected. Works in combination with max-size-bytes for AMQP protocol only.  Default = -1 (no limit).
                           format: int32
                           type: integer
                         messageCounterHistoryDayLimit:
+                          description: how many days to keep message counter history for this address
                           format: int32
                           type: integer
                         minExpiryDelay:
+                          description: Overrides the expiration time for messages using a lower value. "-1" disables this setting.
                           format: int32
                           type: integer
                         pageMaxCacheSize:
+                          description: Number of paging files to cache in memory to avoid IO during paging navigation
                           format: int32
                           type: integer
                         pageSizeBytes:
+                          description: The page size in bytes to use for an address. Supports byte notation like K, Mb, GB, etc.
                           type: string
                         redeliveryCollisionAvoidanceFactor:
                           type: number
                         redeliveryDelay:
+                          description: the time (in ms) to wait before redelivering a cancelled message.
                           format: int32
                           type: integer
                         redeliveryDelayMultiplier:
                           format: int32
                           type: integer
                         redistributionDelay:
+                          description: how long (in ms) to wait after the last consumer is closed on a queue before redistributing messages.
                           format: int32
                           type: integer
                         retroactiveMessageCount:
+                          description: the number of messages to preserve for future queues created on the matching address
                           format: int32
                           type: integer
                         sendToDlaOnNoRoute:
+                          description: if there are no queues matching this address, whether to forward message to DLA (if it exists for this address)
                           type: boolean
                         slowConsumerCheckPeriod:
+                          description: How often to check for slow consumers on a particular queue. Measured in seconds.
                           format: int32
                           type: integer
                         slowConsumerPolicy:
+                          description: what happens when a slow consumer is identified
                           type: string
                         slowConsumerThreshold:
+                          description: The minimum rate of message consumption allowed before a consumer is considered "slow." Measured in messages-per-second.
                           format: int32
                           type: integer
                       type: object
                     type: array
                   applyRule:
+                    description: How to merge the address settings to broker configuration
                     type: string
                 type: object
               adminPassword:
+                description: Password for standard broker user. It is required for connecting to the broker and the web console. If left empty, it will be generated.
                 type: string
               adminUser:
+                description: User name for standard broker user. It is required for connecting to the broker and the web console. If left empty, it will be generated.
                 type: string
               connectors:
+                description: Specifies connectors and connector configuration
                 items:
                   properties:
                     enabledCipherSuites:
+                      description: Comma separated list of cipher suites used for SSL communication.
                       type: string
                     enabledProtocols:
+                      description: Comma separated list of protocols used for SSL communication.
                       type: string
                     expose:
+                      description: Whether or not to expose this connector
                       type: boolean
                     host:
+                      description: Hostname or IP to connect to
                       type: string
                     name:
+                      description: The name of the connector
                       type: string
                     needClientAuth:
+                      description: Tells a client connecting to this connector that 2-way SSL is required. This property takes precedence over wantClientAuth.
                       type: boolean
                     port:
+                      description: Port number
                       format: int32
                       type: integer
                     sniHost:
+                      description: A regular expression used to match the server_name extension on incoming SSL connections. If the name doesn't match then the connection to the acceptor will be rejected.
                       type: string
                     sslEnabled:
+                      description: ' Whether or not to enable SSL on this port'
                       type: boolean
                     sslProvider:
+                      description: Used to change the SSL Provider between JDK and OPENSSL. The default is JDK.
                       type: string
                     sslSecret:
+                      description: Name of the secret to use for ssl information
                       type: string
                     type:
+                      description: The type either tcp or vm
                       type: string
                     verifyHost:
+                      description: The CN of the connecting client's SSL certificate will be compared to its hostname to verify they match. This is useful only for 2-way SSL.
                       type: boolean
                     wantClientAuth:
+                      description: Tells a client connecting to this connector that 2-way SSL is requested but not required. Overridden by needClientAuth.
                       type: boolean
                   required:
                   - host
@@ -6021,30 +6255,41 @@ spec:
                   type: object
                 type: array
               console:
+                description: Specifies the console configuration
                 properties:
                   expose:
+                    description: Whether or not to expose this port
                     type: boolean
                   sslEnabled:
+                    description: Whether or not to enable SSL on this port
                     type: boolean
                   sslSecret:
+                    description: Name of the secret to use for ssl information
                     type: string
                   useClientAuth:
+                    description: If the embedded server requires client authentication
                     type: boolean
                 type: object
               deploymentPlan:
+                description: Specifies the deployment plan
                 properties:
                   image:
+                    description: The image used for the broker, all upgrades are disabled. Needs a corresponding initImage
                     type: string
                   journalType:
+                    description: If aio use ASYNCIO, if nio use NIO for journal IO
                     type: string
                   messageMigration:
+                    description: If true migrate messages on scaledown
                     type: boolean
                   persistenceEnabled:
+                    description: If true use persistent volume via persistent volume claim for journal storage
                     type: boolean
                   requireLogin:
+                    description: If true require user password login credentials for broker protocol ports
                     type: boolean
                   resources:
-                    description: ResourceRequirements describes the compute resource requirements.
+                    description: Specifies the minimum/maximum amount of compute resources required/allowed
                     properties:
                       claims:
                         description: |-
@@ -6097,26 +6342,32 @@ spec:
                         type: object
                     type: object
                   size:
+                    description: The number of broker pods to deploy
                     format: int32
                     type: integer
                   storage:
+                    description: Specifies the storage configurations
                     properties:
                       size:
+                        description: The storage size
                         type: string
                     type: object
                 type: object
               upgrades:
-                description: ActiveMQArtemis App product upgrade flags
+                description: Specifies the upgrades (deprecated in favour of Version)
                 properties:
                   enabled:
+                    description: Set true to enable automatic micro version product upgrades, it is disabled by default.
                     type: boolean
                   minor:
+                    description: Set true to enable automatic minor product version upgrades, it is disabled by default. Requires spec.upgrades.enabled to be true.
                     type: boolean
                 required:
                 - enabled
                 - minor
                 type: object
               version:
+                description: The desired version of the broker. Can be x, or x.y or x.y.z to configure upgrades
                 type: string
             type: object
           status:
@@ -6181,6 +6432,7 @@ spec:
                   type: object
                 type: array
               podStatus:
+                description: The current pods
                 properties:
                   ready:
                     description: Deployments are ready to serve requests
@@ -6209,7 +6461,7 @@ spec:
   - name: v2alpha4
     schema:
       openAPIV3Schema:
-        description: ActiveMQArtemis is the Schema for the activemqartemises API
+        description: A stateful deployment of one or more brokers
         properties:
           apiVersion:
             description: |-
@@ -6232,240 +6484,338 @@ spec:
             description: ActiveMQArtemisSpec defines the desired state of ActiveMQArtemis
             properties:
               acceptors:
+                description: Specifies the acceptor configuration
                 items:
                   properties:
                     amqpMinLargeMessageSize:
+                      description: AMQP Minimum Large Message Size
                       type: integer
                     anycastPrefix:
+                      description: To indicate which kind of routing type to use.
                       type: string
                     connectionsAllowed:
+                      description: Max number of connections allowed to make
                       type: integer
                     enabledCipherSuites:
+                      description: Comma separated list of cipher suites used for SSL communication.
                       type: string
                     enabledProtocols:
+                      description: Comma separated list of protocols used for SSL communication.
                       type: string
                     expose:
+                      description: Whether or not to expose this acceptor
                       type: boolean
                     multicastPrefix:
+                      description: To indicate which kind of routing type to use
                       type: string
                     name:
+                      description: The acceptor name
                       type: string
                     needClientAuth:
+                      description: Tells a client connecting to this acceptor that 2-way SSL is required. This property takes precedence over wantClientAuth.
                       type: boolean
                     port:
+                      description: Port number
                       format: int32
                       type: integer
                     protocols:
+                      description: The protocols to enable for this acceptor
                       type: string
                     sniHost:
+                      description: A regular expression used to match the server_name extension on incoming SSL connections. If the name doesn't match then the connection to the acceptor will be rejected.
                       type: string
                     sslEnabled:
+                      description: Whether or not to enable SSL on this port
                       type: boolean
                     sslProvider:
+                      description: Used to change the SSL Provider between JDK and OPENSSL. The default is JDK.
                       type: string
                     sslSecret:
+                      description: Name of the secret to use for ssl information
                       type: string
                     verifyHost:
+                      description: The CN of the connecting client's SSL certificate will be compared to its hostname to verify they match. This is useful only for 2-way SSL.
                       type: boolean
                     wantClientAuth:
+                      description: Tells a client connecting to this acceptor that 2-way SSL is requested but not required. Overridden by needClientAuth.
                       type: boolean
                   required:
                   - name
                   type: object
                 type: array
               addressSettings:
+                description: Specifies the address configurations (deprecated in favour of BrokerProperties)
                 properties:
                   addressSetting:
+                    description: Specifies the address settings
                     items:
                       properties:
                         addressFullPolicy:
+                          description: what happens when an address where maxSizeBytes is specified becomes full
                           type: string
                         autoCreateAddresses:
+                          description: whether or not to automatically create addresses when a client sends a message to or attempts to consume a message from a queue mapped to an address that doesnt exist
                           type: boolean
                         autoCreateDeadLetterResources:
+                          description: whether or not to automatically create the dead-letter-address and/or a corresponding queue on that address when a message found to be undeliverable
                           type: boolean
                         autoCreateExpiryResources:
+                          description: whether or not to automatically create the expiry-address and/or a corresponding queue on that address when a message is sent to a matching queue
                           type: boolean
                         autoCreateJmsQueues:
+                          description: DEPRECATED. whether or not to automatically create JMS queues when a producer sends or a consumer connects to a queue
                           type: boolean
                         autoCreateJmsTopics:
+                          description: DEPRECATED. whether or not to automatically create JMS topics when a producer sends or a consumer subscribes to a topic
                           type: boolean
                         autoCreateQueues:
+                          description: whether or not to automatically create a queue when a client sends a message to or attempts to consume a message from a queue
                           type: boolean
                         autoDeleteAddresses:
+                          description: whether or not to delete auto-created addresses when it no longer has any queues
                           type: boolean
                         autoDeleteAddressesDelay:
+                          description: how long to wait (in milliseconds) before deleting auto-created addresses after they no longer have any queues
                           format: int32
                           type: integer
                         autoDeleteCreatedQueues:
+                          description: whether or not to delete created queues when the queue has 0 consumers and 0 messages
                           type: boolean
                         autoDeleteJmsQueues:
+                          description: DEPRECATED. whether or not to delete auto-created JMS queues when the queue has 0 consumers and 0 messages
                           type: boolean
                         autoDeleteJmsTopics:
+                          description: DEPRECATED. whether or not to delete auto-created JMS topics when the last subscription is closed
                           type: boolean
                         autoDeleteQueues:
+                          description: whether or not to delete auto-created queues when the queue has 0 consumers and 0 messages
                           type: boolean
                         autoDeleteQueuesDelay:
+                          description: how long to wait (in milliseconds) before deleting auto-created queues after the queue has 0 consumers.
                           format: int32
                           type: integer
                         autoDeleteQueuesMessageCount:
+                          description: the message count the queue must be at or below before it can be evaluated to be auto deleted, 0 waits until empty queue (default) and -1 disables this check.
                           format: int32
                           type: integer
                         configDeleteAddresses:
+                          description: What to do when an address is no longer in broker.xml.  OFF = will do nothing addresses will remain, FORCE = delete address and its queues even if messages remaining.
                           type: string
                         configDeleteQueues:
+                          description: What to do when a queue is no longer in broker.xml.  OFF = will do nothing queues will remain, FORCE = delete queues even if messages remaining.
                           type: string
                         deadLetterAddress:
+                          description: the address to send dead messages to
                           type: string
                         deadLetterQueuePrefix:
+                          description: the prefix to use for auto-created dead letter queues
                           type: string
                         deadLetterQueueSuffix:
+                          description: the suffix to use for auto-created dead letter queues
                           type: string
                         defaultAddressRoutingType:
+                          description: the routing-type used on auto-created addresses
                           type: string
                         defaultConsumerWindowSize:
+                          description: the default window size for a consumer
                           format: int32
                           type: integer
                         defaultConsumersBeforeDispatch:
+                          description: the default number of consumers needed before dispatch can start for queues under the address.
                           format: int32
                           type: integer
                         defaultDelayBeforeDispatch:
+                          description: the default delay (in milliseconds) to wait before dispatching if number of consumers before dispatch is not met for queues under the address.
                           format: int32
                           type: integer
                         defaultExclusiveQueue:
+                          description: whether to treat the queues under the address as exclusive queues by default
                           type: boolean
                         defaultGroupBuckets:
+                          description: number of buckets to use for grouping, -1 (default) is unlimited and uses the raw group, 0 disables message groups.
                           format: int32
                           type: integer
                         defaultGroupFirstKey:
+                          description: key used to mark a message is first in a group for a consumer
                           type: string
                         defaultGroupRebalance:
+                          description: whether to rebalance groups when a consumer is added
                           type: boolean
                         defaultGroupRebalancePauseDispatch:
+                          description: whether to pause dispatch when rebalancing groups
                           type: boolean
                         defaultLastValueKey:
+                          description: the property to use as the key for a last value queue by default
                           type: string
                         defaultLastValueQueue:
+                          description: whether to treat the queues under the address as a last value queues by default
                           type: boolean
                         defaultMaxConsumers:
+                          description: the maximum number of consumers allowed on this queue at any one time
                           format: int32
                           type: integer
                         defaultNonDestructive:
+                          description: whether the queue should be non-destructive by default
                           type: boolean
                         defaultPurgeOnNoConsumers:
+                          description: purge the contents of the queue once there are no consumers
                           type: boolean
                         defaultQueueRoutingType:
+                          description: the routing-type used on auto-created queues
                           type: string
                         defaultRingSize:
+                          description: the default ring-size value for any matching queue which doesnt have ring-size explicitly defined
                           format: int32
                           type: integer
                         enableMetrics:
+                          description: whether or not to enable metrics for metrics plugins on the matching address
                           type: boolean
                         expiryAddress:
+                          description: the address to send expired messages to
                           type: string
                         expiryDelay:
+                          description: Overrides the expiration time for messages using the default value for expiration time. "-1" disables this setting.
                           format: int32
                           type: integer
                         expiryQueuePrefix:
+                          description: the prefix to use for auto-created expiry queues
                           type: string
                         expiryQueueSuffix:
+                          description: the suffix to use for auto-created expiry queues
                           type: string
                         lastValueQueue:
+                          description: This is deprecated please use default-last-value-queue instead.
                           type: boolean
                         managementBrowsePageSize:
+                          description: how many message a management resource can browse
                           format: int32
                           type: integer
                         match:
+                          description: pattern for matching settings against addresses; can use wildards
                           type: string
                         maxDeliveryAttempts:
+                          description: how many times to attempt to deliver a message before sending to dead letter address
                           format: int32
                           type: integer
                         maxExpiryDelay:
+                          description: Overrides the expiration time for messages using a higher value. "-1" disables this setting.
                           format: int32
                           type: integer
                         maxRedeliveryDelay:
+                          description: Maximum value for the redelivery-delay
                           format: int32
                           type: integer
                         maxSizeBytes:
+                          description: the maximum size in bytes for an address. -1 means no limits. This is used in PAGING, BLOCK and FAIL policies. Supports byte notation like K, Mb, GB, etc.
                           type: string
                         maxSizeBytesRejectThreshold:
+                          description: used with the address full BLOCK policy, the maximum size in bytes an address can reach before messages start getting rejected. Works in combination with max-size-bytes for AMQP protocol only.  Default = -1 (no limit).
                           format: int32
                           type: integer
                         messageCounterHistoryDayLimit:
+                          description: how many days to keep message counter history for this address
                           format: int32
                           type: integer
                         minExpiryDelay:
+                          description: Overrides the expiration time for messages using a lower value. "-1" disables this setting.
                           format: int32
                           type: integer
                         pageMaxCacheSize:
+                          description: Number of paging files to cache in memory to avoid IO during paging navigation
                           format: int32
                           type: integer
                         pageSizeBytes:
+                          description: The page size in bytes to use for an address. Supports byte notation like K, Mb, GB, etc.
                           type: string
                         redeliveryCollisionAvoidanceFactor:
                           type: number
                         redeliveryDelay:
+                          description: the time (in ms) to wait before redelivering a cancelled message.
                           format: int32
                           type: integer
                         redeliveryDelayMultiplier:
                           format: int32
                           type: integer
                         redistributionDelay:
+                          description: how long (in ms) to wait after the last consumer is closed on a queue before redistributing messages.
                           format: int32
                           type: integer
                         retroactiveMessageCount:
+                          description: the number of messages to preserve for future queues created on the matching address
                           format: int32
                           type: integer
                         sendToDlaOnNoRoute:
+                          description: if there are no queues matching this address, whether to forward message to DLA (if it exists for this address)
                           type: boolean
                         slowConsumerCheckPeriod:
+                          description: How often to check for slow consumers on a particular queue. Measured in seconds.
                           format: int32
                           type: integer
                         slowConsumerPolicy:
+                          description: what happens when a slow consumer is identified
                           type: string
                         slowConsumerThreshold:
+                          description: The minimum rate of message consumption allowed before a consumer is considered "slow." Measured in messages-per-second.
                           format: int32
                           type: integer
                       type: object
                     type: array
                   applyRule:
+                    description: How to merge the address settings to broker configuration
                     type: string
                 type: object
               adminPassword:
+                description: Password for standard broker user. It is required for connecting to the broker and the web console. If left empty, it will be generated.
                 type: string
               adminUser:
+                description: User name for standard broker user. It is required for connecting to the broker and the web console. If left empty, it will be generated.
                 type: string
               connectors:
+                description: Specifies connectors and connector configuration
                 items:
                   properties:
                     enabledCipherSuites:
+                      description: Comma separated list of cipher suites used for SSL communication.
                       type: string
                     enabledProtocols:
+                      description: Comma separated list of protocols used for SSL communication.
                       type: string
                     expose:
+                      description: Whether or not to expose this connector
                       type: boolean
                     host:
+                      description: Hostname or IP to connect to
                       type: string
                     name:
+                      description: The name of the connector
                       type: string
                     needClientAuth:
+                      description: Tells a client connecting to this connector that 2-way SSL is required. This property takes precedence over wantClientAuth.
                       type: boolean
                     port:
+                      description: Port number
                       format: int32
                       type: integer
                     sniHost:
+                      description: A regular expression used to match the server_name extension on incoming SSL connections. If the name doesn't match then the connection to the acceptor will be rejected.
                       type: string
                     sslEnabled:
+                      description: ' Whether or not to enable SSL on this port'
                       type: boolean
                     sslProvider:
+                      description: Used to change the SSL Provider between JDK and OPENSSL. The default is JDK.
                       type: string
                     sslSecret:
+                      description: Name of the secret to use for ssl information
                       type: string
                     type:
+                      description: The type either tcp or vm
                       type: string
                     verifyHost:
+                      description: The CN of the connecting client's SSL certificate will be compared to its hostname to verify they match. This is useful only for 2-way SSL.
                       type: boolean
                     wantClientAuth:
+                      description: Tells a client connecting to this connector that 2-way SSL is requested but not required. Overridden by needClientAuth.
                       type: boolean
                   required:
                   - host
@@ -6474,36 +6824,50 @@ spec:
                   type: object
                 type: array
               console:
+                description: Specifies the console configuration
                 properties:
                   expose:
+                    description: Whether or not to expose this port
                     type: boolean
                   sslEnabled:
+                    description: Whether or not to enable SSL on this port
                     type: boolean
                   sslSecret:
+                    description: Name of the secret to use for ssl information
                     type: string
                   useClientAuth:
+                    description: If the embedded server requires client authentication
                     type: boolean
                 type: object
               deploymentPlan:
+                description: Specifies the deployment plan
                 properties:
                   image:
+                    description: The image used for the broker, all upgrades are disabled. Needs a corresponding initImage
                     type: string
                   initImage:
+                    description: The init container image used to configure broker, all upgrades are disabled. Needs a corresponding image
                     type: string
                   jolokiaAgentEnabled:
+                    description: If true enable the Jolokia JVM Agent
                     type: boolean
                   journalType:
+                    description: If aio use ASYNCIO, if nio use NIO for journal IO
                     type: string
                   managementRBACEnabled:
+                    description: If true enable the management role based access control
                     type: boolean
                   messageMigration:
+                    description: If true migrate messages on scaledown
                     type: boolean
                   persistenceEnabled:
+                    description: If true use persistent volume via persistent volume claim for journal storage
                     type: boolean
                   requireLogin:
+                    description: If true require user password login credentials for broker protocol ports
                     type: boolean
                   resources:
-                    description: ResourceRequirements describes the compute resource requirements.
+                    description: Specifies the minimum/maximum amount of compute resources required/allowed
                     properties:
                       claims:
                         description: |-
@@ -6556,26 +6920,32 @@ spec:
                         type: object
                     type: object
                   size:
+                    description: The number of broker pods to deploy
                     format: int32
                     type: integer
                   storage:
+                    description: Specifies the storage configurations
                     properties:
                       size:
+                        description: The storage size
                         type: string
                     type: object
                 type: object
               upgrades:
-                description: ActiveMQArtemis App product upgrade flags
+                description: Specifies the upgrades (deprecated in favour of Version)
                 properties:
                   enabled:
+                    description: Set true to enable automatic micro version product upgrades, it is disabled by default.
                     type: boolean
                   minor:
+                    description: Set true to enable automatic minor product version upgrades, it is disabled by default. Requires spec.upgrades.enabled to be true.
                     type: boolean
                 required:
                 - enabled
                 - minor
                 type: object
               version:
+                description: The desired version of the broker. Can be x, or x.y or x.y.z to configure upgrades
                 type: string
             type: object
           status:
@@ -6640,6 +7010,7 @@ spec:
                   type: object
                 type: array
               podStatus:
+                description: The current pods
                 properties:
                   ready:
                     description: Deployments are ready to serve requests
@@ -6668,7 +7039,7 @@ spec:
   - name: v2alpha5
     schema:
       openAPIV3Schema:
-        description: ActiveMQArtemis is the Schema for the activemqartemises API
+        description: A stateful deployment of one or more brokers
         properties:
           apiVersion:
             description: |-
@@ -6691,250 +7062,353 @@ spec:
             description: ActiveMQArtemisSpec defines the desired state of ActiveMQArtemis
             properties:
               acceptors:
+                description: Specifies the acceptor configuration
                 items:
                   properties:
                     amqpMinLargeMessageSize:
+                      description: AMQP Minimum Large Message Size
                       type: integer
                     anycastPrefix:
+                      description: To indicate which kind of routing type to use.
                       type: string
                     connectionsAllowed:
+                      description: Max number of connections allowed to make
                       type: integer
                     enabledCipherSuites:
+                      description: Comma separated list of cipher suites used for SSL communication.
                       type: string
                     enabledProtocols:
+                      description: Comma separated list of protocols used for SSL communication.
                       type: string
                     expose:
+                      description: Whether or not to expose this acceptor
                       type: boolean
                     multicastPrefix:
+                      description: To indicate which kind of routing type to use
                       type: string
                     name:
+                      description: The acceptor name
                       type: string
                     needClientAuth:
+                      description: Tells a client connecting to this acceptor that 2-way SSL is required. This property takes precedence over wantClientAuth.
                       type: boolean
                     port:
+                      description: Port number
                       format: int32
                       type: integer
                     protocols:
+                      description: The protocols to enable for this acceptor
                       type: string
                     sniHost:
+                      description: A regular expression used to match the server_name extension on incoming SSL connections. If the name doesn't match then the connection to the acceptor will be rejected.
                       type: string
                     sslEnabled:
+                      description: Whether or not to enable SSL on this port
                       type: boolean
                     sslProvider:
+                      description: Used to change the SSL Provider between JDK and OPENSSL. The default is JDK.
                       type: string
                     sslSecret:
+                      description: Name of the secret to use for ssl information
                       type: string
                     supportAdvisory:
+                      description: For openwire protocol if advisory topics are enabled, default false
                       type: boolean
                     suppressInternalManagementObjects:
+                      description: If prevents advisory addresses/queues to be registered to management service, default false
                       type: boolean
                     verifyHost:
+                      description: The CN of the connecting client's SSL certificate will be compared to its hostname to verify they match. This is useful only for 2-way SSL.
                       type: boolean
                     wantClientAuth:
+                      description: Tells a client connecting to this acceptor that 2-way SSL is requested but not required. Overridden by needClientAuth.
                       type: boolean
                   required:
                   - name
                   type: object
                 type: array
               addressSettings:
+                description: Specifies the address configurations (deprecated in favour of BrokerProperties)
                 properties:
                   addressSetting:
+                    description: Specifies the address settings
                     items:
                       properties:
                         addressFullPolicy:
+                          description: what happens when an address where maxSizeBytes is specified becomes full
                           type: string
                         autoCreateAddresses:
+                          description: whether or not to automatically create addresses when a client sends a message to or attempts to consume a message from a queue mapped to an address that doesnt exist
                           type: boolean
                         autoCreateDeadLetterResources:
+                          description: whether or not to automatically create the dead-letter-address and/or a corresponding queue on that address when a message found to be undeliverable
                           type: boolean
                         autoCreateExpiryResources:
+                          description: whether or not to automatically create the expiry-address and/or a corresponding queue on that address when a message is sent to a matching queue
                           type: boolean
                         autoCreateJmsQueues:
+                          description: DEPRECATED. whether or not to automatically create JMS queues when a producer sends or a consumer connects to a queue
                           type: boolean
                         autoCreateJmsTopics:
+                          description: DEPRECATED. whether or not to automatically create JMS topics when a producer sends or a consumer subscribes to a topic
                           type: boolean
                         autoCreateQueues:
+                          description: whether or not to automatically create a queue when a client sends a message to or attempts to consume a message from a queue
                           type: boolean
                         autoDeleteAddresses:
+                          description: whether or not to delete auto-created addresses when it no longer has any queues
                           type: boolean
                         autoDeleteAddressesDelay:
+                          description: how long to wait (in milliseconds) before deleting auto-created addresses after they no longer have any queues
                           format: int32
                           type: integer
                         autoDeleteCreatedQueues:
+                          description: whether or not to delete created queues when the queue has 0 consumers and 0 messages
                           type: boolean
                         autoDeleteJmsQueues:
+                          description: DEPRECATED. whether or not to delete auto-created JMS queues when the queue has 0 consumers and 0 messages
                           type: boolean
                         autoDeleteJmsTopics:
+                          description: DEPRECATED. whether or not to delete auto-created JMS topics when the last subscription is closed
                           type: boolean
                         autoDeleteQueues:
+                          description: whether or not to delete auto-created queues when the queue has 0 consumers and 0 messages
                           type: boolean
                         autoDeleteQueuesDelay:
+                          description: how long to wait (in milliseconds) before deleting auto-created queues after the queue has 0 consumers.
                           format: int32
                           type: integer
                         autoDeleteQueuesMessageCount:
+                          description: the message count the queue must be at or below before it can be evaluated to be auto deleted, 0 waits until empty queue (default) and -1 disables this check.
                           format: int32
                           type: integer
                         configDeleteAddresses:
+                          description: What to do when an address is no longer in broker.xml.  OFF = will do nothing addresses will remain, FORCE = delete address and its queues even if messages remaining.
                           type: string
                         configDeleteQueues:
+                          description: What to do when a queue is no longer in broker.xml.  OFF = will do nothing queues will remain, FORCE = delete queues even if messages remaining.
                           type: string
                         deadLetterAddress:
+                          description: the address to send dead messages to
                           type: string
                         deadLetterQueuePrefix:
+                          description: the prefix to use for auto-created dead letter queues
                           type: string
                         deadLetterQueueSuffix:
+                          description: the suffix to use for auto-created dead letter queues
                           type: string
                         defaultAddressRoutingType:
+                          description: the routing-type used on auto-created addresses
                           type: string
                         defaultConsumerWindowSize:
+                          description: the default window size for a consumer
                           format: int32
                           type: integer
                         defaultConsumersBeforeDispatch:
+                          description: the default number of consumers needed before dispatch can start for queues under the address.
                           format: int32
                           type: integer
                         defaultDelayBeforeDispatch:
+                          description: the default delay (in milliseconds) to wait before dispatching if number of consumers before dispatch is not met for queues under the address.
                           format: int32
                           type: integer
                         defaultExclusiveQueue:
+                          description: whether to treat the queues under the address as exclusive queues by default
                           type: boolean
                         defaultGroupBuckets:
+                          description: number of buckets to use for grouping, -1 (default) is unlimited and uses the raw group, 0 disables message groups.
                           format: int32
                           type: integer
                         defaultGroupFirstKey:
+                          description: key used to mark a message is first in a group for a consumer
                           type: string
                         defaultGroupRebalance:
+                          description: whether to rebalance groups when a consumer is added
                           type: boolean
                         defaultGroupRebalancePauseDispatch:
+                          description: whether to pause dispatch when rebalancing groups
                           type: boolean
                         defaultLastValueKey:
+                          description: the property to use as the key for a last value queue by default
                           type: string
                         defaultLastValueQueue:
+                          description: whether to treat the queues under the address as a last value queues by default
                           type: boolean
                         defaultMaxConsumers:
+                          description: the maximum number of consumers allowed on this queue at any one time
                           format: int32
                           type: integer
                         defaultNonDestructive:
+                          description: whether the queue should be non-destructive by default
                           type: boolean
                         defaultPurgeOnNoConsumers:
+                          description: purge the contents of the queue once there are no consumers
                           type: boolean
                         defaultQueueRoutingType:
+                          description: the routing-type used on auto-created queues
                           type: string
                         defaultRingSize:
+                          description: the default ring-size value for any matching queue which doesnt have ring-size explicitly defined
                           format: int32
                           type: integer
                         enableIngressTimestamp:
+                          description: Whether or not set the timestamp of arrival on messages. default false
                           type: boolean
                         enableMetrics:
+                          description: whether or not to enable metrics for metrics plugins on the matching address
                           type: boolean
                         expiryAddress:
+                          description: the address to send expired messages to
                           type: string
                         expiryDelay:
+                          description: Overrides the expiration time for messages using the default value for expiration time. "-1" disables this setting.
                           format: int32
                           type: integer
                         expiryQueuePrefix:
+                          description: the prefix to use for auto-created expiry queues
                           type: string
                         expiryQueueSuffix:
+                          description: the suffix to use for auto-created expiry queues
                           type: string
                         lastValueQueue:
+                          description: This is deprecated please use default-last-value-queue instead.
                           type: boolean
                         managementBrowsePageSize:
+                          description: how many message a management resource can browse
                           format: int32
                           type: integer
                         managementMessageAttributeSizeLimit:
+                          description: max size of the message returned from management API, default 256
                           format: int32
                           type: integer
                         match:
+                          description: pattern for matching settings against addresses; can use wildards
                           type: string
                         maxDeliveryAttempts:
+                          description: how many times to attempt to deliver a message before sending to dead letter address
                           format: int32
                           type: integer
                         maxExpiryDelay:
+                          description: Overrides the expiration time for messages using a higher value. "-1" disables this setting.
                           format: int32
                           type: integer
                         maxRedeliveryDelay:
+                          description: Maximum value for the redelivery-delay
                           format: int32
                           type: integer
                         maxSizeBytes:
+                          description: the maximum size in bytes for an address. -1 means no limits. This is used in PAGING, BLOCK and FAIL policies. Supports byte notation like K, Mb, GB, etc.
                           type: string
                         maxSizeBytesRejectThreshold:
+                          description: used with the address full BLOCK policy, the maximum size in bytes an address can reach before messages start getting rejected. Works in combination with max-size-bytes for AMQP protocol only.  Default = -1 (no limit).
                           format: int32
                           type: integer
                         messageCounterHistoryDayLimit:
+                          description: how many days to keep message counter history for this address
                           format: int32
                           type: integer
                         minExpiryDelay:
+                          description: Overrides the expiration time for messages using a lower value. "-1" disables this setting.
                           format: int32
                           type: integer
                         pageMaxCacheSize:
+                          description: Number of paging files to cache in memory to avoid IO during paging navigation
                           format: int32
                           type: integer
                         pageSizeBytes:
+                          description: The page size in bytes to use for an address. Supports byte notation like K, Mb, GB, etc.
                           type: string
                         redeliveryCollisionAvoidanceFactor:
                           type: number
                         redeliveryDelay:
+                          description: the time (in ms) to wait before redelivering a cancelled message.
                           format: int32
                           type: integer
                         redeliveryDelayMultiplier:
                           type: number
                         redistributionDelay:
+                          description: how long (in ms) to wait after the last consumer is closed on a queue before redistributing messages.
                           format: int32
                           type: integer
                         retroactiveMessageCount:
+                          description: the number of messages to preserve for future queues created on the matching address
                           format: int32
                           type: integer
                         sendToDlaOnNoRoute:
+                          description: if there are no queues matching this address, whether to forward message to DLA (if it exists for this address)
                           type: boolean
                         slowConsumerCheckPeriod:
+                          description: How often to check for slow consumers on a particular queue. Measured in seconds.
                           format: int32
                           type: integer
                         slowConsumerPolicy:
+                          description: what happens when a slow consumer is identified
                           type: string
                         slowConsumerThreshold:
+                          description: The minimum rate of message consumption allowed before a consumer is considered "slow." Measured in messages-per-second.
                           format: int32
                           type: integer
                         slowConsumerThresholdMeasurementUnit:
+                          description: Unit used in specifying slow consumer threshold, default is MESSAGE_PER_SECOND
                           type: string
                       type: object
                     type: array
                   applyRule:
+                    description: How to merge the address settings to broker configuration
                     type: string
                 type: object
               adminPassword:
+                description: Password for standard broker user. It is required for connecting to the broker and the web console. If left empty, it will be generated.
                 type: string
               adminUser:
+                description: User name for standard broker user. It is required for connecting to the broker and the web console. If left empty, it will be generated.
                 type: string
               connectors:
+                description: Specifies connectors and connector configuration
                 items:
                   properties:
                     enabledCipherSuites:
+                      description: Comma separated list of cipher suites used for SSL communication.
                       type: string
                     enabledProtocols:
+                      description: Comma separated list of protocols used for SSL communication.
                       type: string
                     expose:
+                      description: Whether or not to expose this connector
                       type: boolean
                     host:
+                      description: Hostname or IP to connect to
                       type: string
                     name:
+                      description: The name of the connector
                       type: string
                     needClientAuth:
+                      description: Tells a client connecting to this connector that 2-way SSL is required. This property takes precedence over wantClientAuth.
                       type: boolean
                     port:
+                      description: Port number
                       format: int32
                       type: integer
                     sniHost:
+                      description: A regular expression used to match the server_name extension on incoming SSL connections. If the name doesn't match then the connection to the acceptor will be rejected.
                       type: string
                     sslEnabled:
+                      description: ' Whether or not to enable SSL on this port'
                       type: boolean
                     sslProvider:
+                      description: Used to change the SSL Provider between JDK and OPENSSL. The default is JDK.
                       type: string
                     sslSecret:
+                      description: Name of the secret to use for ssl information
                       type: string
                     type:
+                      description: The type either tcp or vm
                       type: string
                     verifyHost:
+                      description: The CN of the connecting client's SSL certificate will be compared to its hostname to verify they match. This is useful only for 2-way SSL.
                       type: boolean
                     wantClientAuth:
+                      description: Tells a client connecting to this connector that 2-way SSL is requested but not required. Overridden by needClientAuth.
                       type: boolean
                   required:
                   - host
@@ -6943,71 +7417,95 @@ spec:
                   type: object
                 type: array
               console:
+                description: Specifies the console configuration
                 properties:
                   expose:
+                    description: Whether or not to expose this port
                     type: boolean
                   sslEnabled:
+                    description: Whether or not to enable SSL on this port
                     type: boolean
                   sslSecret:
+                    description: Name of the secret to use for ssl information
                     type: string
                   useClientAuth:
+                    description: If the embedded server requires client authentication
                     type: boolean
                 type: object
               deploymentPlan:
+                description: Specifies the deployment plan
                 properties:
                   clustered:
+                    description: Whether broker is clustered
                     type: boolean
                   enableMetricsPlugin:
+                    description: Whether or not to install the artemis metrics plugin
                     type: boolean
                   extraMounts:
+                    description: Specifies extra mounts
                     properties:
                       configMaps:
+                        description: Specifies ConfigMap names
                         items:
                           type: string
                         type: array
                       secrets:
+                        description: Specifies Secret names
                         items:
                           type: string
                         type: array
                     type: object
                   image:
+                    description: The image used for the broker, all upgrades are disabled. Needs a corresponding initImage
                     type: string
                   initImage:
+                    description: The init container image used to configure broker, all upgrades are disabled. Needs a corresponding image
                     type: string
                   jolokiaAgentEnabled:
+                    description: If true enable the Jolokia JVM Agent
                     type: boolean
                   journalType:
+                    description: If aio use ASYNCIO, if nio use NIO for journal IO
                     type: string
                   livenessProbe:
+                    description: Specifies the liveness probe configuration
                     properties:
                       timeoutSeconds:
                         format: int32
                         type: integer
                     type: object
                   managementRBACEnabled:
+                    description: If true enable the management role based access control
                     type: boolean
                   messageMigration:
+                    description: If true migrate messages on scaledown
                     type: boolean
                   persistenceEnabled:
+                    description: If true use persistent volume via persistent volume claim for journal storage
                     type: boolean
                   podSecurity:
+                    description: Specifies the pod security configurations
                     properties:
                       runAsUser:
+                        description: runAsUser as defined in PodSecurityContext for the pod
                         format: int64
                         type: integer
                       serviceAccountName:
+                        description: ServiceAccount Name of the pod
                         type: string
                     type: object
                   readinessProbe:
+                    description: Specifies the readiness probe configuration
                     properties:
                       timeoutSeconds:
                         format: int32
                         type: integer
                     type: object
                   requireLogin:
+                    description: If true require user password login credentials for broker protocol ports
                     type: boolean
                   resources:
-                    description: ResourceRequirements describes the compute resource requirements.
+                    description: Specifies the minimum/maximum amount of compute resources required/allowed
                     properties:
                       claims:
                         description: |-
@@ -7060,26 +7558,32 @@ spec:
                         type: object
                     type: object
                   size:
+                    description: The number of broker pods to deploy
                     format: int32
                     type: integer
                   storage:
+                    description: Specifies the storage configurations
                     properties:
                       size:
+                        description: The storage size
                         type: string
                     type: object
                 type: object
               upgrades:
-                description: ActiveMQArtemis App product upgrade flags
+                description: Specifies the upgrades (deprecated in favour of Version)
                 properties:
                   enabled:
+                    description: Set true to enable automatic micro version product upgrades, it is disabled by default.
                     type: boolean
                   minor:
+                    description: Set true to enable automatic minor product version upgrades, it is disabled by default. Requires spec.upgrades.enabled to be true.
                     type: boolean
                 required:
                 - enabled
                 - minor
                 type: object
               version:
+                description: The desired version of the broker. Can be x, or x.y or x.y.z to configure upgrades
                 type: string
             type: object
           status:
@@ -7144,9 +7648,7 @@ spec:
                   type: object
                 type: array
               podStatus:
-                description: |-
-                  INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
-                  Important: Run "make" to regenerate code after modifying this file
+                description: The current pods
                 properties:
                   ready:
                     description: Deployments are ready to serve requests

--- a/deploy/crds/broker_activemqartemis_crd.yaml
+++ b/deploy/crds/broker_activemqartemis_crd.yaml
@@ -4688,7 +4688,7 @@ spec:
   - name: v2alpha1
     schema:
       openAPIV3Schema:
-        description: ActiveMQArtemis is the Schema for the activemqartemises API
+        description: A stateful deployment of one or more brokers
         properties:
           apiVersion:
             description: |-
@@ -4711,80 +4711,114 @@ spec:
             description: ActiveMQArtemisSpec defines the desired state of ActiveMQArtemis
             properties:
               acceptors:
+                description: Specifies the acceptor configuration
                 items:
                   properties:
                     anycastPrefix:
+                      description: To indicate which kind of routing type to use.
                       type: string
                     connectionsAllowed:
+                      description: Max number of connections allowed to make
                       type: integer
                     enabledCipherSuites:
+                      description: Comma separated list of cipher suites used for SSL communication.
                       type: string
                     enabledProtocols:
+                      description: Comma separated list of protocols used for SSL communication.
                       type: string
                     expose:
+                      description: Whether or not to expose this acceptor
                       type: boolean
                     multicastPrefix:
+                      description: To indicate which kind of routing type to use
                       type: string
                     name:
+                      description: The acceptor name
                       type: string
                     needClientAuth:
+                      description: Tells a client connecting to this acceptor that 2-way SSL is required. This property takes precedence over wantClientAuth.
                       type: boolean
                     port:
+                      description: Port number
                       format: int32
                       type: integer
                     protocols:
+                      description: The protocols to enable for this acceptor
                       type: string
                     sniHost:
+                      description: A regular expression used to match the server_name extension on incoming SSL connections. If the name doesn't match then the connection to the acceptor will be rejected.
                       type: string
                     sslEnabled:
+                      description: Whether or not to enable SSL on this port
                       type: boolean
                     sslProvider:
+                      description: Used to change the SSL Provider between JDK and OPENSSL. The default is JDK.
                       type: string
                     sslSecret:
+                      description: Name of the secret to use for ssl information
                       type: string
                     verifyHost:
+                      description: The CN of the connecting client's SSL certificate will be compared to its hostname to verify they match. This is useful only for 2-way SSL.
                       type: boolean
                     wantClientAuth:
+                      description: Tells a client connecting to this acceptor that 2-way SSL is requested but not required. Overridden by needClientAuth.
                       type: boolean
                   required:
                   - name
                   type: object
                 type: array
               adminPassword:
+                description: Password for standard broker user. It is required for connecting to the broker and the web console. If left empty, it will be generated.
                 type: string
               adminUser:
+                description: User name for standard broker user. It is required for connecting to the broker and the web console. If left empty, it will be generated.
                 type: string
               connectors:
+                description: Specifies connectors and connector configuration
                 items:
                   properties:
                     enabledCipherSuites:
+                      description: Comma separated list of cipher suites used for SSL communication.
                       type: string
                     enabledProtocols:
+                      description: Comma separated list of protocols used for SSL communication.
                       type: string
                     expose:
+                      description: Whether or not to expose this connector
                       type: boolean
                     host:
+                      description: Hostname or IP to connect to
                       type: string
                     name:
+                      description: The name of the connector
                       type: string
                     needClientAuth:
+                      description: Tells a client connecting to this connector that 2-way SSL is required. This property takes precedence over wantClientAuth.
                       type: boolean
                     port:
+                      description: Port number
                       format: int32
                       type: integer
                     sniHost:
+                      description: A regular expression used to match the server_name extension on incoming SSL connections. If the name doesn't match then the connection to the acceptor will be rejected.
                       type: string
                     sslEnabled:
+                      description: ' Whether or not to enable SSL on this port'
                       type: boolean
                     sslProvider:
+                      description: Used to change the SSL Provider between JDK and OPENSSL. The default is JDK.
                       type: string
                     sslSecret:
+                      description: Name of the secret to use for ssl information
                       type: string
                     type:
+                      description: The type either tcp or vm
                       type: string
                     verifyHost:
+                      description: The CN of the connecting client's SSL certificate will be compared to its hostname to verify they match. This is useful only for 2-way SSL.
                       type: boolean
                     wantClientAuth:
+                      description: Tells a client connecting to this connector that 2-way SSL is requested but not required. Overridden by needClientAuth.
                       type: boolean
                   required:
                   - host
@@ -4793,29 +4827,41 @@ spec:
                   type: object
                 type: array
               console:
+                description: Specifies the console configuration
                 properties:
                   expose:
+                    description: Whether or not to expose this port
                     type: boolean
                   sslEnabled:
+                    description: Whether or not to enable SSL on this port
                     type: boolean
                   sslSecret:
+                    description: Name of the secret to use for ssl information
                     type: string
                   useClientAuth:
+                    description: If the embedded server requires client authentication
                     type: boolean
                 type: object
               deploymentPlan:
+                description: Specifies the deployment plan
                 properties:
                   image:
+                    description: The image used for the broker, all upgrades are disabled. Needs a corresponding initImage
                     type: string
                   journalType:
+                    description: If aio use ASYNCIO, if nio use NIO for journal IO
                     type: string
                   messageMigration:
+                    description: If true migrate messages on scaledown
                     type: boolean
                   persistenceEnabled:
+                    description: If true use persistent volume via persistent volume claim for journal storage
                     type: boolean
                   requireLogin:
+                    description: If true require user password login credentials for broker protocol ports
                     type: boolean
                   size:
+                    description: The number of broker pods to deploy
                     format: int32
                     type: integer
                 type: object
@@ -4910,7 +4956,7 @@ spec:
   - name: v2alpha2
     schema:
       openAPIV3Schema:
-        description: ActiveMQArtemis is the Schema for the activemqartemises API
+        description: A stateful deployment of one or more brokers
         properties:
           apiVersion:
             description: |-
@@ -4933,80 +4979,114 @@ spec:
             description: ActiveMQArtemisSpec defines the desired state of ActiveMQArtemis
             properties:
               acceptors:
+                description: Specifies the acceptor configuration
                 items:
                   properties:
                     anycastPrefix:
+                      description: To indicate which kind of routing type to use.
                       type: string
                     connectionsAllowed:
+                      description: Max number of connections allowed to make
                       type: integer
                     enabledCipherSuites:
+                      description: Comma separated list of cipher suites used for SSL communication.
                       type: string
                     enabledProtocols:
+                      description: Comma separated list of protocols used for SSL communication.
                       type: string
                     expose:
+                      description: Whether or not to expose this acceptor
                       type: boolean
                     multicastPrefix:
+                      description: To indicate which kind of routing type to use
                       type: string
                     name:
+                      description: The acceptor name
                       type: string
                     needClientAuth:
+                      description: Tells a client connecting to this acceptor that 2-way SSL is required. This property takes precedence over wantClientAuth.
                       type: boolean
                     port:
+                      description: Port number
                       format: int32
                       type: integer
                     protocols:
+                      description: The protocols to enable for this acceptor
                       type: string
                     sniHost:
+                      description: A regular expression used to match the server_name extension on incoming SSL connections. If the name doesn't match then the connection to the acceptor will be rejected.
                       type: string
                     sslEnabled:
+                      description: Whether or not to enable SSL on this port
                       type: boolean
                     sslProvider:
+                      description: Used to change the SSL Provider between JDK and OPENSSL. The default is JDK.
                       type: string
                     sslSecret:
+                      description: Name of the secret to use for ssl information
                       type: string
                     verifyHost:
+                      description: The CN of the connecting client's SSL certificate will be compared to its hostname to verify they match. This is useful only for 2-way SSL.
                       type: boolean
                     wantClientAuth:
+                      description: Tells a client connecting to this acceptor that 2-way SSL is requested but not required. Overridden by needClientAuth.
                       type: boolean
                   required:
                   - name
                   type: object
                 type: array
               adminPassword:
+                description: Password for standard broker user. It is required for connecting to the broker and the web console. If left empty, it will be generated.
                 type: string
               adminUser:
+                description: User name for standard broker user. It is required for connecting to the broker and the web console. If left empty, it will be generated.
                 type: string
               connectors:
+                description: Specifies connectors and connector configuration
                 items:
                   properties:
                     enabledCipherSuites:
+                      description: Comma separated list of cipher suites used for SSL communication.
                       type: string
                     enabledProtocols:
+                      description: Comma separated list of protocols used for SSL communication.
                       type: string
                     expose:
+                      description: Whether or not to expose this connector
                       type: boolean
                     host:
+                      description: Hostname or IP to connect to
                       type: string
                     name:
+                      description: The name of the connector
                       type: string
                     needClientAuth:
+                      description: Tells a client connecting to this connector that 2-way SSL is required. This property takes precedence over wantClientAuth.
                       type: boolean
                     port:
+                      description: Port number
                       format: int32
                       type: integer
                     sniHost:
+                      description: A regular expression used to match the server_name extension on incoming SSL connections. If the name doesn't match then the connection to the acceptor will be rejected.
                       type: string
                     sslEnabled:
+                      description: ' Whether or not to enable SSL on this port'
                       type: boolean
                     sslProvider:
+                      description: Used to change the SSL Provider between JDK and OPENSSL. The default is JDK.
                       type: string
                     sslSecret:
+                      description: Name of the secret to use for ssl information
                       type: string
                     type:
+                      description: The type either tcp or vm
                       type: string
                     verifyHost:
+                      description: The CN of the connecting client's SSL certificate will be compared to its hostname to verify they match. This is useful only for 2-way SSL.
                       type: boolean
                     wantClientAuth:
+                      description: Tells a client connecting to this connector that 2-way SSL is requested but not required. Overridden by needClientAuth.
                       type: boolean
                   required:
                   - host
@@ -5015,44 +5095,59 @@ spec:
                   type: object
                 type: array
               console:
+                description: Specifies the console configuration
                 properties:
                   expose:
+                    description: Whether or not to expose this port
                     type: boolean
                   sslEnabled:
+                    description: Whether or not to enable SSL on this port
                     type: boolean
                   sslSecret:
+                    description: Name of the secret to use for ssl information
                     type: string
                   useClientAuth:
+                    description: If the embedded server requires client authentication
                     type: boolean
                 type: object
               deploymentPlan:
+                description: Specifies the deployment plan
                 properties:
                   image:
+                    description: The image used for the broker, all upgrades are disabled. Needs a corresponding initImage
                     type: string
                   journalType:
+                    description: If aio use ASYNCIO, if nio use NIO for journal IO
                     type: string
                   messageMigration:
+                    description: If true migrate messages on scaledown
                     type: boolean
                   persistenceEnabled:
+                    description: If true use persistent volume via persistent volume claim for journal storage
                     type: boolean
                   requireLogin:
+                    description: If true require user password login credentials for broker protocol ports
                     type: boolean
                   size:
+                    description: The number of broker pods to deploy
                     format: int32
                     type: integer
                 type: object
               upgrades:
-                description: ActiveMQArtemis App product upgrade flags
+                description: Specifies the upgrades (deprecated in favour of Version)
                 properties:
                   enabled:
+                    description: Set true to enable automatic micro version product upgrades, it is disabled by default.
                     type: boolean
                   minor:
+                    description: Set true to enable automatic minor product version upgrades, it is disabled by default. Requires spec.upgrades.enabled to be true.
                     type: boolean
                 required:
                 - enabled
                 - minor
                 type: object
               version:
+                description: The desired version of the broker. Can be x, or x.y or x.y.z to configure upgrades
                 type: string
             type: object
           status:
@@ -5145,7 +5240,7 @@ spec:
   - name: v2alpha3
     schema:
       openAPIV3Schema:
-        description: ActiveMQArtemis is the Schema for the activemqartemises API
+        description: A stateful deployment of one or more brokers
         properties:
           apiVersion:
             description: |-
@@ -5168,240 +5263,338 @@ spec:
             description: ActiveMQArtemisSpec defines the desired state of ActiveMQArtemis
             properties:
               acceptors:
+                description: Specifies the acceptor configuration
                 items:
                   properties:
                     amqpMinLargeMessageSize:
+                      description: AMQP Minimum Large Message Size
                       type: integer
                     anycastPrefix:
+                      description: To indicate which kind of routing type to use.
                       type: string
                     connectionsAllowed:
+                      description: Max number of connections allowed to make
                       type: integer
                     enabledCipherSuites:
+                      description: Comma separated list of cipher suites used for SSL communication.
                       type: string
                     enabledProtocols:
+                      description: Comma separated list of protocols used for SSL communication.
                       type: string
                     expose:
+                      description: Whether or not to expose this acceptor
                       type: boolean
                     multicastPrefix:
+                      description: To indicate which kind of routing type to use
                       type: string
                     name:
+                      description: The acceptor name
                       type: string
                     needClientAuth:
+                      description: Tells a client connecting to this acceptor that 2-way SSL is required. This property takes precedence over wantClientAuth.
                       type: boolean
                     port:
+                      description: Port number
                       format: int32
                       type: integer
                     protocols:
+                      description: The protocols to enable for this acceptor
                       type: string
                     sniHost:
+                      description: A regular expression used to match the server_name extension on incoming SSL connections. If the name doesn't match then the connection to the acceptor will be rejected.
                       type: string
                     sslEnabled:
+                      description: Whether or not to enable SSL on this port
                       type: boolean
                     sslProvider:
+                      description: Used to change the SSL Provider between JDK and OPENSSL. The default is JDK.
                       type: string
                     sslSecret:
+                      description: Name of the secret to use for ssl information
                       type: string
                     verifyHost:
+                      description: The CN of the connecting client's SSL certificate will be compared to its hostname to verify they match. This is useful only for 2-way SSL.
                       type: boolean
                     wantClientAuth:
+                      description: Tells a client connecting to this acceptor that 2-way SSL is requested but not required. Overridden by needClientAuth.
                       type: boolean
                   required:
                   - name
                   type: object
                 type: array
               addressSettings:
+                description: Specifies the address configurations (deprecated in favour of BrokerProperties)
                 properties:
                   addressSetting:
+                    description: Specifies the address settings
                     items:
                       properties:
                         addressFullPolicy:
+                          description: what happens when an address where maxSizeBytes is specified becomes full
                           type: string
                         autoCreateAddresses:
+                          description: whether or not to automatically create addresses when a client sends a message to or attempts to consume a message from a queue mapped to an address that doesnt exist
                           type: boolean
                         autoCreateDeadLetterResources:
+                          description: whether or not to automatically create the dead-letter-address and/or a corresponding queue on that address when a message found to be undeliverable
                           type: boolean
                         autoCreateExpiryResources:
+                          description: whether or not to automatically create the expiry-address and/or a corresponding queue on that address when a message is sent to a matching queue
                           type: boolean
                         autoCreateJmsQueues:
+                          description: DEPRECATED. whether or not to automatically create JMS queues when a producer sends or a consumer connects to a queue
                           type: boolean
                         autoCreateJmsTopics:
+                          description: DEPRECATED. whether or not to automatically create JMS topics when a producer sends or a consumer subscribes to a topic
                           type: boolean
                         autoCreateQueues:
+                          description: whether or not to automatically create a queue when a client sends a message to or attempts to consume a message from a queue
                           type: boolean
                         autoDeleteAddresses:
+                          description: whether or not to delete auto-created addresses when it no longer has any queues
                           type: boolean
                         autoDeleteAddressesDelay:
+                          description: how long to wait (in milliseconds) before deleting auto-created addresses after they no longer have any queues
                           format: int32
                           type: integer
                         autoDeleteCreatedQueues:
+                          description: whether or not to delete created queues when the queue has 0 consumers and 0 messages
                           type: boolean
                         autoDeleteJmsQueues:
+                          description: DEPRECATED. whether or not to delete auto-created JMS queues when the queue has 0 consumers and 0 messages
                           type: boolean
                         autoDeleteJmsTopics:
+                          description: DEPRECATED. whether or not to delete auto-created JMS topics when the last subscription is closed
                           type: boolean
                         autoDeleteQueues:
+                          description: whether or not to delete auto-created queues when the queue has 0 consumers and 0 messages
                           type: boolean
                         autoDeleteQueuesDelay:
+                          description: how long to wait (in milliseconds) before deleting auto-created queues after the queue has 0 consumers.
                           format: int32
                           type: integer
                         autoDeleteQueuesMessageCount:
+                          description: the message count the queue must be at or below before it can be evaluated to be auto deleted, 0 waits until empty queue (default) and -1 disables this check.
                           format: int32
                           type: integer
                         configDeleteAddresses:
+                          description: What to do when an address is no longer in broker.xml.  OFF = will do nothing addresses will remain, FORCE = delete address and its queues even if messages remaining.
                           type: string
                         configDeleteQueues:
+                          description: What to do when a queue is no longer in broker.xml.  OFF = will do nothing queues will remain, FORCE = delete queues even if messages remaining.
                           type: string
                         deadLetterAddress:
+                          description: the address to send dead messages to
                           type: string
                         deadLetterQueuePrefix:
+                          description: the prefix to use for auto-created dead letter queues
                           type: string
                         deadLetterQueueSuffix:
+                          description: the suffix to use for auto-created dead letter queues
                           type: string
                         defaultAddressRoutingType:
+                          description: the routing-type used on auto-created addresses
                           type: string
                         defaultConsumerWindowSize:
+                          description: the default window size for a consumer
                           format: int32
                           type: integer
                         defaultConsumersBeforeDispatch:
+                          description: the default number of consumers needed before dispatch can start for queues under the address.
                           format: int32
                           type: integer
                         defaultDelayBeforeDispatch:
+                          description: the default delay (in milliseconds) to wait before dispatching if number of consumers before dispatch is not met for queues under the address.
                           format: int32
                           type: integer
                         defaultExclusiveQueue:
+                          description: whether to treat the queues under the address as exclusive queues by default
                           type: boolean
                         defaultGroupBuckets:
+                          description: number of buckets to use for grouping, -1 (default) is unlimited and uses the raw group, 0 disables message groups.
                           format: int32
                           type: integer
                         defaultGroupFirstKey:
+                          description: key used to mark a message is first in a group for a consumer
                           type: string
                         defaultGroupRebalance:
+                          description: whether to rebalance groups when a consumer is added
                           type: boolean
                         defaultGroupRebalancePauseDispatch:
+                          description: whether to pause dispatch when rebalancing groups
                           type: boolean
                         defaultLastValueKey:
+                          description: the property to use as the key for a last value queue by default
                           type: string
                         defaultLastValueQueue:
+                          description: whether to treat the queues under the address as a last value queues by default
                           type: boolean
                         defaultMaxConsumers:
+                          description: the maximum number of consumers allowed on this queue at any one time
                           format: int32
                           type: integer
                         defaultNonDestructive:
+                          description: whether the queue should be non-destructive by default
                           type: boolean
                         defaultPurgeOnNoConsumers:
+                          description: purge the contents of the queue once there are no consumers
                           type: boolean
                         defaultQueueRoutingType:
+                          description: the routing-type used on auto-created queues
                           type: string
                         defaultRingSize:
+                          description: the default ring-size value for any matching queue which doesnt have ring-size explicitly defined
                           format: int32
                           type: integer
                         enableMetrics:
+                          description: whether or not to enable metrics for metrics plugins on the matching address
                           type: boolean
                         expiryAddress:
+                          description: the address to send expired messages to
                           type: string
                         expiryDelay:
+                          description: Overrides the expiration time for messages using the default value for expiration time. "-1" disables this setting.
                           format: int32
                           type: integer
                         expiryQueuePrefix:
+                          description: the prefix to use for auto-created expiry queues
                           type: string
                         expiryQueueSuffix:
+                          description: the suffix to use for auto-created expiry queues
                           type: string
                         lastValueQueue:
+                          description: This is deprecated please use default-last-value-queue instead.
                           type: boolean
                         managementBrowsePageSize:
+                          description: how many message a management resource can browse
                           format: int32
                           type: integer
                         match:
+                          description: pattern for matching settings against addresses; can use wildards
                           type: string
                         maxDeliveryAttempts:
+                          description: how many times to attempt to deliver a message before sending to dead letter address
                           format: int32
                           type: integer
                         maxExpiryDelay:
+                          description: Overrides the expiration time for messages using a higher value. "-1" disables this setting.
                           format: int32
                           type: integer
                         maxRedeliveryDelay:
+                          description: Maximum value for the redelivery-delay
                           format: int32
                           type: integer
                         maxSizeBytes:
+                          description: the maximum size in bytes for an address. -1 means no limits. This is used in PAGING, BLOCK and FAIL policies. Supports byte notation like K, Mb, GB, etc.
                           type: string
                         maxSizeBytesRejectThreshold:
+                          description: used with the address full BLOCK policy, the maximum size in bytes an address can reach before messages start getting rejected. Works in combination with max-size-bytes for AMQP protocol only.  Default = -1 (no limit).
                           format: int32
                           type: integer
                         messageCounterHistoryDayLimit:
+                          description: how many days to keep message counter history for this address
                           format: int32
                           type: integer
                         minExpiryDelay:
+                          description: Overrides the expiration time for messages using a lower value. "-1" disables this setting.
                           format: int32
                           type: integer
                         pageMaxCacheSize:
+                          description: Number of paging files to cache in memory to avoid IO during paging navigation
                           format: int32
                           type: integer
                         pageSizeBytes:
+                          description: The page size in bytes to use for an address. Supports byte notation like K, Mb, GB, etc.
                           type: string
                         redeliveryCollisionAvoidanceFactor:
                           type: number
                         redeliveryDelay:
+                          description: the time (in ms) to wait before redelivering a cancelled message.
                           format: int32
                           type: integer
                         redeliveryDelayMultiplier:
                           format: int32
                           type: integer
                         redistributionDelay:
+                          description: how long (in ms) to wait after the last consumer is closed on a queue before redistributing messages.
                           format: int32
                           type: integer
                         retroactiveMessageCount:
+                          description: the number of messages to preserve for future queues created on the matching address
                           format: int32
                           type: integer
                         sendToDlaOnNoRoute:
+                          description: if there are no queues matching this address, whether to forward message to DLA (if it exists for this address)
                           type: boolean
                         slowConsumerCheckPeriod:
+                          description: How often to check for slow consumers on a particular queue. Measured in seconds.
                           format: int32
                           type: integer
                         slowConsumerPolicy:
+                          description: what happens when a slow consumer is identified
                           type: string
                         slowConsumerThreshold:
+                          description: The minimum rate of message consumption allowed before a consumer is considered "slow." Measured in messages-per-second.
                           format: int32
                           type: integer
                       type: object
                     type: array
                   applyRule:
+                    description: How to merge the address settings to broker configuration
                     type: string
                 type: object
               adminPassword:
+                description: Password for standard broker user. It is required for connecting to the broker and the web console. If left empty, it will be generated.
                 type: string
               adminUser:
+                description: User name for standard broker user. It is required for connecting to the broker and the web console. If left empty, it will be generated.
                 type: string
               connectors:
+                description: Specifies connectors and connector configuration
                 items:
                   properties:
                     enabledCipherSuites:
+                      description: Comma separated list of cipher suites used for SSL communication.
                       type: string
                     enabledProtocols:
+                      description: Comma separated list of protocols used for SSL communication.
                       type: string
                     expose:
+                      description: Whether or not to expose this connector
                       type: boolean
                     host:
+                      description: Hostname or IP to connect to
                       type: string
                     name:
+                      description: The name of the connector
                       type: string
                     needClientAuth:
+                      description: Tells a client connecting to this connector that 2-way SSL is required. This property takes precedence over wantClientAuth.
                       type: boolean
                     port:
+                      description: Port number
                       format: int32
                       type: integer
                     sniHost:
+                      description: A regular expression used to match the server_name extension on incoming SSL connections. If the name doesn't match then the connection to the acceptor will be rejected.
                       type: string
                     sslEnabled:
+                      description: ' Whether or not to enable SSL on this port'
                       type: boolean
                     sslProvider:
+                      description: Used to change the SSL Provider between JDK and OPENSSL. The default is JDK.
                       type: string
                     sslSecret:
+                      description: Name of the secret to use for ssl information
                       type: string
                     type:
+                      description: The type either tcp or vm
                       type: string
                     verifyHost:
+                      description: The CN of the connecting client's SSL certificate will be compared to its hostname to verify they match. This is useful only for 2-way SSL.
                       type: boolean
                     wantClientAuth:
+                      description: Tells a client connecting to this connector that 2-way SSL is requested but not required. Overridden by needClientAuth.
                       type: boolean
                   required:
                   - host
@@ -5410,30 +5603,41 @@ spec:
                   type: object
                 type: array
               console:
+                description: Specifies the console configuration
                 properties:
                   expose:
+                    description: Whether or not to expose this port
                     type: boolean
                   sslEnabled:
+                    description: Whether or not to enable SSL on this port
                     type: boolean
                   sslSecret:
+                    description: Name of the secret to use for ssl information
                     type: string
                   useClientAuth:
+                    description: If the embedded server requires client authentication
                     type: boolean
                 type: object
               deploymentPlan:
+                description: Specifies the deployment plan
                 properties:
                   image:
+                    description: The image used for the broker, all upgrades are disabled. Needs a corresponding initImage
                     type: string
                   journalType:
+                    description: If aio use ASYNCIO, if nio use NIO for journal IO
                     type: string
                   messageMigration:
+                    description: If true migrate messages on scaledown
                     type: boolean
                   persistenceEnabled:
+                    description: If true use persistent volume via persistent volume claim for journal storage
                     type: boolean
                   requireLogin:
+                    description: If true require user password login credentials for broker protocol ports
                     type: boolean
                   resources:
-                    description: ResourceRequirements describes the compute resource requirements.
+                    description: Specifies the minimum/maximum amount of compute resources required/allowed
                     properties:
                       claims:
                         description: |-
@@ -5486,26 +5690,32 @@ spec:
                         type: object
                     type: object
                   size:
+                    description: The number of broker pods to deploy
                     format: int32
                     type: integer
                   storage:
+                    description: Specifies the storage configurations
                     properties:
                       size:
+                        description: The storage size
                         type: string
                     type: object
                 type: object
               upgrades:
-                description: ActiveMQArtemis App product upgrade flags
+                description: Specifies the upgrades (deprecated in favour of Version)
                 properties:
                   enabled:
+                    description: Set true to enable automatic micro version product upgrades, it is disabled by default.
                     type: boolean
                   minor:
+                    description: Set true to enable automatic minor product version upgrades, it is disabled by default. Requires spec.upgrades.enabled to be true.
                     type: boolean
                 required:
                 - enabled
                 - minor
                 type: object
               version:
+                description: The desired version of the broker. Can be x, or x.y or x.y.z to configure upgrades
                 type: string
             type: object
           status:
@@ -5570,6 +5780,7 @@ spec:
                   type: object
                 type: array
               podStatus:
+                description: The current pods
                 properties:
                   ready:
                     description: Deployments are ready to serve requests
@@ -5598,7 +5809,7 @@ spec:
   - name: v2alpha4
     schema:
       openAPIV3Schema:
-        description: ActiveMQArtemis is the Schema for the activemqartemises API
+        description: A stateful deployment of one or more brokers
         properties:
           apiVersion:
             description: |-
@@ -5621,240 +5832,338 @@ spec:
             description: ActiveMQArtemisSpec defines the desired state of ActiveMQArtemis
             properties:
               acceptors:
+                description: Specifies the acceptor configuration
                 items:
                   properties:
                     amqpMinLargeMessageSize:
+                      description: AMQP Minimum Large Message Size
                       type: integer
                     anycastPrefix:
+                      description: To indicate which kind of routing type to use.
                       type: string
                     connectionsAllowed:
+                      description: Max number of connections allowed to make
                       type: integer
                     enabledCipherSuites:
+                      description: Comma separated list of cipher suites used for SSL communication.
                       type: string
                     enabledProtocols:
+                      description: Comma separated list of protocols used for SSL communication.
                       type: string
                     expose:
+                      description: Whether or not to expose this acceptor
                       type: boolean
                     multicastPrefix:
+                      description: To indicate which kind of routing type to use
                       type: string
                     name:
+                      description: The acceptor name
                       type: string
                     needClientAuth:
+                      description: Tells a client connecting to this acceptor that 2-way SSL is required. This property takes precedence over wantClientAuth.
                       type: boolean
                     port:
+                      description: Port number
                       format: int32
                       type: integer
                     protocols:
+                      description: The protocols to enable for this acceptor
                       type: string
                     sniHost:
+                      description: A regular expression used to match the server_name extension on incoming SSL connections. If the name doesn't match then the connection to the acceptor will be rejected.
                       type: string
                     sslEnabled:
+                      description: Whether or not to enable SSL on this port
                       type: boolean
                     sslProvider:
+                      description: Used to change the SSL Provider between JDK and OPENSSL. The default is JDK.
                       type: string
                     sslSecret:
+                      description: Name of the secret to use for ssl information
                       type: string
                     verifyHost:
+                      description: The CN of the connecting client's SSL certificate will be compared to its hostname to verify they match. This is useful only for 2-way SSL.
                       type: boolean
                     wantClientAuth:
+                      description: Tells a client connecting to this acceptor that 2-way SSL is requested but not required. Overridden by needClientAuth.
                       type: boolean
                   required:
                   - name
                   type: object
                 type: array
               addressSettings:
+                description: Specifies the address configurations (deprecated in favour of BrokerProperties)
                 properties:
                   addressSetting:
+                    description: Specifies the address settings
                     items:
                       properties:
                         addressFullPolicy:
+                          description: what happens when an address where maxSizeBytes is specified becomes full
                           type: string
                         autoCreateAddresses:
+                          description: whether or not to automatically create addresses when a client sends a message to or attempts to consume a message from a queue mapped to an address that doesnt exist
                           type: boolean
                         autoCreateDeadLetterResources:
+                          description: whether or not to automatically create the dead-letter-address and/or a corresponding queue on that address when a message found to be undeliverable
                           type: boolean
                         autoCreateExpiryResources:
+                          description: whether or not to automatically create the expiry-address and/or a corresponding queue on that address when a message is sent to a matching queue
                           type: boolean
                         autoCreateJmsQueues:
+                          description: DEPRECATED. whether or not to automatically create JMS queues when a producer sends or a consumer connects to a queue
                           type: boolean
                         autoCreateJmsTopics:
+                          description: DEPRECATED. whether or not to automatically create JMS topics when a producer sends or a consumer subscribes to a topic
                           type: boolean
                         autoCreateQueues:
+                          description: whether or not to automatically create a queue when a client sends a message to or attempts to consume a message from a queue
                           type: boolean
                         autoDeleteAddresses:
+                          description: whether or not to delete auto-created addresses when it no longer has any queues
                           type: boolean
                         autoDeleteAddressesDelay:
+                          description: how long to wait (in milliseconds) before deleting auto-created addresses after they no longer have any queues
                           format: int32
                           type: integer
                         autoDeleteCreatedQueues:
+                          description: whether or not to delete created queues when the queue has 0 consumers and 0 messages
                           type: boolean
                         autoDeleteJmsQueues:
+                          description: DEPRECATED. whether or not to delete auto-created JMS queues when the queue has 0 consumers and 0 messages
                           type: boolean
                         autoDeleteJmsTopics:
+                          description: DEPRECATED. whether or not to delete auto-created JMS topics when the last subscription is closed
                           type: boolean
                         autoDeleteQueues:
+                          description: whether or not to delete auto-created queues when the queue has 0 consumers and 0 messages
                           type: boolean
                         autoDeleteQueuesDelay:
+                          description: how long to wait (in milliseconds) before deleting auto-created queues after the queue has 0 consumers.
                           format: int32
                           type: integer
                         autoDeleteQueuesMessageCount:
+                          description: the message count the queue must be at or below before it can be evaluated to be auto deleted, 0 waits until empty queue (default) and -1 disables this check.
                           format: int32
                           type: integer
                         configDeleteAddresses:
+                          description: What to do when an address is no longer in broker.xml.  OFF = will do nothing addresses will remain, FORCE = delete address and its queues even if messages remaining.
                           type: string
                         configDeleteQueues:
+                          description: What to do when a queue is no longer in broker.xml.  OFF = will do nothing queues will remain, FORCE = delete queues even if messages remaining.
                           type: string
                         deadLetterAddress:
+                          description: the address to send dead messages to
                           type: string
                         deadLetterQueuePrefix:
+                          description: the prefix to use for auto-created dead letter queues
                           type: string
                         deadLetterQueueSuffix:
+                          description: the suffix to use for auto-created dead letter queues
                           type: string
                         defaultAddressRoutingType:
+                          description: the routing-type used on auto-created addresses
                           type: string
                         defaultConsumerWindowSize:
+                          description: the default window size for a consumer
                           format: int32
                           type: integer
                         defaultConsumersBeforeDispatch:
+                          description: the default number of consumers needed before dispatch can start for queues under the address.
                           format: int32
                           type: integer
                         defaultDelayBeforeDispatch:
+                          description: the default delay (in milliseconds) to wait before dispatching if number of consumers before dispatch is not met for queues under the address.
                           format: int32
                           type: integer
                         defaultExclusiveQueue:
+                          description: whether to treat the queues under the address as exclusive queues by default
                           type: boolean
                         defaultGroupBuckets:
+                          description: number of buckets to use for grouping, -1 (default) is unlimited and uses the raw group, 0 disables message groups.
                           format: int32
                           type: integer
                         defaultGroupFirstKey:
+                          description: key used to mark a message is first in a group for a consumer
                           type: string
                         defaultGroupRebalance:
+                          description: whether to rebalance groups when a consumer is added
                           type: boolean
                         defaultGroupRebalancePauseDispatch:
+                          description: whether to pause dispatch when rebalancing groups
                           type: boolean
                         defaultLastValueKey:
+                          description: the property to use as the key for a last value queue by default
                           type: string
                         defaultLastValueQueue:
+                          description: whether to treat the queues under the address as a last value queues by default
                           type: boolean
                         defaultMaxConsumers:
+                          description: the maximum number of consumers allowed on this queue at any one time
                           format: int32
                           type: integer
                         defaultNonDestructive:
+                          description: whether the queue should be non-destructive by default
                           type: boolean
                         defaultPurgeOnNoConsumers:
+                          description: purge the contents of the queue once there are no consumers
                           type: boolean
                         defaultQueueRoutingType:
+                          description: the routing-type used on auto-created queues
                           type: string
                         defaultRingSize:
+                          description: the default ring-size value for any matching queue which doesnt have ring-size explicitly defined
                           format: int32
                           type: integer
                         enableMetrics:
+                          description: whether or not to enable metrics for metrics plugins on the matching address
                           type: boolean
                         expiryAddress:
+                          description: the address to send expired messages to
                           type: string
                         expiryDelay:
+                          description: Overrides the expiration time for messages using the default value for expiration time. "-1" disables this setting.
                           format: int32
                           type: integer
                         expiryQueuePrefix:
+                          description: the prefix to use for auto-created expiry queues
                           type: string
                         expiryQueueSuffix:
+                          description: the suffix to use for auto-created expiry queues
                           type: string
                         lastValueQueue:
+                          description: This is deprecated please use default-last-value-queue instead.
                           type: boolean
                         managementBrowsePageSize:
+                          description: how many message a management resource can browse
                           format: int32
                           type: integer
                         match:
+                          description: pattern for matching settings against addresses; can use wildards
                           type: string
                         maxDeliveryAttempts:
+                          description: how many times to attempt to deliver a message before sending to dead letter address
                           format: int32
                           type: integer
                         maxExpiryDelay:
+                          description: Overrides the expiration time for messages using a higher value. "-1" disables this setting.
                           format: int32
                           type: integer
                         maxRedeliveryDelay:
+                          description: Maximum value for the redelivery-delay
                           format: int32
                           type: integer
                         maxSizeBytes:
+                          description: the maximum size in bytes for an address. -1 means no limits. This is used in PAGING, BLOCK and FAIL policies. Supports byte notation like K, Mb, GB, etc.
                           type: string
                         maxSizeBytesRejectThreshold:
+                          description: used with the address full BLOCK policy, the maximum size in bytes an address can reach before messages start getting rejected. Works in combination with max-size-bytes for AMQP protocol only.  Default = -1 (no limit).
                           format: int32
                           type: integer
                         messageCounterHistoryDayLimit:
+                          description: how many days to keep message counter history for this address
                           format: int32
                           type: integer
                         minExpiryDelay:
+                          description: Overrides the expiration time for messages using a lower value. "-1" disables this setting.
                           format: int32
                           type: integer
                         pageMaxCacheSize:
+                          description: Number of paging files to cache in memory to avoid IO during paging navigation
                           format: int32
                           type: integer
                         pageSizeBytes:
+                          description: The page size in bytes to use for an address. Supports byte notation like K, Mb, GB, etc.
                           type: string
                         redeliveryCollisionAvoidanceFactor:
                           type: number
                         redeliveryDelay:
+                          description: the time (in ms) to wait before redelivering a cancelled message.
                           format: int32
                           type: integer
                         redeliveryDelayMultiplier:
                           format: int32
                           type: integer
                         redistributionDelay:
+                          description: how long (in ms) to wait after the last consumer is closed on a queue before redistributing messages.
                           format: int32
                           type: integer
                         retroactiveMessageCount:
+                          description: the number of messages to preserve for future queues created on the matching address
                           format: int32
                           type: integer
                         sendToDlaOnNoRoute:
+                          description: if there are no queues matching this address, whether to forward message to DLA (if it exists for this address)
                           type: boolean
                         slowConsumerCheckPeriod:
+                          description: How often to check for slow consumers on a particular queue. Measured in seconds.
                           format: int32
                           type: integer
                         slowConsumerPolicy:
+                          description: what happens when a slow consumer is identified
                           type: string
                         slowConsumerThreshold:
+                          description: The minimum rate of message consumption allowed before a consumer is considered "slow." Measured in messages-per-second.
                           format: int32
                           type: integer
                       type: object
                     type: array
                   applyRule:
+                    description: How to merge the address settings to broker configuration
                     type: string
                 type: object
               adminPassword:
+                description: Password for standard broker user. It is required for connecting to the broker and the web console. If left empty, it will be generated.
                 type: string
               adminUser:
+                description: User name for standard broker user. It is required for connecting to the broker and the web console. If left empty, it will be generated.
                 type: string
               connectors:
+                description: Specifies connectors and connector configuration
                 items:
                   properties:
                     enabledCipherSuites:
+                      description: Comma separated list of cipher suites used for SSL communication.
                       type: string
                     enabledProtocols:
+                      description: Comma separated list of protocols used for SSL communication.
                       type: string
                     expose:
+                      description: Whether or not to expose this connector
                       type: boolean
                     host:
+                      description: Hostname or IP to connect to
                       type: string
                     name:
+                      description: The name of the connector
                       type: string
                     needClientAuth:
+                      description: Tells a client connecting to this connector that 2-way SSL is required. This property takes precedence over wantClientAuth.
                       type: boolean
                     port:
+                      description: Port number
                       format: int32
                       type: integer
                     sniHost:
+                      description: A regular expression used to match the server_name extension on incoming SSL connections. If the name doesn't match then the connection to the acceptor will be rejected.
                       type: string
                     sslEnabled:
+                      description: ' Whether or not to enable SSL on this port'
                       type: boolean
                     sslProvider:
+                      description: Used to change the SSL Provider between JDK and OPENSSL. The default is JDK.
                       type: string
                     sslSecret:
+                      description: Name of the secret to use for ssl information
                       type: string
                     type:
+                      description: The type either tcp or vm
                       type: string
                     verifyHost:
+                      description: The CN of the connecting client's SSL certificate will be compared to its hostname to verify they match. This is useful only for 2-way SSL.
                       type: boolean
                     wantClientAuth:
+                      description: Tells a client connecting to this connector that 2-way SSL is requested but not required. Overridden by needClientAuth.
                       type: boolean
                   required:
                   - host
@@ -5863,36 +6172,50 @@ spec:
                   type: object
                 type: array
               console:
+                description: Specifies the console configuration
                 properties:
                   expose:
+                    description: Whether or not to expose this port
                     type: boolean
                   sslEnabled:
+                    description: Whether or not to enable SSL on this port
                     type: boolean
                   sslSecret:
+                    description: Name of the secret to use for ssl information
                     type: string
                   useClientAuth:
+                    description: If the embedded server requires client authentication
                     type: boolean
                 type: object
               deploymentPlan:
+                description: Specifies the deployment plan
                 properties:
                   image:
+                    description: The image used for the broker, all upgrades are disabled. Needs a corresponding initImage
                     type: string
                   initImage:
+                    description: The init container image used to configure broker, all upgrades are disabled. Needs a corresponding image
                     type: string
                   jolokiaAgentEnabled:
+                    description: If true enable the Jolokia JVM Agent
                     type: boolean
                   journalType:
+                    description: If aio use ASYNCIO, if nio use NIO for journal IO
                     type: string
                   managementRBACEnabled:
+                    description: If true enable the management role based access control
                     type: boolean
                   messageMigration:
+                    description: If true migrate messages on scaledown
                     type: boolean
                   persistenceEnabled:
+                    description: If true use persistent volume via persistent volume claim for journal storage
                     type: boolean
                   requireLogin:
+                    description: If true require user password login credentials for broker protocol ports
                     type: boolean
                   resources:
-                    description: ResourceRequirements describes the compute resource requirements.
+                    description: Specifies the minimum/maximum amount of compute resources required/allowed
                     properties:
                       claims:
                         description: |-
@@ -5945,26 +6268,32 @@ spec:
                         type: object
                     type: object
                   size:
+                    description: The number of broker pods to deploy
                     format: int32
                     type: integer
                   storage:
+                    description: Specifies the storage configurations
                     properties:
                       size:
+                        description: The storage size
                         type: string
                     type: object
                 type: object
               upgrades:
-                description: ActiveMQArtemis App product upgrade flags
+                description: Specifies the upgrades (deprecated in favour of Version)
                 properties:
                   enabled:
+                    description: Set true to enable automatic micro version product upgrades, it is disabled by default.
                     type: boolean
                   minor:
+                    description: Set true to enable automatic minor product version upgrades, it is disabled by default. Requires spec.upgrades.enabled to be true.
                     type: boolean
                 required:
                 - enabled
                 - minor
                 type: object
               version:
+                description: The desired version of the broker. Can be x, or x.y or x.y.z to configure upgrades
                 type: string
             type: object
           status:
@@ -6029,6 +6358,7 @@ spec:
                   type: object
                 type: array
               podStatus:
+                description: The current pods
                 properties:
                   ready:
                     description: Deployments are ready to serve requests
@@ -6057,7 +6387,7 @@ spec:
   - name: v2alpha5
     schema:
       openAPIV3Schema:
-        description: ActiveMQArtemis is the Schema for the activemqartemises API
+        description: A stateful deployment of one or more brokers
         properties:
           apiVersion:
             description: |-
@@ -6080,250 +6410,353 @@ spec:
             description: ActiveMQArtemisSpec defines the desired state of ActiveMQArtemis
             properties:
               acceptors:
+                description: Specifies the acceptor configuration
                 items:
                   properties:
                     amqpMinLargeMessageSize:
+                      description: AMQP Minimum Large Message Size
                       type: integer
                     anycastPrefix:
+                      description: To indicate which kind of routing type to use.
                       type: string
                     connectionsAllowed:
+                      description: Max number of connections allowed to make
                       type: integer
                     enabledCipherSuites:
+                      description: Comma separated list of cipher suites used for SSL communication.
                       type: string
                     enabledProtocols:
+                      description: Comma separated list of protocols used for SSL communication.
                       type: string
                     expose:
+                      description: Whether or not to expose this acceptor
                       type: boolean
                     multicastPrefix:
+                      description: To indicate which kind of routing type to use
                       type: string
                     name:
+                      description: The acceptor name
                       type: string
                     needClientAuth:
+                      description: Tells a client connecting to this acceptor that 2-way SSL is required. This property takes precedence over wantClientAuth.
                       type: boolean
                     port:
+                      description: Port number
                       format: int32
                       type: integer
                     protocols:
+                      description: The protocols to enable for this acceptor
                       type: string
                     sniHost:
+                      description: A regular expression used to match the server_name extension on incoming SSL connections. If the name doesn't match then the connection to the acceptor will be rejected.
                       type: string
                     sslEnabled:
+                      description: Whether or not to enable SSL on this port
                       type: boolean
                     sslProvider:
+                      description: Used to change the SSL Provider between JDK and OPENSSL. The default is JDK.
                       type: string
                     sslSecret:
+                      description: Name of the secret to use for ssl information
                       type: string
                     supportAdvisory:
+                      description: For openwire protocol if advisory topics are enabled, default false
                       type: boolean
                     suppressInternalManagementObjects:
+                      description: If prevents advisory addresses/queues to be registered to management service, default false
                       type: boolean
                     verifyHost:
+                      description: The CN of the connecting client's SSL certificate will be compared to its hostname to verify they match. This is useful only for 2-way SSL.
                       type: boolean
                     wantClientAuth:
+                      description: Tells a client connecting to this acceptor that 2-way SSL is requested but not required. Overridden by needClientAuth.
                       type: boolean
                   required:
                   - name
                   type: object
                 type: array
               addressSettings:
+                description: Specifies the address configurations (deprecated in favour of BrokerProperties)
                 properties:
                   addressSetting:
+                    description: Specifies the address settings
                     items:
                       properties:
                         addressFullPolicy:
+                          description: what happens when an address where maxSizeBytes is specified becomes full
                           type: string
                         autoCreateAddresses:
+                          description: whether or not to automatically create addresses when a client sends a message to or attempts to consume a message from a queue mapped to an address that doesnt exist
                           type: boolean
                         autoCreateDeadLetterResources:
+                          description: whether or not to automatically create the dead-letter-address and/or a corresponding queue on that address when a message found to be undeliverable
                           type: boolean
                         autoCreateExpiryResources:
+                          description: whether or not to automatically create the expiry-address and/or a corresponding queue on that address when a message is sent to a matching queue
                           type: boolean
                         autoCreateJmsQueues:
+                          description: DEPRECATED. whether or not to automatically create JMS queues when a producer sends or a consumer connects to a queue
                           type: boolean
                         autoCreateJmsTopics:
+                          description: DEPRECATED. whether or not to automatically create JMS topics when a producer sends or a consumer subscribes to a topic
                           type: boolean
                         autoCreateQueues:
+                          description: whether or not to automatically create a queue when a client sends a message to or attempts to consume a message from a queue
                           type: boolean
                         autoDeleteAddresses:
+                          description: whether or not to delete auto-created addresses when it no longer has any queues
                           type: boolean
                         autoDeleteAddressesDelay:
+                          description: how long to wait (in milliseconds) before deleting auto-created addresses after they no longer have any queues
                           format: int32
                           type: integer
                         autoDeleteCreatedQueues:
+                          description: whether or not to delete created queues when the queue has 0 consumers and 0 messages
                           type: boolean
                         autoDeleteJmsQueues:
+                          description: DEPRECATED. whether or not to delete auto-created JMS queues when the queue has 0 consumers and 0 messages
                           type: boolean
                         autoDeleteJmsTopics:
+                          description: DEPRECATED. whether or not to delete auto-created JMS topics when the last subscription is closed
                           type: boolean
                         autoDeleteQueues:
+                          description: whether or not to delete auto-created queues when the queue has 0 consumers and 0 messages
                           type: boolean
                         autoDeleteQueuesDelay:
+                          description: how long to wait (in milliseconds) before deleting auto-created queues after the queue has 0 consumers.
                           format: int32
                           type: integer
                         autoDeleteQueuesMessageCount:
+                          description: the message count the queue must be at or below before it can be evaluated to be auto deleted, 0 waits until empty queue (default) and -1 disables this check.
                           format: int32
                           type: integer
                         configDeleteAddresses:
+                          description: What to do when an address is no longer in broker.xml.  OFF = will do nothing addresses will remain, FORCE = delete address and its queues even if messages remaining.
                           type: string
                         configDeleteQueues:
+                          description: What to do when a queue is no longer in broker.xml.  OFF = will do nothing queues will remain, FORCE = delete queues even if messages remaining.
                           type: string
                         deadLetterAddress:
+                          description: the address to send dead messages to
                           type: string
                         deadLetterQueuePrefix:
+                          description: the prefix to use for auto-created dead letter queues
                           type: string
                         deadLetterQueueSuffix:
+                          description: the suffix to use for auto-created dead letter queues
                           type: string
                         defaultAddressRoutingType:
+                          description: the routing-type used on auto-created addresses
                           type: string
                         defaultConsumerWindowSize:
+                          description: the default window size for a consumer
                           format: int32
                           type: integer
                         defaultConsumersBeforeDispatch:
+                          description: the default number of consumers needed before dispatch can start for queues under the address.
                           format: int32
                           type: integer
                         defaultDelayBeforeDispatch:
+                          description: the default delay (in milliseconds) to wait before dispatching if number of consumers before dispatch is not met for queues under the address.
                           format: int32
                           type: integer
                         defaultExclusiveQueue:
+                          description: whether to treat the queues under the address as exclusive queues by default
                           type: boolean
                         defaultGroupBuckets:
+                          description: number of buckets to use for grouping, -1 (default) is unlimited and uses the raw group, 0 disables message groups.
                           format: int32
                           type: integer
                         defaultGroupFirstKey:
+                          description: key used to mark a message is first in a group for a consumer
                           type: string
                         defaultGroupRebalance:
+                          description: whether to rebalance groups when a consumer is added
                           type: boolean
                         defaultGroupRebalancePauseDispatch:
+                          description: whether to pause dispatch when rebalancing groups
                           type: boolean
                         defaultLastValueKey:
+                          description: the property to use as the key for a last value queue by default
                           type: string
                         defaultLastValueQueue:
+                          description: whether to treat the queues under the address as a last value queues by default
                           type: boolean
                         defaultMaxConsumers:
+                          description: the maximum number of consumers allowed on this queue at any one time
                           format: int32
                           type: integer
                         defaultNonDestructive:
+                          description: whether the queue should be non-destructive by default
                           type: boolean
                         defaultPurgeOnNoConsumers:
+                          description: purge the contents of the queue once there are no consumers
                           type: boolean
                         defaultQueueRoutingType:
+                          description: the routing-type used on auto-created queues
                           type: string
                         defaultRingSize:
+                          description: the default ring-size value for any matching queue which doesnt have ring-size explicitly defined
                           format: int32
                           type: integer
                         enableIngressTimestamp:
+                          description: Whether or not set the timestamp of arrival on messages. default false
                           type: boolean
                         enableMetrics:
+                          description: whether or not to enable metrics for metrics plugins on the matching address
                           type: boolean
                         expiryAddress:
+                          description: the address to send expired messages to
                           type: string
                         expiryDelay:
+                          description: Overrides the expiration time for messages using the default value for expiration time. "-1" disables this setting.
                           format: int32
                           type: integer
                         expiryQueuePrefix:
+                          description: the prefix to use for auto-created expiry queues
                           type: string
                         expiryQueueSuffix:
+                          description: the suffix to use for auto-created expiry queues
                           type: string
                         lastValueQueue:
+                          description: This is deprecated please use default-last-value-queue instead.
                           type: boolean
                         managementBrowsePageSize:
+                          description: how many message a management resource can browse
                           format: int32
                           type: integer
                         managementMessageAttributeSizeLimit:
+                          description: max size of the message returned from management API, default 256
                           format: int32
                           type: integer
                         match:
+                          description: pattern for matching settings against addresses; can use wildards
                           type: string
                         maxDeliveryAttempts:
+                          description: how many times to attempt to deliver a message before sending to dead letter address
                           format: int32
                           type: integer
                         maxExpiryDelay:
+                          description: Overrides the expiration time for messages using a higher value. "-1" disables this setting.
                           format: int32
                           type: integer
                         maxRedeliveryDelay:
+                          description: Maximum value for the redelivery-delay
                           format: int32
                           type: integer
                         maxSizeBytes:
+                          description: the maximum size in bytes for an address. -1 means no limits. This is used in PAGING, BLOCK and FAIL policies. Supports byte notation like K, Mb, GB, etc.
                           type: string
                         maxSizeBytesRejectThreshold:
+                          description: used with the address full BLOCK policy, the maximum size in bytes an address can reach before messages start getting rejected. Works in combination with max-size-bytes for AMQP protocol only.  Default = -1 (no limit).
                           format: int32
                           type: integer
                         messageCounterHistoryDayLimit:
+                          description: how many days to keep message counter history for this address
                           format: int32
                           type: integer
                         minExpiryDelay:
+                          description: Overrides the expiration time for messages using a lower value. "-1" disables this setting.
                           format: int32
                           type: integer
                         pageMaxCacheSize:
+                          description: Number of paging files to cache in memory to avoid IO during paging navigation
                           format: int32
                           type: integer
                         pageSizeBytes:
+                          description: The page size in bytes to use for an address. Supports byte notation like K, Mb, GB, etc.
                           type: string
                         redeliveryCollisionAvoidanceFactor:
                           type: number
                         redeliveryDelay:
+                          description: the time (in ms) to wait before redelivering a cancelled message.
                           format: int32
                           type: integer
                         redeliveryDelayMultiplier:
                           type: number
                         redistributionDelay:
+                          description: how long (in ms) to wait after the last consumer is closed on a queue before redistributing messages.
                           format: int32
                           type: integer
                         retroactiveMessageCount:
+                          description: the number of messages to preserve for future queues created on the matching address
                           format: int32
                           type: integer
                         sendToDlaOnNoRoute:
+                          description: if there are no queues matching this address, whether to forward message to DLA (if it exists for this address)
                           type: boolean
                         slowConsumerCheckPeriod:
+                          description: How often to check for slow consumers on a particular queue. Measured in seconds.
                           format: int32
                           type: integer
                         slowConsumerPolicy:
+                          description: what happens when a slow consumer is identified
                           type: string
                         slowConsumerThreshold:
+                          description: The minimum rate of message consumption allowed before a consumer is considered "slow." Measured in messages-per-second.
                           format: int32
                           type: integer
                         slowConsumerThresholdMeasurementUnit:
+                          description: Unit used in specifying slow consumer threshold, default is MESSAGE_PER_SECOND
                           type: string
                       type: object
                     type: array
                   applyRule:
+                    description: How to merge the address settings to broker configuration
                     type: string
                 type: object
               adminPassword:
+                description: Password for standard broker user. It is required for connecting to the broker and the web console. If left empty, it will be generated.
                 type: string
               adminUser:
+                description: User name for standard broker user. It is required for connecting to the broker and the web console. If left empty, it will be generated.
                 type: string
               connectors:
+                description: Specifies connectors and connector configuration
                 items:
                   properties:
                     enabledCipherSuites:
+                      description: Comma separated list of cipher suites used for SSL communication.
                       type: string
                     enabledProtocols:
+                      description: Comma separated list of protocols used for SSL communication.
                       type: string
                     expose:
+                      description: Whether or not to expose this connector
                       type: boolean
                     host:
+                      description: Hostname or IP to connect to
                       type: string
                     name:
+                      description: The name of the connector
                       type: string
                     needClientAuth:
+                      description: Tells a client connecting to this connector that 2-way SSL is required. This property takes precedence over wantClientAuth.
                       type: boolean
                     port:
+                      description: Port number
                       format: int32
                       type: integer
                     sniHost:
+                      description: A regular expression used to match the server_name extension on incoming SSL connections. If the name doesn't match then the connection to the acceptor will be rejected.
                       type: string
                     sslEnabled:
+                      description: ' Whether or not to enable SSL on this port'
                       type: boolean
                     sslProvider:
+                      description: Used to change the SSL Provider between JDK and OPENSSL. The default is JDK.
                       type: string
                     sslSecret:
+                      description: Name of the secret to use for ssl information
                       type: string
                     type:
+                      description: The type either tcp or vm
                       type: string
                     verifyHost:
+                      description: The CN of the connecting client's SSL certificate will be compared to its hostname to verify they match. This is useful only for 2-way SSL.
                       type: boolean
                     wantClientAuth:
+                      description: Tells a client connecting to this connector that 2-way SSL is requested but not required. Overridden by needClientAuth.
                       type: boolean
                   required:
                   - host
@@ -6332,71 +6765,95 @@ spec:
                   type: object
                 type: array
               console:
+                description: Specifies the console configuration
                 properties:
                   expose:
+                    description: Whether or not to expose this port
                     type: boolean
                   sslEnabled:
+                    description: Whether or not to enable SSL on this port
                     type: boolean
                   sslSecret:
+                    description: Name of the secret to use for ssl information
                     type: string
                   useClientAuth:
+                    description: If the embedded server requires client authentication
                     type: boolean
                 type: object
               deploymentPlan:
+                description: Specifies the deployment plan
                 properties:
                   clustered:
+                    description: Whether broker is clustered
                     type: boolean
                   enableMetricsPlugin:
+                    description: Whether or not to install the artemis metrics plugin
                     type: boolean
                   extraMounts:
+                    description: Specifies extra mounts
                     properties:
                       configMaps:
+                        description: Specifies ConfigMap names
                         items:
                           type: string
                         type: array
                       secrets:
+                        description: Specifies Secret names
                         items:
                           type: string
                         type: array
                     type: object
                   image:
+                    description: The image used for the broker, all upgrades are disabled. Needs a corresponding initImage
                     type: string
                   initImage:
+                    description: The init container image used to configure broker, all upgrades are disabled. Needs a corresponding image
                     type: string
                   jolokiaAgentEnabled:
+                    description: If true enable the Jolokia JVM Agent
                     type: boolean
                   journalType:
+                    description: If aio use ASYNCIO, if nio use NIO for journal IO
                     type: string
                   livenessProbe:
+                    description: Specifies the liveness probe configuration
                     properties:
                       timeoutSeconds:
                         format: int32
                         type: integer
                     type: object
                   managementRBACEnabled:
+                    description: If true enable the management role based access control
                     type: boolean
                   messageMigration:
+                    description: If true migrate messages on scaledown
                     type: boolean
                   persistenceEnabled:
+                    description: If true use persistent volume via persistent volume claim for journal storage
                     type: boolean
                   podSecurity:
+                    description: Specifies the pod security configurations
                     properties:
                       runAsUser:
+                        description: runAsUser as defined in PodSecurityContext for the pod
                         format: int64
                         type: integer
                       serviceAccountName:
+                        description: ServiceAccount Name of the pod
                         type: string
                     type: object
                   readinessProbe:
+                    description: Specifies the readiness probe configuration
                     properties:
                       timeoutSeconds:
                         format: int32
                         type: integer
                     type: object
                   requireLogin:
+                    description: If true require user password login credentials for broker protocol ports
                     type: boolean
                   resources:
-                    description: ResourceRequirements describes the compute resource requirements.
+                    description: Specifies the minimum/maximum amount of compute resources required/allowed
                     properties:
                       claims:
                         description: |-
@@ -6449,26 +6906,32 @@ spec:
                         type: object
                     type: object
                   size:
+                    description: The number of broker pods to deploy
                     format: int32
                     type: integer
                   storage:
+                    description: Specifies the storage configurations
                     properties:
                       size:
+                        description: The storage size
                         type: string
                     type: object
                 type: object
               upgrades:
-                description: ActiveMQArtemis App product upgrade flags
+                description: Specifies the upgrades (deprecated in favour of Version)
                 properties:
                   enabled:
+                    description: Set true to enable automatic micro version product upgrades, it is disabled by default.
                     type: boolean
                   minor:
+                    description: Set true to enable automatic minor product version upgrades, it is disabled by default. Requires spec.upgrades.enabled to be true.
                     type: boolean
                 required:
                 - enabled
                 - minor
                 type: object
               version:
+                description: The desired version of the broker. Can be x, or x.y or x.y.z to configure upgrades
                 type: string
             type: object
           status:
@@ -6533,9 +6996,7 @@ spec:
                   type: object
                 type: array
               podStatus:
-                description: |-
-                  INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
-                  Important: Run "make" to regenerate code after modifying this file
+                description: The current pods
                 properties:
                   ready:
                     description: Deployments are ready to serve requests

--- a/deploy/crds/broker_activemqartemisaddress_crd.yaml
+++ b/deploy/crds/broker_activemqartemisaddress_crd.yaml
@@ -228,7 +228,7 @@ spec:
     name: v2alpha1
     schema:
       openAPIV3Schema:
-        description: ActiveMQArtemisAddress is the Schema for the activemqartemisaddresses API
+        description: Adding and removing addresses using custom resource definitions
         properties:
           apiVersion:
             description: |-
@@ -251,10 +251,13 @@ spec:
             description: ActiveMQArtemisAddressSpec defines the desired state of ActiveMQArtemisAddress
             properties:
               addressName:
+                description: The Address Name
                 type: string
               queueName:
+                description: The Queue Name
                 type: string
               routingType:
+                description: The Routing Type
                 type: string
             type: object
           status:
@@ -329,7 +332,7 @@ spec:
     name: v2alpha2
     schema:
       openAPIV3Schema:
-        description: ActiveMQArtemisAddress is the Schema for the activemqartemisaddresses API
+        description: Adding and removing addresses using custom resource definitions
         properties:
           apiVersion:
             description: |-
@@ -352,12 +355,16 @@ spec:
             description: ActiveMQArtemisAddressSpec defines the desired state of ActiveMQArtemisAddress
             properties:
               addressName:
+                description: The Address Name
                 type: string
               queueName:
+                description: The Queue Name
                 type: string
               removeFromBrokerOnDelete:
+                description: Whether or not delete the queue from broker when CR is undeployed(default false)
                 type: boolean
               routingType:
+                description: The Routing Type
                 type: string
             type: object
           status:
@@ -432,7 +439,7 @@ spec:
     name: v2alpha3
     schema:
       openAPIV3Schema:
-        description: ActiveMQArtemisAddress is the Schema for the activemqartemisaddresses API
+        description: Adding and removing addresses using custom resource definitions
         properties:
           apiVersion:
             description: |-
@@ -455,83 +462,117 @@ spec:
             description: ActiveMQArtemisAddressSpec defines the desired state of ActiveMQArtemisAddress
             properties:
               addressName:
+                description: The Address Name
                 type: string
               applyToCrNames:
+                description: Apply to the broker crs in the current namespace. A value of * or empty string means applying to all broker crs. Default apply to all broker crs
                 items:
                   type: string
                 type: array
               password:
+                description: The password for the user
                 type: string
               queueConfiguration:
+                description: Specify the queue configuration
                 properties:
                   autoCreateAddress:
+                    description: Whether auto create address
                     type: boolean
                   autoDelete:
+                    description: Auto-delete the queue
                     type: boolean
                   autoDeleteDelay:
+                    description: Delay (Milliseconds) before auto-delete the queue
                     format: int64
                     type: integer
                   autoDeleteMessageCount:
+                    description: Message count of the queue to allow auto delete
                     format: int64
                     type: integer
                   configurationManaged:
+                    description: ' If the queue is configuration managed'
                     type: boolean
                   consumerPriority:
+                    description: Consumer Priority
                     format: int32
                     type: integer
                   consumersBeforeDispatch:
+                    description: Number of consumers required before dispatching messages
                     format: int32
                     type: integer
                   delayBeforeDispatch:
+                    description: Milliseconds to wait for `consumers-before-dispatch` to be met before dispatching messages anyway
                     format: int64
                     type: integer
                   durable:
+                    description: If the queue is durable or not
                     type: boolean
                   enabled:
+                    description: If the queue is enabled
                     type: boolean
                   exclusive:
+                    description: If the queue is exclusive
                     type: boolean
                   filterString:
+                    description: The filter string for the queue
                     type: string
                   groupBuckets:
+                    description: Number of messaging group buckets
                     format: int32
                     type: integer
                   groupFirstKey:
+                    description: Header set on the first group message
                     type: string
                   groupRebalance:
+                    description: If rebalance the message group
                     type: boolean
                   groupRebalancePauseDispatch:
+                    description: If pause message dispatch when rebalancing groups
                     type: boolean
                   ignoreIfExists:
+                    description: If ignore if the target queue already exists
                     type: boolean
                   lastValue:
+                    description: If it is a last value queue
                     type: boolean
                   lastValueKey:
+                    description: The property used for last value queue to identify last values
                     type: string
                   maxConsumers:
+                    description: Max number of consumers allowed on this queue
                     format: int32
                     type: integer
                   nonDestructive:
+                    description: If force non-destructive consumers on the queue
                     type: boolean
                   purgeOnNoConsumers:
+                    description: Whether to delete all messages when no consumers connected to the queue
                     type: boolean
                   ringSize:
+                    description: The size the queue should maintain according to ring semantics
                     format: int64
                     type: integer
                   routingType:
+                    description: The routing type of the queue
                     type: string
                   temporary:
+                    description: If the queue is temporary
                     type: boolean
                   user:
+                    description: The user associated with the queue
                     type: string
                 type: object
               queueName:
+                description: The Queue Name
                 type: string
               removeFromBrokerOnDelete:
+                description: Whether or not delete the queue from broker when CR is undeployed(default false)
                 type: boolean
               routingType:
+                description: The Routing Type
                 type: string
               user:
+                description: User name for creating the queue or address
                 type: string
             type: object
           status:


### PR DESCRIPTION
Updated scorecard test image from `v1.34` to ` v1.41` to align with latest Operator SDK best practices and ensure all OLM/basic tests pass.

fixes: [Issue#1197](https://github.com/arkmq-org/activemq-artemis-operator/issues/1197)