### PR TITLE
[#1255] Move tutorials at the end of the CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,26 +114,6 @@ jobs:
       - name: Run scorecard tests
         run: make scorecard | tee scorecard.log && ! grep 'Suggestions' scorecard.log
 
-      - name: Get changed files in tutorials
-        id: changed-tutorial-files
-        if: github.event_name == 'pull_request'
-        uses: tj-actions/changed-files@v47
-        with:
-          files: docs/tutorials/**
-
-      - name: Install markdown-runner
-        if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.runTutorials) || (github.event_name == 'pull_request' && steps.changed-tutorial-files.outputs.any_changed == 'true')
-        run: go install github.com/arkmq-org/markdown-runner@latest
-
-      - name: run the tutorials on the image
-        if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.runTutorials) || (github.event_name == 'pull_request' && steps.changed-tutorial-files.outputs.any_changed == 'true')
-        run: |
-          find docs/tutorials -type f -exec sed -i "s|^minikube start|minikube start --insecure-registry=$HOSTNAME:5000|" {} +
-          sed -i "s|image: quay.io/arkmq-org/activemq-artemis-operator:.*|image: ${HOSTNAME}:5000/$IMAGE_NAME:dev.latest|" deploy/operator.yaml
-          minikube delete
-          markdown-runner docs/tutorials --view ci
-          minikube start --insecure-registry=$HOSTNAME:5000
-
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
@@ -195,7 +175,7 @@ jobs:
           minikube kubectl -- get catalogsource arkmq-org-broker-operator-catalog-source --namespace operators -o yaml
           minikube kubectl -- wait pod -l olm.catalogSource=arkmq-org-broker-operator-catalog-source --for=condition=Ready --namespace=operators --timeout=3m ||
           minikube kubectl -- describe pod -l olm.catalogSource=arkmq-org-broker-operator-catalog-source --namespace=operators
-         
+
       - name: Create and verify subscription
         run: |
           minikube kubectl -- create -f ./examples/catalog/subscription.yaml
@@ -206,3 +186,21 @@ jobs:
           minikube kubectl -- wait pod -l name=activemq-artemis-operator --for=condition=Ready --namespace=operators --timeout=3m ||
           minikube kubectl -- get pod -l name=activemq-artemis-operator --namespace=operators -o yaml
 
+      - name: Get changed files in tutorials
+        id: changed-tutorial-files
+        if: github.event_name == 'pull_request'
+        uses: tj-actions/changed-files@v47
+        with:
+          files: docs/tutorials/**
+
+      - name: Install markdown-runner
+        if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.runTutorials) || (github.event_name == 'pull_request' && steps.changed-tutorial-files.outputs.any_changed == 'true')
+        run: go install github.com/arkmq-org/markdown-runner@latest
+
+      - name: run the tutorials on the image
+        if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.runTutorials) || (github.event_name == 'pull_request' && steps.changed-tutorial-files.outputs.any_changed == 'true')
+        run: |
+          minikube delete
+          find docs/tutorials -type f -exec sed -i "s|^minikube start|minikube start --insecure-registry=$HOSTNAME:5000|" {} +
+          sed -i "s|image: quay.io/arkmq-org/activemq-artemis-operator:.*|image: ${HOSTNAME}:5000/$IMAGE_NAME:dev.latest|" deploy/operator.yaml
+          markdown-runner docs/tutorials --view ci


### PR DESCRIPTION
The execution of the tutorials is moved to the end of the CI workflow because it deletes the minikube instance required by other steps.