### PR TITLE
[NO-ISSUE] update setup-envtest reference, our go version now matches…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -299,9 +299,7 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-## The latest envtest version of envtest doesn't work with go 1.20 because of https://github.com/kubernetes-sigs/controller-runtime/issues/2720
-## Use the command `TZ=UTC git --no-pager show --quiet --abbrev=12 --date='format-local:%Y%m%d%H%M%S' --format="%cd-%h"` to get a pseudo-version
-	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20240215143116-d0396a3d6f9f
+	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 
 .PHONY: bundle
 bundle: manifests operator-sdk kustomize ## Generate bundle manifests and metadata, then validate generated files.


### PR DESCRIPTION
… latest

the latest works with our go version and knows where to pick up the relevant binaries