### PR TITLE
[#915] provide a status condition when a resource template is unmatched

### DIFF
--- a/api/v1beta1/activemqartemis_types.go
+++ b/api/v1beta1/activemqartemis_types.go
@@ -847,7 +847,4 @@ const (
 
 	ReconcileBlockedType   = "ReconcileBlocked"
 	ReconcileBlockedReason = "AnnotationPresent"
-
-	UnmatchedResourceTemplateConditionType = "UnmatchedResourceTemplate"
-	UnmatchedResourceTemplateReason        = "TemplateDidNotMatchAnyResources"
 )

--- a/api/v1beta1/activemqartemis_types.go
+++ b/api/v1beta1/activemqartemis_types.go
@@ -847,4 +847,7 @@ const (
 
 	ReconcileBlockedType   = "ReconcileBlocked"
 	ReconcileBlockedReason = "AnnotationPresent"
+
+	UnmatchedResourceTemplateConditionType = "UnmatchedResourceTemplate"
+	UnmatchedResourceTemplateReason        = "TemplateDidNotMatchAnyResources"
 )

--- a/controllers/activemqartemis_controller_test.go
+++ b/controllers/activemqartemis_controller_test.go
@@ -7279,10 +7279,10 @@ var _ = Describe("artemis controller", func() {
 				By("verifying UnmatchedResourceTemplate condition is set with correct indices")
 				Eventually(func(g Gomega) {
 					g.Expect(k8sClient.Get(ctx, brokerKey, createdCrd)).Should(Succeed())
-					condition := meta.FindStatusCondition(createdCrd.Status.Conditions, brokerv1beta1.UnmatchedResourceTemplateConditionType)
+					condition := meta.FindStatusCondition(createdCrd.Status.Conditions, brokerv1beta1.ValidConditionType)
 					g.Expect(condition).NotTo(BeNil())
 					g.Expect(condition.Status).To(Equal(metav1.ConditionUnknown))
-					g.Expect(condition.Reason).To(Equal(brokerv1beta1.UnmatchedResourceTemplateReason))
+					g.Expect(condition.Reason).To(Equal(brokerv1beta1.ValidConditionUnknownReason))
 				}, existingClusterTimeout, existingClusterInterval).Should(Succeed())
 
 				By("removing unmatched templates")
@@ -7304,7 +7304,7 @@ var _ = Describe("artemis controller", func() {
 				By("verifying unmatched condition is removed")
 				Eventually(func(g Gomega) {
 					g.Expect(k8sClient.Get(ctx, brokerKey, createdCrd)).Should(Succeed())
-					condition := meta.FindStatusCondition(createdCrd.Status.Conditions, brokerv1beta1.UnmatchedResourceTemplateConditionType)
+					condition := meta.FindStatusCondition(createdCrd.Status.Conditions, brokerv1beta1.ValidConditionType)
 					g.Expect(condition).To(BeNil())
 					g.Expect(meta.IsStatusConditionTrue(createdCrd.Status.Conditions, brokerv1beta1.ReadyConditionType)).Should(BeTrue())
 				}, existingClusterTimeout, existingClusterInterval).Should(Succeed())

--- a/controllers/activemqartemis_reconciler.go
+++ b/controllers/activemqartemis_reconciler.go
@@ -1659,15 +1659,15 @@ func (reconciler *ActiveMQArtemisReconcilerImpl) ProcessResources(customResource
 	if len(unmatchedIndices) > 0 {
 		message := fmt.Sprintf("Resource Template(s) at index/indices %v did not match operator generated resources", unmatchedIndices)
 		meta.SetStatusCondition(&customResource.Status.Conditions, metav1.Condition{
-			Type:               brokerv1beta1.UnmatchedResourceTemplateConditionType,
+			Type:               brokerv1beta1.ValidConditionType,
 			Status:             metav1.ConditionUnknown,
-			Reason:             brokerv1beta1.UnmatchedResourceTemplateReason,
+			Reason:             brokerv1beta1.ValidConditionUnknownReason,
 			Message:            message,
 			ObservedGeneration: customResource.Generation,
 		})
 	} else {
 		//to revert the status if the unmatched resource is corrected
-		meta.RemoveStatusCondition(&customResource.Status.Conditions, brokerv1beta1.UnmatchedResourceTemplateConditionType)
+		meta.RemoveStatusCondition(&customResource.Status.Conditions, brokerv1beta1.ValidConditionType)
 	}
 
 	if len(compositeError) == 0 {

--- a/controllers/activemqartemis_reconciler.go
+++ b/controllers/activemqartemis_reconciler.go
@@ -1605,8 +1605,6 @@ func (reconciler *ActiveMQArtemisReconcilerImpl) ProcessResources(customResource
 
 	reqLogger := reconciler.log.WithValues("ActiveMQArtemis Name", customResource.Name)
 
-	reconciler.matchedTemplates = make(map[int]bool)
-
 	for _, requested := range common.ToResourceList(reconciler.requestedResources) {
 		requested.SetNamespace(customResource.Namespace)
 		if err = reconciler.applyTemplates(requested); err != nil {


### PR DESCRIPTION
The changes are to flag with a status condition unknown when a resource template is unmatched with any of the operator generated resources and the tests for the new logic

