### PR TITLE
Move operator version update logic from update.yml to Makefile

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -68,10 +68,8 @@ jobs:
           VERSION_MINOR=${VERSION_MINOR/\*/${CURRENT_VERSION_MINOR}} && VERSION_MINOR=${VERSION_MINOR/+/$((CURRENT_VERSION_MINOR+1))}
           VERSION_PATCH=${VERSION_PATCH/\*/${CURRENT_VERSION_PATCH}} && VERSION_PATCH=${VERSION_PATCH/+/$((CURRENT_VERSION_PATCH+1))}
           VERSION="${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}"
-          sed -i "s~Version = \"${CURRENT_VERSION}\"~Version = \"${VERSION}\"~" version/version.go
           sed -i "s~^VERSION ?=.*~VERSION ?= ${VERSION}~" Makefile
           sed -i "s~^OPERATOR_VERSION :=.*~OPERATOR_VERSION := ${VERSION}~" Makefile
-          sed -i "s~^LABEL version=.*~LABEL version=\"${VERSION}\"~g" Dockerfile
           make build && make generate-deploy && make bundle && git status
           git commit --all --message "Update version to ${VERSION}" || echo "nothing to commit"
 

--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,9 @@ endif
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
+	sed -i "s~Version = \"${CURRENT_VERSION}\"~Version = \"${VERSION}\"~" version/version.go
+	sed -i "s~^LABEL version=.*~LABEL version=\"${VERSION}\"~g" Dockerfile
+
 
 .PHONY: fmt
 fmt: ## Run go fmt against code.
@@ -288,6 +291,7 @@ bundle: manifests operator-sdk kustomize ## Generate bundle manifests and metada
 	sed -i.bak '/creationTimestamp:/d' ./bundle/manifests/*.yaml && rm ./bundle/manifests/*.bak
 	sed -i.bak "s/createdAt:.*/`grep -oP 'createdAt:.*' config/manifests/bases/$(BUNDLE_PACKAGE).clusterserviceversion.yaml`/" ./bundle/manifests/*.yaml && rm ./bundle/manifests/*.bak
 	sed -i.bak 's|containerImage: .*|containerImage: '${IMG}'|' ./bundle/manifests/*.yaml && rm ./bundle/manifests/*.bak
+	sed -i "s~version:.*~version: \"${VERSION}\"~" config/metadata/$(BUNDLE_PACKAGE).annotations.yaml
 	sed 's/annotations://' config/metadata/$(BUNDLE_PACKAGE).annotations.yaml >> bundle/metadata/annotations.yaml
 	sed -e 's/annotations://' -e 's/  /LABEL /g' -e 's/: /=/g'  config/metadata/$(BUNDLE_PACKAGE).annotations.yaml >> bundle.Dockerfile
 	sed -i.bak 's/operators.operatorframework.io.bundle.package.v1:.*/operators.operatorframework.io.bundle.package.v1: $(BUNDLE_ANNOTATION_PACKAGE)/' bundle/metadata/annotations.yaml && rm bundle/metadata/annotations.yaml.bak

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -22,5 +22,5 @@ COPY bundle/tests/scorecard /tests/scorecard/
 
 LABEL name="arkmq-org/activemq-artemis-operator-bundle"
 LABEL description="ActiveMQ Artemis Broker Operator Bundle"
-LABEL maintainer="Roddie Kieley <rkieley@redhat.com>"
-LABEL version="1.0.10"
+LABEL maintainer="arkmq-org <info@arkmq.org>"
+LABEL version="2.0.2"

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -16,5 +16,5 @@ annotations:
 
   name: "arkmq-org/activemq-artemis-operator-bundle"
   description: "ActiveMQ Artemis Broker Operator Bundle"
-  maintainer: "Roddie Kieley <rkieley@redhat.com>"
-  version: "1.0.10"
+  maintainer: "arkmq-org <info@arkmq.org>"
+  version: "2.0.2"

--- a/config/metadata/activemq-artemis-operator.annotations.yaml
+++ b/config/metadata/activemq-artemis-operator.annotations.yaml
@@ -1,5 +1,5 @@
 annotations:
   name: "arkmq-org/activemq-artemis-operator-bundle"
   description: "ActiveMQ Artemis Broker Operator Bundle"
-  maintainer: "Roddie Kieley <rkieley@redhat.com>"
-  version: "1.0.10"
+  maintainer: "arkmq-org <info@arkmq.org>"
+  version: "2.0.2"


### PR DESCRIPTION
- Moved the operator version update logic from the update.yml GitHub Action to the Makefile
under the generate and bundle targets.
- This ensures consistency and allows PR checks to validate the operator version
across all relevant files automatically.

fixes:  [#1147](https://github.com/arkmq-org/activemq-artemis-operator/issues/1147)