### PR TITLE
[1321] Add pod scheduling fields & update fix script

### DIFF
--- a/hack/fix_helm_chart.sh
+++ b/hack/fix_helm_chart.sh
@@ -47,3 +47,11 @@ sed -i "s~.Values.controllerManager.manager.env.enableWebhooks~false~" ${dir}/te
 # imagePullPolicy (null preserves Kubernetes default behavior)
 $YQ -i '.controllerManager.manager.image.pullPolicy=null' ${dir}/values.yaml
 sed -i '/name: manager/a\        {{- with .Values.controllerManager.manager.image.pullPolicy }}\n        imagePullPolicy: {{ . }}\n        {{- end }}' ${dir}/templates/deployment.yaml
+
+# pod scheduling fields
+$YQ -i ".controllerManager.nodeSelector={}" ${dir}/values.yaml
+$YQ -i ".controllerManager.tolerations=[]" ${dir}/values.yaml
+$YQ -i ".controllerManager.topologySpreadConstraints=[]" ${dir}/values.yaml
+sed -i '/terminationGracePeriodSeconds:/a\      nodeSelector: {{- toYaml .Values.controllerManager.nodeSelector | nindent 8 }}' ${dir}/templates/deployment.yaml
+sed -i '/terminationGracePeriodSeconds:/a\      tolerations: {{ .Values.controllerManager.tolerations | default list | toJson }}' ${dir}/templates/deployment.yaml
+sed -i '/terminationGracePeriodSeconds:/a\      topologySpreadConstraints: {{ .Values.controllerManager.topologySpreadConstraints | default list | toJson }}' ${dir}/templates/deployment.yaml

--- a/helm-charts/arkmq-org-broker-operator/templates/deployment.yaml
+++ b/helm-charts/arkmq-org-broker-operator/templates/deployment.yaml
@@ -255,3 +255,9 @@ spec:
         8 }}
       serviceAccountName: activemq-artemis-controller-manager
       terminationGracePeriodSeconds: 10
+<<<<<<< Updated upstream
+=======
+      nodeSelector: {{- toYaml .Values.controllerManager.nodeSelector | nindent 8 }}
+      tolerations: {{ .Values.controllerManager.tolerations | default list | toJson }}
+      topologySpreadConstraints: {{ .Values.controllerManager.topologySpreadConstraints | default list | toJson }}
+>>>>>>> Stashed changes

--- a/helm-charts/arkmq-org-broker-operator/values.yaml
+++ b/helm-charts/arkmq-org-broker-operator/values.yaml
@@ -147,7 +147,14 @@ controllerManager:
       activemqArtemisBrokerKubernetes2440:
         digest: sha256:fd94e89353cbfb282f3716da7862e087348e41a81033f5e90c45552938217c55
       activemqArtemisBrokerKubernetes2500:
+<<<<<<< Updated upstream
         digest: sha256:1686d24d5aaa3cbb2d1c6284dd31a33fa6a4ea5e3ed30f023d21e31ca8212a75
+=======
+        digest: sha256:6052521772a69f81c69db6bc79f6713a49f36888063dcc7a2a22db71bb32162f
+  nodeSelector: {}
+  tolerations: []
+  topologySpreadConstraints: []
+>>>>>>> Stashed changes
   podSecurityContext:
     runAsNonRoot: true
     seccompProfile:


### PR DESCRIPTION
Introduce controllerManager pod scheduling options (nodeSelector, tolerations, topologySpreadConstraints) to the Helm chart and update the hack/fix_helm_chart.sh to set defaults and inject the corresponding template snippets into deployment.yaml. These changes allow configuring pod scheduling for the controller manager (defaults: nodeSelector={}, tolerations=[], topologySpreadConstraints=[]). Note: the diff contains unresolved merge conflict markers in deployment.yaml and values.yaml that should be cleaned up before finalizing the change.