### PR TITLE
[#1285] ci: freeing disk space for the tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,11 @@ jobs:
         ports:
           - 5000:5000
     steps:
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          large-packages: false
+
       - name: Set up env
         run: |
           echo "HOSTNAME=${HOSTNAME}" >> ${GITHUB_ENV}


### PR DESCRIPTION
Our tests are using more storage than what's available on the machines by default. This commits add a routine cleanup that will free up to 31GB of disk in under 3 minutes (from the action's author documentation).