### PR TITLE
removing the irrelevant text from tutorial

### DIFF
--- a/docs/tutorials/send_receive_port_forwarding.md
+++ b/docs/tutorials/send_receive_port_forwarding.md
@@ -41,7 +41,7 @@ minikube profile tutorialtester
 * minikube profile was successfully set to tutorialtester
 ```
 
-### Deploy the operator
+### Deploy the operator 
 
 #### create the namespace
 

--- a/docs/tutorials/send_receive_port_forwarding.md
+++ b/docs/tutorials/send_receive_port_forwarding.md
@@ -58,13 +58,6 @@ You can view the list of minikube maintainers at: https://github.com/kubernetes/
 deployment.apps/ingress-nginx-controller patched
 ```
 
-#### Make sure the domain of your cluster is resolvable
-
-If you are running your OpenShift cluster locally, you might not be able to
-resolve the urls to IPs out of the blue. Follow [this guide](../help/hostname_resolution.md) to configure your setup.
-
-This tutorial will follow the simple /etc/hosts approach, but feel free to use
-the most appropriate one for you.
 
 ### Deploy the operator
 

--- a/docs/tutorials/send_receive_port_forwarding.md
+++ b/docs/tutorials/send_receive_port_forwarding.md
@@ -1,6 +1,6 @@
 ---
 title: "Exchanging messages using port forwarding"  
-description: "Steps to get a producer and a consummer exchanging messages over a deployed broker on OpenShift using port forwwarding"
+description: "Steps to get a producer and a consummer exchanging messages over a deployed broker on OpenShift using port forwarding"
 draft: false
 images: []
 menu:
@@ -40,24 +40,6 @@ minikube profile tutorialtester
 ! Image was not built for the current minikube version. To resolve this you can delete and recreate your minikube cluster using the latest images. Expected minikube version: v1.35.0 -> Actual minikube version: v1.36.0
 * minikube profile was successfully set to tutorialtester
 ```
-
-#### Enable nginx and ssl passthrough for minikube
-
-```{"stage":"init"}
-minikube addons enable ingress
-minikube kubectl -- patch deployment -n ingress-nginx ingress-nginx-controller --type='json' -p='[{"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value":"--enable-ssl-passthrough"}]'
-```
-```shell markdown_runner
-* ingress is an addon maintained by Kubernetes. For any concerns contact minikube on GitHub.
-You can view the list of minikube maintainers at: https://github.com/kubernetes/minikube/blob/master/OWNERS
-  - Using image registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.5.3
-  - Using image registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.5.3
-  - Using image registry.k8s.io/ingress-nginx/controller:v1.12.2
-* Verifying ingress addon...
-* The 'ingress' addon is enabled
-deployment.apps/ingress-nginx-controller patched
-```
-
 
 ### Deploy the operator
 

--- a/docs/tutorials/send_receive_port_forwarding.md
+++ b/docs/tutorials/send_receive_port_forwarding.md
@@ -1,6 +1,6 @@
 ---
 title: "Exchanging messages using port forwarding"  
-description: "Steps to get a producer and a consummer exchanging messages over a deployed broker on OpenShift using port forwwarding"
+description: "Steps to get a producer and a consummer exchanging messages over a deployed broker on OpenShift using port forwarding"
 draft: false
 images: []
 menu:
@@ -41,32 +41,7 @@ minikube profile tutorialtester
 * minikube profile was successfully set to tutorialtester
 ```
 
-#### Enable nginx and ssl passthrough for minikube
-
-```{"stage":"init"}
-minikube addons enable ingress
-minikube kubectl -- patch deployment -n ingress-nginx ingress-nginx-controller --type='json' -p='[{"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value":"--enable-ssl-passthrough"}]'
-```
-```shell markdown_runner
-* ingress is an addon maintained by Kubernetes. For any concerns contact minikube on GitHub.
-You can view the list of minikube maintainers at: https://github.com/kubernetes/minikube/blob/master/OWNERS
-  - Using image registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.5.3
-  - Using image registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.5.3
-  - Using image registry.k8s.io/ingress-nginx/controller:v1.12.2
-* Verifying ingress addon...
-* The 'ingress' addon is enabled
-deployment.apps/ingress-nginx-controller patched
-```
-
-#### Make sure the domain of your cluster is resolvable
-
-If you are running your OpenShift cluster locally, you might not be able to
-resolve the urls to IPs out of the blue. Follow [this guide](../help/hostname_resolution.md) to configure your setup.
-
-This tutorial will follow the simple /etc/hosts approach, but feel free to use
-the most appropriate one for you.
-
-### Deploy the operator
+### Deploy the operator 
 
 #### create the namespace
 


### PR DESCRIPTION
In the port-forwarding tutorial's workflow, no external DNS or hostname resolution is involved. Removed the misleading text that implied hostname resolution was needed for the port‑forward workflow. 