### PR TITLE
[#1356] adding network policies for the operand

### DIFF
--- a/api/v1beta2/broker_types.go
+++ b/api/v1beta2/broker_types.go
@@ -19,6 +19,7 @@ package v1beta2
 import (
 	"github.com/RHsyseng/operator-utils/pkg/olm"
 	corev1 "k8s.io/api/core/v1"
+	netv1 "k8s.io/api/networking/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -75,6 +76,11 @@ type BrokerSpec struct {
 	// Restricted deployment, mtls jolokia agent with RBAC
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Restricted"
 	Restricted *bool `json:"restricted,omitempty"`
+
+	// Optional NetworkPolicy spec for the broker pods. When set, the operator
+	// uses this spec directly instead of auto-generating a NetworkPolicy.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Network Policy"
+	NetworkPolicy *netv1.NetworkPolicySpec `json:"networkPolicy,omitempty"`
 }
 
 type AddressSettingsType struct {

--- a/api/v1beta2/zz_generated.deepcopy.go
+++ b/api/v1beta2/zz_generated.deepcopy.go
@@ -22,6 +22,7 @@ package v1beta2
 
 import (
 	"k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -871,6 +872,11 @@ func (in *BrokerSpec) DeepCopyInto(out *BrokerSpec) {
 		in, out := &in.Restricted, &out.Restricted
 		*out = new(bool)
 		**out = **in
+	}
+	if in.NetworkPolicy != nil {
+		in, out := &in.NetworkPolicy, &out.NetworkPolicy
+		*out = new(networkingv1.NetworkPolicySpec)
+		(*in).DeepCopyInto(*out)
 	}
 }
 

--- a/bundle/manifests/arkmq-org-broker-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/arkmq-org-broker-operator.clusterserviceversion.yaml
@@ -6603,6 +6603,11 @@ spec:
         path: ingressDomain
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: |-
+          Optional NetworkPolicy spec for the broker pods. When set, the operator
+          uses this spec directly instead of auto-generating a NetworkPolicy.
+        displayName: Network Policy
+        path: networkPolicy
       - description: Specifies the template for various resources that the operator
           controls
         displayName: Resource Templates
@@ -7155,6 +7160,7 @@ spec:
           - networking.k8s.io
           resources:
           - ingresses
+          - networkpolicies
           verbs:
           - create
           - delete

--- a/bundle/manifests/broker.arkmq.org_brokers.yaml
+++ b/bundle/manifests/broker.arkmq.org_brokers.yaml
@@ -4849,6 +4849,461 @@ spec:
                   connector or console uses the ingress mode and does not specify
                   an IngressHost.
                 type: string
+              networkPolicy:
+                description: |-
+                  Optional NetworkPolicy spec for the broker pods. When set, the operator
+                  uses this spec directly instead of auto-generating a NetworkPolicy.
+                properties:
+                  egress:
+                    description: |-
+                      egress is a list of egress rules to be applied to the selected pods. Outgoing traffic
+                      is allowed if there are no NetworkPolicies selecting the pod (and cluster policy
+                      otherwise allows the traffic), OR if the traffic matches at least one egress rule
+                      across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                      this field is empty then this NetworkPolicy limits all outgoing traffic (and serves
+                      solely to ensure that the pods it selects are isolated by default).
+                      This field is beta-level in 1.8
+                    items:
+                      description: |-
+                        NetworkPolicyEgressRule describes a particular set of traffic that is allowed out of pods
+                        matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and to.
+                        This type is beta-level in 1.8
+                      properties:
+                        ports:
+                          description: |-
+                            ports is a list of destination ports for outgoing traffic.
+                            Each item in this list is combined using a logical OR. If this field is
+                            empty or missing, this rule matches all ports (traffic not restricted by port).
+                            If this field is present and contains at least one item, then this rule allows
+                            traffic only if the traffic matches at least one port in the list.
+                          items:
+                            description: NetworkPolicyPort describes a port to allow
+                              traffic on
+                            properties:
+                              endPort:
+                                description: |-
+                                  endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                  should be allowed by the policy. This field cannot be defined if the port field
+                                  is not defined or if the port field is defined as a named (string) port.
+                                  The endPort must be equal or greater than port.
+                                format: int32
+                                type: integer
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: |-
+                                  port represents the port on the given protocol. This can either be a numerical or named
+                                  port on a pod. If this field is not provided, this matches all port names and
+                                  numbers.
+                                  If present, only traffic on the specified protocol AND port will be matched.
+                                x-kubernetes-int-or-string: true
+                              protocol:
+                                description: |-
+                                  protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                  If not specified, this field defaults to TCP.
+                                type: string
+                            type: object
+                          type: array
+                        to:
+                          description: |-
+                            to is a list of destinations for outgoing traffic of pods selected for this rule.
+                            Items in this list are combined using a logical OR operation. If this field is
+                            empty or missing, this rule matches all destinations (traffic not restricted by
+                            destination). If this field is present and contains at least one item, this rule
+                            allows traffic only if the traffic matches at least one item in the to list.
+                          items:
+                            description: |-
+                              NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                              fields are allowed
+                            properties:
+                              ipBlock:
+                                description: |-
+                                  ipBlock defines policy on a particular IPBlock. If this field is set then
+                                  neither of the other fields can be.
+                                properties:
+                                  cidr:
+                                    description: |-
+                                      cidr is a string representing the IPBlock
+                                      Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                    type: string
+                                  except:
+                                    description: |-
+                                      except is a slice of CIDRs that should not be included within an IPBlock
+                                      Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                      Except values will be rejected if they are outside the cidr range
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - cidr
+                                type: object
+                              namespaceSelector:
+                                description: |-
+                                  namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                  standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                  If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                  the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                  Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: |-
+                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                        relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: |-
+                                            operator represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: |-
+                                            values is an array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array is replaced during a strategic
+                                            merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    type: object
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              podSelector:
+                                description: |-
+                                  podSelector is a label selector which selects pods. This field follows standard label
+                                  selector semantics; if present but empty, it selects all pods.
+
+                                  If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                  the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                  Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: |-
+                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                        relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: |-
+                                            operator represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: |-
+                                            values is an array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array is replaced during a strategic
+                                            merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    type: object
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                          type: array
+                      type: object
+                    type: array
+                  ingress:
+                    description: |-
+                      ingress is a list of ingress rules to be applied to the selected pods.
+                      Traffic is allowed to a pod if there are no NetworkPolicies selecting the pod
+                      (and cluster policy otherwise allows the traffic), OR if the traffic source is
+                      the pod's local node, OR if the traffic matches at least one ingress rule
+                      across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                      this field is empty then this NetworkPolicy does not allow any traffic (and serves
+                      solely to ensure that the pods it selects are isolated by default)
+                    items:
+                      description: |-
+                        NetworkPolicyIngressRule describes a particular set of traffic that is allowed to the pods
+                        matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and from.
+                      properties:
+                        from:
+                          description: |-
+                            from is a list of sources which should be able to access the pods selected for this rule.
+                            Items in this list are combined using a logical OR operation. If this field is
+                            empty or missing, this rule matches all sources (traffic not restricted by
+                            source). If this field is present and contains at least one item, this rule
+                            allows traffic only if the traffic matches at least one item in the from list.
+                          items:
+                            description: |-
+                              NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                              fields are allowed
+                            properties:
+                              ipBlock:
+                                description: |-
+                                  ipBlock defines policy on a particular IPBlock. If this field is set then
+                                  neither of the other fields can be.
+                                properties:
+                                  cidr:
+                                    description: |-
+                                      cidr is a string representing the IPBlock
+                                      Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                    type: string
+                                  except:
+                                    description: |-
+                                      except is a slice of CIDRs that should not be included within an IPBlock
+                                      Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                      Except values will be rejected if they are outside the cidr range
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - cidr
+                                type: object
+                              namespaceSelector:
+                                description: |-
+                                  namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                  standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                  If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                  the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                  Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: |-
+                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                        relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: |-
+                                            operator represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: |-
+                                            values is an array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array is replaced during a strategic
+                                            merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    type: object
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              podSelector:
+                                description: |-
+                                  podSelector is a label selector which selects pods. This field follows standard label
+                                  selector semantics; if present but empty, it selects all pods.
+
+                                  If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                  the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                  Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: |-
+                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                        relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: |-
+                                            operator represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: |-
+                                            values is an array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array is replaced during a strategic
+                                            merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    type: object
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                          type: array
+                        ports:
+                          description: |-
+                            ports is a list of ports which should be made accessible on the pods selected for
+                            this rule. Each item in this list is combined using a logical OR. If this field is
+                            empty or missing, this rule matches all ports (traffic not restricted by port).
+                            If this field is present and contains at least one item, then this rule allows
+                            traffic only if the traffic matches at least one port in the list.
+                          items:
+                            description: NetworkPolicyPort describes a port to allow
+                              traffic on
+                            properties:
+                              endPort:
+                                description: |-
+                                  endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                  should be allowed by the policy. This field cannot be defined if the port field
+                                  is not defined or if the port field is defined as a named (string) port.
+                                  The endPort must be equal or greater than port.
+                                format: int32
+                                type: integer
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: |-
+                                  port represents the port on the given protocol. This can either be a numerical or named
+                                  port on a pod. If this field is not provided, this matches all port names and
+                                  numbers.
+                                  If present, only traffic on the specified protocol AND port will be matched.
+                                x-kubernetes-int-or-string: true
+                              protocol:
+                                description: |-
+                                  protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                  If not specified, this field defaults to TCP.
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    type: array
+                  podSelector:
+                    description: |-
+                      podSelector selects the pods to which this NetworkPolicy object applies.
+                      The array of ingress rules is applied to any pods selected by this field.
+                      Multiple network policies can select the same set of pods. In this case,
+                      the ingress rules for each are combined additively.
+                      This field is NOT optional and follows standard label selector semantics.
+                      An empty podSelector matches all pods in this namespace.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced during a strategic
+                                merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  policyTypes:
+                    description: |-
+                      policyTypes is a list of rule types that the NetworkPolicy relates to.
+                      Valid options are ["Ingress"], ["Egress"], or ["Ingress", "Egress"].
+                      If this field is not specified, it will default based on the existence of ingress or egress rules;
+                      policies that contain an egress section are assumed to affect egress, and all policies
+                      (whether or not they contain an ingress section) are assumed to affect ingress.
+                      If you want to write an egress-only policy, you must explicitly specify policyTypes [ "Egress" ].
+                      Likewise, if you want to write a policy that specifies that no egress is allowed,
+                      you must specify a policyTypes value that include "Egress" (since such a policy would not include
+                      an egress section and would otherwise default to just [ "Ingress" ]).
+                      This field is beta-level in 1.8
+                    items:
+                      description: |-
+                        PolicyType string describes the NetworkPolicy type
+                        This type is beta-level in 1.8
+                      type: string
+                    type: array
+                required:
+                - podSelector
+                type: object
               resourceTemplates:
                 description: Specifies the template for various resources that the
                   operator controls

--- a/config/crd/bases/broker.arkmq.org_brokers.yaml
+++ b/config/crd/bases/broker.arkmq.org_brokers.yaml
@@ -4850,6 +4850,461 @@ spec:
                   connector or console uses the ingress mode and does not specify
                   an IngressHost.
                 type: string
+              networkPolicy:
+                description: |-
+                  Optional NetworkPolicy spec for the broker pods. When set, the operator
+                  uses this spec directly instead of auto-generating a NetworkPolicy.
+                properties:
+                  egress:
+                    description: |-
+                      egress is a list of egress rules to be applied to the selected pods. Outgoing traffic
+                      is allowed if there are no NetworkPolicies selecting the pod (and cluster policy
+                      otherwise allows the traffic), OR if the traffic matches at least one egress rule
+                      across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                      this field is empty then this NetworkPolicy limits all outgoing traffic (and serves
+                      solely to ensure that the pods it selects are isolated by default).
+                      This field is beta-level in 1.8
+                    items:
+                      description: |-
+                        NetworkPolicyEgressRule describes a particular set of traffic that is allowed out of pods
+                        matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and to.
+                        This type is beta-level in 1.8
+                      properties:
+                        ports:
+                          description: |-
+                            ports is a list of destination ports for outgoing traffic.
+                            Each item in this list is combined using a logical OR. If this field is
+                            empty or missing, this rule matches all ports (traffic not restricted by port).
+                            If this field is present and contains at least one item, then this rule allows
+                            traffic only if the traffic matches at least one port in the list.
+                          items:
+                            description: NetworkPolicyPort describes a port to allow
+                              traffic on
+                            properties:
+                              endPort:
+                                description: |-
+                                  endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                  should be allowed by the policy. This field cannot be defined if the port field
+                                  is not defined or if the port field is defined as a named (string) port.
+                                  The endPort must be equal or greater than port.
+                                format: int32
+                                type: integer
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: |-
+                                  port represents the port on the given protocol. This can either be a numerical or named
+                                  port on a pod. If this field is not provided, this matches all port names and
+                                  numbers.
+                                  If present, only traffic on the specified protocol AND port will be matched.
+                                x-kubernetes-int-or-string: true
+                              protocol:
+                                description: |-
+                                  protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                  If not specified, this field defaults to TCP.
+                                type: string
+                            type: object
+                          type: array
+                        to:
+                          description: |-
+                            to is a list of destinations for outgoing traffic of pods selected for this rule.
+                            Items in this list are combined using a logical OR operation. If this field is
+                            empty or missing, this rule matches all destinations (traffic not restricted by
+                            destination). If this field is present and contains at least one item, this rule
+                            allows traffic only if the traffic matches at least one item in the to list.
+                          items:
+                            description: |-
+                              NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                              fields are allowed
+                            properties:
+                              ipBlock:
+                                description: |-
+                                  ipBlock defines policy on a particular IPBlock. If this field is set then
+                                  neither of the other fields can be.
+                                properties:
+                                  cidr:
+                                    description: |-
+                                      cidr is a string representing the IPBlock
+                                      Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                    type: string
+                                  except:
+                                    description: |-
+                                      except is a slice of CIDRs that should not be included within an IPBlock
+                                      Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                      Except values will be rejected if they are outside the cidr range
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - cidr
+                                type: object
+                              namespaceSelector:
+                                description: |-
+                                  namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                  standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                  If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                  the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                  Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: |-
+                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                        relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: |-
+                                            operator represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: |-
+                                            values is an array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array is replaced during a strategic
+                                            merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    type: object
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              podSelector:
+                                description: |-
+                                  podSelector is a label selector which selects pods. This field follows standard label
+                                  selector semantics; if present but empty, it selects all pods.
+
+                                  If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                  the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                  Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: |-
+                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                        relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: |-
+                                            operator represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: |-
+                                            values is an array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array is replaced during a strategic
+                                            merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    type: object
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                          type: array
+                      type: object
+                    type: array
+                  ingress:
+                    description: |-
+                      ingress is a list of ingress rules to be applied to the selected pods.
+                      Traffic is allowed to a pod if there are no NetworkPolicies selecting the pod
+                      (and cluster policy otherwise allows the traffic), OR if the traffic source is
+                      the pod's local node, OR if the traffic matches at least one ingress rule
+                      across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                      this field is empty then this NetworkPolicy does not allow any traffic (and serves
+                      solely to ensure that the pods it selects are isolated by default)
+                    items:
+                      description: |-
+                        NetworkPolicyIngressRule describes a particular set of traffic that is allowed to the pods
+                        matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and from.
+                      properties:
+                        from:
+                          description: |-
+                            from is a list of sources which should be able to access the pods selected for this rule.
+                            Items in this list are combined using a logical OR operation. If this field is
+                            empty or missing, this rule matches all sources (traffic not restricted by
+                            source). If this field is present and contains at least one item, this rule
+                            allows traffic only if the traffic matches at least one item in the from list.
+                          items:
+                            description: |-
+                              NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                              fields are allowed
+                            properties:
+                              ipBlock:
+                                description: |-
+                                  ipBlock defines policy on a particular IPBlock. If this field is set then
+                                  neither of the other fields can be.
+                                properties:
+                                  cidr:
+                                    description: |-
+                                      cidr is a string representing the IPBlock
+                                      Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                    type: string
+                                  except:
+                                    description: |-
+                                      except is a slice of CIDRs that should not be included within an IPBlock
+                                      Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                      Except values will be rejected if they are outside the cidr range
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - cidr
+                                type: object
+                              namespaceSelector:
+                                description: |-
+                                  namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                  standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                  If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                  the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                  Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: |-
+                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                        relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: |-
+                                            operator represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: |-
+                                            values is an array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array is replaced during a strategic
+                                            merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    type: object
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              podSelector:
+                                description: |-
+                                  podSelector is a label selector which selects pods. This field follows standard label
+                                  selector semantics; if present but empty, it selects all pods.
+
+                                  If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                  the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                  Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: |-
+                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                        relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: |-
+                                            operator represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: |-
+                                            values is an array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array is replaced during a strategic
+                                            merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    type: object
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                          type: array
+                        ports:
+                          description: |-
+                            ports is a list of ports which should be made accessible on the pods selected for
+                            this rule. Each item in this list is combined using a logical OR. If this field is
+                            empty or missing, this rule matches all ports (traffic not restricted by port).
+                            If this field is present and contains at least one item, then this rule allows
+                            traffic only if the traffic matches at least one port in the list.
+                          items:
+                            description: NetworkPolicyPort describes a port to allow
+                              traffic on
+                            properties:
+                              endPort:
+                                description: |-
+                                  endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                  should be allowed by the policy. This field cannot be defined if the port field
+                                  is not defined or if the port field is defined as a named (string) port.
+                                  The endPort must be equal or greater than port.
+                                format: int32
+                                type: integer
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: |-
+                                  port represents the port on the given protocol. This can either be a numerical or named
+                                  port on a pod. If this field is not provided, this matches all port names and
+                                  numbers.
+                                  If present, only traffic on the specified protocol AND port will be matched.
+                                x-kubernetes-int-or-string: true
+                              protocol:
+                                description: |-
+                                  protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                  If not specified, this field defaults to TCP.
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    type: array
+                  podSelector:
+                    description: |-
+                      podSelector selects the pods to which this NetworkPolicy object applies.
+                      The array of ingress rules is applied to any pods selected by this field.
+                      Multiple network policies can select the same set of pods. In this case,
+                      the ingress rules for each are combined additively.
+                      This field is NOT optional and follows standard label selector semantics.
+                      An empty podSelector matches all pods in this namespace.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced during a strategic
+                                merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  policyTypes:
+                    description: |-
+                      policyTypes is a list of rule types that the NetworkPolicy relates to.
+                      Valid options are ["Ingress"], ["Egress"], or ["Ingress", "Egress"].
+                      If this field is not specified, it will default based on the existence of ingress or egress rules;
+                      policies that contain an egress section are assumed to affect egress, and all policies
+                      (whether or not they contain an ingress section) are assumed to affect ingress.
+                      If you want to write an egress-only policy, you must explicitly specify policyTypes [ "Egress" ].
+                      Likewise, if you want to write a policy that specifies that no egress is allowed,
+                      you must specify a policyTypes value that include "Egress" (since such a policy would not include
+                      an egress section and would otherwise default to just [ "Ingress" ]).
+                      This field is beta-level in 1.8
+                    items:
+                      description: |-
+                        PolicyType string describes the NetworkPolicy type
+                        This type is beta-level in 1.8
+                      type: string
+                    type: array
+                required:
+                - podSelector
+                type: object
               resourceTemplates:
                 description: Specifies the template for various resources that the
                   operator controls

--- a/config/manifests/bases/arkmq-org-broker-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/arkmq-org-broker-operator.clusterserviceversion.yaml
@@ -7310,6 +7310,11 @@ spec:
         path: ingressDomain
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: |-
+          Optional NetworkPolicy spec for the broker pods. When set, the operator
+          uses this spec directly instead of auto-generating a NetworkPolicy.
+        displayName: Network Policy
+        path: networkPolicy
       - description: Specifies the template for various resources that the operator
           controls
         displayName: Resource Templates

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -144,6 +144,7 @@ rules:
   - networking.k8s.io
   resources:
   - ingresses
+  - networkpolicies
   verbs:
   - create
   - delete

--- a/controllers/activemqartemis_controller.go
+++ b/controllers/activemqartemis_controller.go
@@ -140,6 +140,7 @@ func (r *ActiveMQArtemisReconciler) toBrokerParent() *BrokerReconciler {
 //+kubebuilder:rbac:groups=apps,namespace=arkmq-org-broker-operator,resources=deployments/finalizers,verbs=update
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,namespace=arkmq-org-broker-operator,resources=roles;rolebindings,verbs=create;get;delete
 //+kubebuilder:rbac:groups=policy,namespace=arkmq-org-broker-operator,resources=poddisruptionbudgets,verbs=create;get;delete;list;update;watch
+//+kubebuilder:rbac:groups=networking.k8s.io,namespace=arkmq-org-broker-operator,resources=networkpolicies,verbs=create;get;delete;list;update;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -245,7 +246,8 @@ func (r *ActiveMQArtemisReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&corev1.ConfigMap{}).
 		Owns(&corev1.Service{}).
 		Owns(&netv1.Ingress{}).
-		Owns(&policyv1.PodDisruptionBudget{})
+		Owns(&policyv1.PodDisruptionBudget{}).
+		Owns(&netv1.NetworkPolicy{})
 
 	if r.isOnOpenShift {
 		builder.Owns(&routev1.Route{})

--- a/controllers/activemqartemis_controller_deploy_operator_test.go
+++ b/controllers/activemqartemis_controller_deploy_operator_test.go
@@ -413,10 +413,9 @@ var _ = Describe("artemis controller", Label("do"), func() {
 						strings.TrimSpace(*currentMemoryText), 10, 64)
 					g.Expect(err).To(BeNil())
 
-					// 256Mi threshold is set below the 384Mi limit to ensure adequate
-					// headroom for memory spikes and to verify the operator runs
-					// efficiently when managing 1000 broker CRs
-					thresholdMemoryMegaBytes := int64(256 * 1024 * 1024)
+					// 288Mi threshold accounts for per-CR NetworkPolicy objects while
+					// staying well below the 384Mi container limit
+					thresholdMemoryMegaBytes := int64(288 * 1024 * 1024)
 					g.Expect(currentMemoryBytes < thresholdMemoryMegaBytes).Should(BeTrue(),
 						"memory usage %d bytes exceeds threshold of %d bytes",
 						currentMemoryBytes, thresholdMemoryMegaBytes)

--- a/controllers/activemqartemis_controller_networkpolicy_test.go
+++ b/controllers/activemqartemis_controller_networkpolicy_test.go
@@ -1,0 +1,469 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+// +kubebuilder:docs-gen:collapse=Apache License
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	cmv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmmetav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	netv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+
+	brokerv1beta2 "github.com/arkmq-org/arkmq-org-broker-operator/api/v1beta2"
+	"github.com/arkmq-org/arkmq-org-broker-operator/pkg/utils/common"
+	"github.com/arkmq-org/arkmq-org-broker-operator/pkg/utils/namer"
+)
+
+var _ = Describe("NetworkPolicy for broker operand", Label("network-policy"), func() {
+
+	BeforeEach(func() {
+		BeforeEachSpec()
+	})
+
+	AfterEach(func() {
+		AfterEachSpec()
+	})
+
+	// brokerPropertiesAMQP returns the broker-properties that configure an
+	// acceptor on port 5672 speaking AMQP. Used by both positive and negative
+	// tests so the broker always listens on the same port.
+	brokerPropertiesAMQP := func() []string {
+		return []string{
+			"acceptorConfigurations.custom-amqp.factoryClassName=org.apache.activemq.artemis.core.remoting.impl.netty.NettyAcceptorFactory",
+			"acceptorConfigurations.custom-amqp.params.port=5672",
+			"acceptorConfigurations.custom-amqp.params.host=0.0.0.0",
+			"acceptorConfigurations.custom-amqp.params.protocols=AMQP",
+		}
+	}
+
+	Context("broker-properties acceptor with ResourceTemplate opens port in NetworkPolicy", func() {
+		It("allows cross-pod traffic on a port opened via ResourceTemplate", func() {
+			if os.Getenv("USE_EXISTING_CLUSTER") != "true" || !isOpenshift {
+				Skip("requires OpenShift cluster with NP-enforcing CNI for cross-pod connectivity testing")
+			}
+
+			netpolKind := "NetworkPolicy"
+			brokerCr, createdCr := DeployCustomBrokerV1(defaultNamespace, func(candidate *brokerv1beta2.Broker) {
+				candidate.Spec.DeploymentPlan.Size = common.Int32ToPtr(1)
+				candidate.Spec.BrokerProperties = brokerPropertiesAMQP()
+				candidate.Spec.ResourceTemplates = []brokerv1beta2.ResourceTemplate{
+					{
+						Selector: &brokerv1beta2.ResourceSelector{
+							Kind: &netpolKind,
+						},
+						// ResourceTemplate patches REPLACE the entire spec.ingress list
+						// (no merge key on NetworkPolicyIngressRule), so all desired
+						// ports must be specified here -- not just the extra one.
+						Patch: FromUnstructuredToRawExtension(&unstructured.Unstructured{
+							Object: map[string]interface{}{
+								"kind":       "NetworkPolicy",
+								"apiVersion": "networking.k8s.io/v1",
+								"spec": map[string]interface{}{
+									"ingress": []interface{}{
+										map[string]interface{}{
+											"ports": []interface{}{
+												map[string]interface{}{"port": int64(7800), "protocol": "TCP"},
+												map[string]interface{}{"port": int64(8161), "protocol": "TCP"},
+												map[string]interface{}{"port": int64(8778), "protocol": "TCP"},
+												map[string]interface{}{"port": int64(61616), "protocol": "TCP"},
+												map[string]interface{}{"port": int64(5672), "protocol": "TCP"},
+											},
+										},
+									},
+								},
+							},
+						}),
+					},
+				}
+			})
+
+			netpolKey := types.NamespacedName{
+				Name:      brokerCr.Name + "-netpol",
+				Namespace: defaultNamespace,
+			}
+
+			By("verifying the NetworkPolicy includes all ports from the ResourceTemplate")
+			netpolObject := netv1.NetworkPolicy{}
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, netpolKey, &netpolObject)).Should(Succeed())
+				ingressPorts := collectIngressPorts(&netpolObject)
+				g.Expect(ingressPorts).To(ContainElement(int32(7800)), "jgroups port")
+				g.Expect(ingressPorts).To(ContainElement(int32(8161)), "console-jolokia port")
+				g.Expect(ingressPorts).To(ContainElement(int32(8778)), "jolokia port")
+				g.Expect(ingressPorts).To(ContainElement(int32(61616)), "all-protocols port")
+				g.Expect(ingressPorts).To(ContainElement(int32(5672)), "amqp port from resource template")
+			}, existingClusterTimeout, existingClusterInterval).Should(Succeed())
+
+			By("waiting for broker to be ready")
+			brokerKey := types.NamespacedName{Name: createdCr.Name, Namespace: createdCr.Namespace}
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, brokerKey, createdCr)).Should(Succeed())
+				g.Expect(meta.IsStatusConditionTrue(createdCr.Status.Conditions, brokerv1beta2.ReadyConditionType)).Should(BeTrue())
+			}, existingClusterTimeout, existingClusterInterval).Should(Succeed())
+
+			clientPodName := "netpol-positive-client"
+			createClientPod(clientPodName, defaultNamespace)
+			defer deleteClientPod(clientPodName, defaultNamespace)
+
+			brokerFQDN := common.OrdinalFQDNS(brokerCr.Name, defaultNamespace, 0)
+
+			// TCP connectivity check from a separate pod (not loopback) to
+			// verify that the NetworkPolicy allows cross-pod traffic on 5672.
+			// Bash's /dev/tcp opens a TCP socket; timeout kills it if it hangs.
+			By("verifying the broker-properties acceptor port is reachable from a separate client pod")
+			Eventually(func(g Gomega) {
+				result, err := RunCommandInPodWithNamespace(
+					clientPodName, defaultNamespace, clientPodName,
+					[]string{"/bin/bash", "-c", fmt.Sprintf("timeout 5 bash -c 'echo > /dev/tcp/%s/5672'", brokerFQDN)})
+				g.Expect(err).To(BeNil(), "exec should succeed")
+				g.Expect(result).NotTo(BeNil())
+			}, existingClusterTimeout, existingClusterInterval).Should(Succeed())
+
+			CleanResource(brokerCr, brokerCr.Name, defaultNamespace)
+		})
+	})
+
+	Context("broker-properties acceptor without ResourceTemplate blocks port via NetworkPolicy", func() {
+		It("blocks cross-pod traffic on a port not listed in the NetworkPolicy", func() {
+			if os.Getenv("USE_EXISTING_CLUSTER") != "true" || !isOpenshift {
+				Skip("requires OpenShift cluster with NP-enforcing CNI for cross-pod connectivity testing")
+			}
+
+			brokerCr, createdCr := DeployCustomBrokerV1(defaultNamespace, func(candidate *brokerv1beta2.Broker) {
+				candidate.Spec.DeploymentPlan.Size = common.Int32ToPtr(1)
+				candidate.Spec.BrokerProperties = brokerPropertiesAMQP()
+			})
+
+			netpolKey := types.NamespacedName{
+				Name:      brokerCr.Name + "-netpol",
+				Namespace: defaultNamespace,
+			}
+
+			By("verifying the NetworkPolicy does NOT include port 5672")
+			netpolObject := netv1.NetworkPolicy{}
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, netpolKey, &netpolObject)).Should(Succeed())
+				ingressPorts := collectIngressPorts(&netpolObject)
+				g.Expect(ingressPorts).NotTo(ContainElement(int32(5672)), "5672 should not be in NP without ResourceTemplate")
+			}, existingClusterTimeout, existingClusterInterval).Should(Succeed())
+
+			By("waiting for broker to be ready")
+			brokerKey := types.NamespacedName{Name: createdCr.Name, Namespace: createdCr.Namespace}
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, brokerKey, createdCr)).Should(Succeed())
+				g.Expect(meta.IsStatusConditionTrue(createdCr.Status.Conditions, brokerv1beta2.ReadyConditionType)).Should(BeTrue())
+			}, existingClusterTimeout, existingClusterInterval).Should(Succeed())
+
+			By("confirming the broker IS listening on 5672 from inside its own pod (loopback bypasses NP)")
+			brokerPodName := namer.CrToSS(brokerCr.Name) + "-0"
+			Eventually(func(g Gomega) {
+				result, err := RunCommandInPod(brokerPodName, brokerCr.Name+"-container",
+					[]string{"/bin/bash", "-c", "timeout 3 bash -c 'echo > /dev/tcp/localhost/5672'"})
+				g.Expect(err).To(BeNil())
+				g.Expect(result).NotTo(BeNil())
+			}, existingClusterTimeout, existingClusterInterval).Should(Succeed())
+
+			clientPodName := "netpol-negative-client"
+			createClientPod(clientPodName, defaultNamespace)
+			defer deleteClientPod(clientPodName, defaultNamespace)
+
+			brokerFQDN := common.OrdinalFQDNS(brokerCr.Name, defaultNamespace, 0)
+
+			// Cross-pod TCP probe to a port NOT in the NetworkPolicy.
+			// The command appends "EXIT_CODE=$?" so the exec always returns
+			// success (the outer echo never fails), letting us inspect the
+			// connection result from the output rather than the exec error.
+			By("verifying cross-pod connection to port 5672 is blocked by NetworkPolicy")
+			Consistently(func(g Gomega) {
+				result, err := RunCommandInPodWithNamespace(
+					clientPodName, defaultNamespace, clientPodName,
+					[]string{"/bin/bash", "-c", fmt.Sprintf("timeout 5 bash -c 'echo > /dev/tcp/%s/5672' 2>&1; echo EXIT_CODE=$?", brokerFQDN)})
+				g.Expect(err).To(BeNil(), "exec should succeed even if the TCP probe fails")
+				g.Expect(result).NotTo(BeNil())
+				g.Expect(*result).To(ContainSubstring("EXIT_CODE="), "should report exit code")
+				g.Expect(*result).NotTo(ContainSubstring("EXIT_CODE=0"), "connection should NOT succeed when NP blocks port 5672")
+			}, "30s", "10s").Should(Succeed())
+
+			CleanResource(brokerCr, brokerCr.Name, defaultNamespace)
+		})
+	})
+})
+
+var _ = Describe("BrokerService NetworkPolicy for BrokerApp ports", Label("network-policy"), func() {
+
+	var installedCertManager bool = false
+
+	BeforeEach(func() {
+		BeforeEachSpec()
+
+		if os.Getenv("USE_EXISTING_CLUSTER") == "true" {
+			if !CertManagerInstalled() {
+				Expect(InstallCertManager()).To(Succeed())
+				installedCertManager = true
+			}
+
+			rootIssuer = InstallClusteredIssuer(rootIssuerName, nil)
+			rootCert = InstallCert(rootCertName, rootCertNamespce, func(candidate *cmv1.Certificate) {
+				candidate.Spec.IsCA = true
+				candidate.Spec.CommonName = "artemis.root.ca"
+				candidate.Spec.SecretName = rootCertSecretName
+				candidate.Spec.IssuerRef = cmmetav1.ObjectReference{
+					Name: rootIssuer.Name,
+					Kind: "ClusterIssuer",
+				}
+			})
+			caIssuer = InstallClusteredIssuer(caIssuerName, func(candidate *cmv1.ClusterIssuer) {
+				candidate.Spec.SelfSigned = nil
+				candidate.Spec.CA = &cmv1.CAIssuer{
+					SecretName: rootCertSecretName,
+				}
+			})
+			InstallCaBundle(common.DefaultOperatorCASecretName, rootCertSecretName, caPemTrustStoreName)
+
+			InstallCert(common.DefaultOperatorCertSecretName, defaultNamespace, func(candidate *cmv1.Certificate) {
+				candidate.Spec.SecretName = common.DefaultOperatorCertSecretName
+				candidate.Spec.CommonName = "activemq-artemis-operator"
+				candidate.Spec.IssuerRef = cmmetav1.ObjectReference{
+					Name: caIssuer.Name,
+					Kind: "ClusterIssuer",
+				}
+			})
+		}
+	})
+
+	AfterEach(func() {
+		if os.Getenv("USE_EXISTING_CLUSTER") == "true" && installedCertManager {
+			Expect(UninstallCertManager()).To(Succeed())
+			installedCertManager = false
+		}
+		AfterEachSpec()
+	})
+
+	It("includes BrokerApp acceptor ports in the NetworkPolicy created for the broker", func() {
+		if os.Getenv("USE_EXISTING_CLUSTER") != "true" || !isOpenshift {
+			Skip("requires OpenShift cluster with NP-enforcing CNI")
+		}
+
+		ctx := context.Background()
+		serviceName := NextSpecResourceName()
+
+		sharedOperandCertName := serviceName + "-" + common.DefaultOperandCertSecretName
+		By("installing broker cert")
+		InstallCert(sharedOperandCertName, defaultNamespace, func(candidate *cmv1.Certificate) {
+			candidate.Spec.SecretName = sharedOperandCertName
+			candidate.Spec.CommonName = serviceName
+			candidate.Spec.DNSNames = []string{
+				serviceName,
+				fmt.Sprintf("%s.%s", serviceName, defaultNamespace),
+				fmt.Sprintf("%s.%s.svc.%s", serviceName, defaultNamespace, common.GetClusterDomain()),
+				common.ClusterDNSWildCard(serviceName, defaultNamespace),
+			}
+			candidate.Spec.IssuerRef = cmmetav1.ObjectReference{
+				Name: caIssuer.Name,
+				Kind: "ClusterIssuer",
+			}
+		})
+
+		prometheusCertName := common.DefaultPrometheusCertSecretName
+		By("installing prometheus cert")
+		InstallCert(prometheusCertName, defaultNamespace, func(candidate *cmv1.Certificate) {
+			candidate.Spec.SecretName = prometheusCertName
+			candidate.Spec.CommonName = "prometheus"
+			candidate.Spec.IssuerRef = cmmetav1.ObjectReference{
+				Name: caIssuer.Name,
+				Kind: "ClusterIssuer",
+			}
+		})
+
+		By("deploying a BrokerService")
+		svc := brokerv1beta2.BrokerService{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "BrokerService",
+				APIVersion: brokerv1beta2.GroupVersion.Identifier(),
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      serviceName,
+				Namespace: defaultNamespace,
+				Labels:    map[string]string{"env": "netpol-test"},
+			},
+			Spec: brokerv1beta2.BrokerServiceSpec{},
+		}
+		Expect(k8sClient.Create(ctx, &svc)).Should(Succeed())
+
+		serviceKey := types.NamespacedName{Name: svc.Name, Namespace: svc.Namespace}
+		createdSvc := &brokerv1beta2.BrokerService{}
+		Eventually(func(g Gomega) {
+			g.Expect(k8sClient.Get(ctx, serviceKey, createdSvc)).Should(Succeed())
+			g.Expect(meta.IsStatusConditionTrue(createdSvc.Status.Conditions, brokerv1beta2.ReadyConditionType)).Should(BeTrue())
+		}, existingClusterTimeout, existingClusterInterval).Should(Succeed())
+
+		By("verifying the NetworkPolicy exists with only restricted ports before any app is bound")
+		netpolKey := types.NamespacedName{
+			Name:      serviceName + "-netpol",
+			Namespace: defaultNamespace,
+		}
+		netpolObject := netv1.NetworkPolicy{}
+		Eventually(func(g Gomega) {
+			g.Expect(k8sClient.Get(ctx, netpolKey, &netpolObject)).Should(Succeed())
+			ports := collectIngressPorts(&netpolObject)
+			g.Expect(ports).To(ContainElement(int32(8778)), "Jolokia port")
+			g.Expect(ports).To(ContainElement(int32(8888)), "Prometheus port")
+			g.Expect(ports).To(HaveLen(2), "only restricted ports before app binding")
+		}, existingClusterTimeout, existingClusterInterval).Should(Succeed())
+
+		By("deploying a BrokerApp that binds to the service")
+		appPort := int32(62616)
+		app := brokerv1beta2.BrokerApp{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "BrokerApp",
+				APIVersion: brokerv1beta2.GroupVersion.Identifier(),
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "netpol-app",
+				Namespace: defaultNamespace,
+			},
+			Spec: brokerv1beta2.BrokerAppSpec{
+				ServiceSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"env": "netpol-test"},
+				},
+				Acceptor: brokerv1beta2.AppAcceptorType{
+					Port: appPort,
+				},
+				Capabilities: []brokerv1beta2.AppCapabilityType{
+					{
+						ProducerOf: []brokerv1beta2.AppAddressType{{Address: "TEST.QUEUE"}},
+						ConsumerOf: []brokerv1beta2.AppAddressType{{Address: "TEST.QUEUE"}},
+					},
+				},
+			},
+		}
+
+		appCertName := app.Name + common.AppCertSecretSuffix
+		By("installing app client cert")
+		InstallCert(appCertName, defaultNamespace, func(candidate *cmv1.Certificate) {
+			candidate.Spec.SecretName = appCertName
+			candidate.Spec.CommonName = app.Name
+			candidate.Spec.Subject.Organizations = nil
+			candidate.Spec.Subject.OrganizationalUnits = []string{defaultNamespace}
+			candidate.Spec.IssuerRef = cmmetav1.ObjectReference{
+				Name: caIssuer.Name,
+				Kind: "ClusterIssuer",
+			}
+		})
+
+		Expect(k8sClient.Create(ctx, &app)).Should(Succeed())
+
+		appKey := types.NamespacedName{Name: app.Name, Namespace: app.Namespace}
+		createdApp := &brokerv1beta2.BrokerApp{}
+		Eventually(func(g Gomega) {
+			g.Expect(k8sClient.Get(ctx, appKey, createdApp)).Should(Succeed())
+			g.Expect(meta.IsStatusConditionTrue(createdApp.Status.Conditions, brokerv1beta2.ReadyConditionType)).Should(BeTrue())
+		}, existingClusterTimeout, existingClusterInterval).Should(Succeed())
+
+		By("verifying the NetworkPolicy now includes the BrokerApp acceptor port")
+		Eventually(func(g Gomega) {
+			g.Expect(k8sClient.Get(ctx, netpolKey, &netpolObject)).Should(Succeed())
+			ports := collectIngressPorts(&netpolObject)
+			g.Expect(ports).To(ContainElement(int32(8778)), "Jolokia port")
+			g.Expect(ports).To(ContainElement(int32(8888)), "Prometheus port")
+			g.Expect(ports).To(ContainElement(appPort), "BrokerApp acceptor port")
+			g.Expect(ports).To(HaveLen(3), "restricted ports + app port")
+		}, existingClusterTimeout, existingClusterInterval).Should(Succeed())
+
+		By("deleting the BrokerApp and verifying the port is removed from the NetworkPolicy")
+		Expect(k8sClient.Delete(ctx, &app)).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			g.Expect(k8sClient.Get(ctx, netpolKey, &netpolObject)).Should(Succeed())
+			ports := collectIngressPorts(&netpolObject)
+			g.Expect(ports).NotTo(ContainElement(appPort), "app port removed after unbind")
+			g.Expect(ports).To(HaveLen(2), "only restricted ports after app removal")
+		}, existingClusterTimeout, existingClusterInterval).Should(Succeed())
+
+		CleanResource(&svc, svc.Name, defaultNamespace)
+	})
+})
+
+// createClientPod deploys a minimal UBI pod for cross-pod connectivity testing.
+// The pod runs "sleep infinity" and is ready once its container is running.
+func createClientPod(name, namespace string) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:    name,
+					Image:   "registry.access.redhat.com/ubi8/ubi:8.9",
+					Command: []string{"/bin/bash", "-c", "sleep infinity"},
+				},
+			},
+		},
+	}
+
+	Expect(k8sClient.Create(ctx, pod)).Should(Succeed())
+
+	podKey := types.NamespacedName{Name: name, Namespace: namespace}
+	Eventually(func(g Gomega) {
+		fetched := &corev1.Pod{}
+		g.Expect(k8sClient.Get(ctx, podKey, fetched)).Should(Succeed())
+		g.Expect(fetched.Status.ContainerStatuses).NotTo(BeEmpty())
+		g.Expect(fetched.Status.ContainerStatuses[0].State.Running).NotTo(BeNil())
+	}, existingClusterTimeout, existingClusterInterval).Should(Succeed())
+}
+
+func deleteClientPod(name, namespace string) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+	k8sClient.Delete(ctx, pod)
+
+	podKey := types.NamespacedName{Name: name, Namespace: namespace}
+	Eventually(func(g Gomega) {
+		err := k8sClient.Get(ctx, podKey, &corev1.Pod{})
+		g.Expect(err).To(HaveOccurred(), "pod should be gone")
+	}, existingClusterTimeout, existingClusterInterval).Should(Succeed())
+}
+
+// collectIngressPorts extracts all port numbers from all ingress rules
+// of a NetworkPolicy into a flat slice for easy assertion.
+func collectIngressPorts(netpol *netv1.NetworkPolicy) []int32 {
+	_ = context.Background()
+	var ports []int32
+	for _, rule := range netpol.Spec.Ingress {
+		for _, p := range rule.Ports {
+			if p.Port != nil {
+				ports = append(ports, int32(p.Port.IntValue()))
+			}
+		}
+	}
+	return ports
+}

--- a/controllers/activemqartemis_controller_unit_test.go
+++ b/controllers/activemqartemis_controller_unit_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	netv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -482,6 +483,7 @@ func TestReconcileRequeuesOnNotReady(t *testing.T) {
 	_ = brokerv1beta1.AddToScheme(s)
 	_ = corev1.AddToScheme(s)
 	_ = appsv1.AddToScheme(s)
+	_ = netv1.AddToScheme(s)
 
 	crd := &brokerv1beta1.ActiveMQArtemis{
 		ObjectMeta: v1.ObjectMeta{

--- a/controllers/broker_reconciler.go
+++ b/controllers/broker_reconciler.go
@@ -19,6 +19,7 @@ import (
 	"github.com/arkmq-org/arkmq-org-broker-operator/pkg/resources"
 	"github.com/arkmq-org/arkmq-org-broker-operator/pkg/resources/containers"
 	"github.com/arkmq-org/arkmq-org-broker-operator/pkg/resources/ingresses"
+	"github.com/arkmq-org/arkmq-org-broker-operator/pkg/resources/networkpolicies"
 	"github.com/arkmq-org/arkmq-org-broker-operator/pkg/resources/persistentvolumeclaims"
 	"github.com/arkmq-org/arkmq-org-broker-operator/pkg/resources/pods"
 	"github.com/arkmq-org/arkmq-org-broker-operator/pkg/resources/routes"
@@ -190,6 +191,10 @@ func (reconciler *BrokerReconcilerImpl) Process(customResource *v1beta2.Broker, 
 	if err != nil {
 		reconciler.log.Error(err, "Error processing console")
 		return err
+	}
+
+	if !common.OperandNetworkPolicyDisabled() {
+		reconciler.applyNetworkPolicy(customResource)
 	}
 
 	// mods to env var values sourced from secrets are not detected by process resources
@@ -546,6 +551,22 @@ func (reconciler *BrokerReconcilerImpl) applyPodDisruptionBudget(customResource 
 		MatchLabels: matchLabels,
 	}
 
+	reconciler.trackDesired(desired)
+}
+
+func (reconciler *BrokerReconcilerImpl) applyNetworkPolicy(customResource *v1beta2.Broker) {
+
+	var existing *netv1.NetworkPolicy
+	if obj := reconciler.cloneOfDeployed(reflect.TypeFor[netv1.NetworkPolicy](), customResource.Name+"-netpol"); obj != nil {
+		existing = obj.(*netv1.NetworkPolicy)
+	}
+
+	var desired *netv1.NetworkPolicy
+	if customResource.Spec.NetworkPolicy != nil {
+		desired = networkpolicies.NewNetworkPolicyFromSpec(existing, customResource)
+	} else {
+		desired = networkpolicies.NewNetworkPolicyForCR(existing, customResource)
+	}
 	reconciler.trackDesired(desired)
 }
 
@@ -1923,7 +1944,7 @@ var orderedTypes *([]reflect.Type)
 
 func getOrderedTypeList() []reflect.Type {
 	if orderedTypes == nil {
-		types := make([]reflect.Type, 7)
+		types := make([]reflect.Type, 8)
 
 		// we want to create/update in this order
 		types[0] = reflect.TypeOf(corev1.Secret{})
@@ -1933,6 +1954,7 @@ func getOrderedTypeList() []reflect.Type {
 		types[4] = reflect.TypeOf(netv1.Ingress{})
 		types[5] = reflect.TypeOf(routev1.Route{})
 		types[6] = reflect.TypeOf(policyv1.PodDisruptionBudget{})
+		types[7] = reflect.TypeOf(netv1.NetworkPolicy{})
 		orderedTypes = &types
 	}
 	return *orderedTypes

--- a/controllers/brokerservice_controller.go
+++ b/controllers/brokerservice_controller.go
@@ -27,16 +27,20 @@ import (
 	"github.com/arkmq-org/arkmq-org-broker-operator/pkg/appselector"
 	servicemetrics "github.com/arkmq-org/arkmq-org-broker-operator/pkg/metrics"
 	"github.com/arkmq-org/arkmq-org-broker-operator/pkg/resources"
+	"github.com/arkmq-org/arkmq-org-broker-operator/pkg/resources/networkpolicies"
 	"github.com/arkmq-org/arkmq-org-broker-operator/pkg/resources/secrets"
 	"github.com/arkmq-org/arkmq-org-broker-operator/pkg/utils/common"
+	"github.com/arkmq-org/arkmq-org-broker-operator/pkg/utils/selectors"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	netv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -197,14 +201,19 @@ func (reconciler *BrokerServiceInstanceReconciler) processBroker() (err error) {
 		reconciler.appPropertiesSecretName(),
 	}
 
-	err = reconciler.processAppSecrets()
+	appPorts, err := reconciler.processAppSecrets()
+	if err != nil {
+		return err
+	}
+
+	desired.Spec.NetworkPolicy = buildBrokerServiceNetworkPolicy(desired.Name, appPorts)
 
 	reconciler.TrackDesired(desired)
 
-	return err
+	return nil
 }
 
-func (reconciler *BrokerServiceInstanceReconciler) processAppSecrets() (err error) {
+func (reconciler *BrokerServiceInstanceReconciler) processAppSecrets() (appPorts []int32, err error) {
 	// avoid restart for app onboarding with existing mount points
 	// TODO potentially N app-secrets to overcome 1Mb size limit
 	resourceName := types.NamespacedName{
@@ -225,7 +234,7 @@ func (reconciler *BrokerServiceInstanceReconciler) processAppSecrets() (err erro
 	apps := &broker.BrokerAppList{}
 	key := reconciler.instance.Namespace + ":" + reconciler.instance.Name
 	if err = reconciler.Client.List(context.TODO(), apps, client.MatchingFields{common.AppServiceBindingField: key}); err != nil {
-		return err
+		return nil, err
 	}
 
 	// reset data
@@ -259,6 +268,7 @@ func (reconciler *BrokerServiceInstanceReconciler) processAppSecrets() (err erro
 			reconciler.log.Error(err, "failed to process acceptor for app", "app", app.Name)
 			break
 		}
+		appPorts = append(appPorts, app.Spec.Acceptor.Port)
 		appIdentities = append(appIdentities, AppIdentity(&app))
 		validApps = append(validApps, app)
 	}
@@ -279,7 +289,47 @@ func (reconciler *BrokerServiceInstanceReconciler) processAppSecrets() (err erro
 		err = reconciler.processControlPlaneOverrideSecret(validApps)
 	}
 
-	return err
+	return appPorts, err
+}
+
+// buildBrokerServiceNetworkPolicy constructs a NetworkPolicySpec for a
+// BrokerService-managed broker. It opens the restricted-mode management
+// ports (Jolokia, Prometheus) plus every bound BrokerApp acceptor port.
+func buildBrokerServiceNetworkPolicy(brokerName string, appPorts []int32) *netv1.NetworkPolicySpec {
+	tcp := corev1.ProtocolTCP
+	seen := make(map[int32]bool)
+	var ports []netv1.NetworkPolicyPort
+
+	addPort := func(port int32) {
+		if port <= 0 || seen[port] {
+			return
+		}
+		seen[port] = true
+		p := intstr.FromInt32(port)
+		ports = append(ports, netv1.NetworkPolicyPort{
+			Protocol: &tcp,
+			Port:     &p,
+		})
+	}
+
+	addPort(networkpolicies.RestrictedJolokiaPort)
+	addPort(networkpolicies.RestrictedPrometheusPort)
+
+	for _, port := range appPorts {
+		addPort(port)
+	}
+
+	return &netv1.NetworkPolicySpec{
+		PodSelector: metav1.LabelSelector{
+			MatchLabels: map[string]string{selectors.LabelResourceKey: brokerName},
+		},
+		PolicyTypes: []netv1.PolicyType{netv1.PolicyTypeIngress},
+		Ingress: []netv1.NetworkPolicyIngressRule{
+			{
+				Ports: ports,
+			},
+		},
+	}
 }
 
 func (reconciler *BrokerServiceInstanceReconciler) appPropertiesSecretName() string {

--- a/controllers/brokerservice_controller_unit_test.go
+++ b/controllers/brokerservice_controller_unit_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	netv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -1419,4 +1420,63 @@ func TestBrokerServiceConditionTransitionsOnRecovery(t *testing.T) {
 	assert.NotNil(t, deployedCond)
 	assert.Equal(t, metav1.ConditionTrue, deployedCond.Status)
 	assert.Equal(t, v1beta2.ReadyConditionReason, deployedCond.Reason)
+}
+
+func TestBuildBrokerServiceNetworkPolicy_NoApps(t *testing.T) {
+	spec := buildBrokerServiceNetworkPolicy("my-broker", nil)
+
+	assert.NotNil(t, spec)
+	assert.Equal(t, "my-broker", spec.PodSelector.MatchLabels["ActiveMQArtemis"])
+	assert.Contains(t, spec.PolicyTypes, netv1.PolicyTypeIngress)
+
+	ports := collectNetPolPorts(spec)
+	assert.Contains(t, ports, int32(8778), "Jolokia port")
+	assert.Contains(t, ports, int32(8888), "Prometheus port")
+	assert.Len(t, ports, 2)
+}
+
+func TestBuildBrokerServiceNetworkPolicy_WithAppPorts(t *testing.T) {
+	appPorts := []int32{61617, 5672}
+	spec := buildBrokerServiceNetworkPolicy("my-broker", appPorts)
+
+	ports := collectNetPolPorts(spec)
+	assert.Contains(t, ports, int32(8778), "Jolokia port")
+	assert.Contains(t, ports, int32(8888), "Prometheus port")
+	assert.Contains(t, ports, int32(61617), "first app port")
+	assert.Contains(t, ports, int32(5672), "second app port")
+	assert.Len(t, ports, 4)
+}
+
+func TestBuildBrokerServiceNetworkPolicy_DeduplicatesAppPorts(t *testing.T) {
+	appPorts := []int32{8778, 61617, 61617}
+	spec := buildBrokerServiceNetworkPolicy("my-broker", appPorts)
+
+	ports := collectNetPolPorts(spec)
+	assert.Contains(t, ports, int32(8778))
+	assert.Contains(t, ports, int32(8888))
+	assert.Contains(t, ports, int32(61617))
+	assert.Len(t, ports, 3, "duplicates removed")
+}
+
+func TestBuildBrokerServiceNetworkPolicy_AppUnbind(t *testing.T) {
+	specBefore := buildBrokerServiceNetworkPolicy("my-broker", []int32{61617})
+	portsBefore := collectNetPolPorts(specBefore)
+	assert.Contains(t, portsBefore, int32(61617))
+
+	specAfter := buildBrokerServiceNetworkPolicy("my-broker", nil)
+	portsAfter := collectNetPolPorts(specAfter)
+	assert.NotContains(t, portsAfter, int32(61617), "port removed after app unbind")
+	assert.Len(t, portsAfter, 2, "only restricted ports remain")
+}
+
+func collectNetPolPorts(spec *netv1.NetworkPolicySpec) []int32 {
+	var ports []int32
+	for _, rule := range spec.Ingress {
+		for _, p := range rule.Ports {
+			if p.Port != nil {
+				ports = append(ports, int32(p.Port.IntValue()))
+			}
+		}
+	}
+	return ports
 }

--- a/deploy/arkmq-org-broker-operator.yaml
+++ b/deploy/arkmq-org-broker-operator.yaml
@@ -13747,6 +13747,445 @@ spec:
               ingressDomain:
                 description: The default ingress domain. It is required when any acceptor, connector or console uses the ingress mode and does not specify an IngressHost.
                 type: string
+              networkPolicy:
+                description: |-
+                  Optional NetworkPolicy spec for the broker pods. When set, the operator
+                  uses this spec directly instead of auto-generating a NetworkPolicy.
+                properties:
+                  egress:
+                    description: |-
+                      egress is a list of egress rules to be applied to the selected pods. Outgoing traffic
+                      is allowed if there are no NetworkPolicies selecting the pod (and cluster policy
+                      otherwise allows the traffic), OR if the traffic matches at least one egress rule
+                      across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                      this field is empty then this NetworkPolicy limits all outgoing traffic (and serves
+                      solely to ensure that the pods it selects are isolated by default).
+                      This field is beta-level in 1.8
+                    items:
+                      description: |-
+                        NetworkPolicyEgressRule describes a particular set of traffic that is allowed out of pods
+                        matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and to.
+                        This type is beta-level in 1.8
+                      properties:
+                        ports:
+                          description: |-
+                            ports is a list of destination ports for outgoing traffic.
+                            Each item in this list is combined using a logical OR. If this field is
+                            empty or missing, this rule matches all ports (traffic not restricted by port).
+                            If this field is present and contains at least one item, then this rule allows
+                            traffic only if the traffic matches at least one port in the list.
+                          items:
+                            description: NetworkPolicyPort describes a port to allow traffic on
+                            properties:
+                              endPort:
+                                description: |-
+                                  endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                  should be allowed by the policy. This field cannot be defined if the port field
+                                  is not defined or if the port field is defined as a named (string) port.
+                                  The endPort must be equal or greater than port.
+                                format: int32
+                                type: integer
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: |-
+                                  port represents the port on the given protocol. This can either be a numerical or named
+                                  port on a pod. If this field is not provided, this matches all port names and
+                                  numbers.
+                                  If present, only traffic on the specified protocol AND port will be matched.
+                                x-kubernetes-int-or-string: true
+                              protocol:
+                                description: |-
+                                  protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                  If not specified, this field defaults to TCP.
+                                type: string
+                            type: object
+                          type: array
+                        to:
+                          description: |-
+                            to is a list of destinations for outgoing traffic of pods selected for this rule.
+                            Items in this list are combined using a logical OR operation. If this field is
+                            empty or missing, this rule matches all destinations (traffic not restricted by
+                            destination). If this field is present and contains at least one item, this rule
+                            allows traffic only if the traffic matches at least one item in the to list.
+                          items:
+                            description: |-
+                              NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                              fields are allowed
+                            properties:
+                              ipBlock:
+                                description: |-
+                                  ipBlock defines policy on a particular IPBlock. If this field is set then
+                                  neither of the other fields can be.
+                                properties:
+                                  cidr:
+                                    description: |-
+                                      cidr is a string representing the IPBlock
+                                      Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                    type: string
+                                  except:
+                                    description: |-
+                                      except is a slice of CIDRs that should not be included within an IPBlock
+                                      Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                      Except values will be rejected if they are outside the cidr range
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - cidr
+                                type: object
+                              namespaceSelector:
+                                description: |-
+                                  namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                  standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                  If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                  the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                  Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                    items:
+                                      description: |-
+                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                        relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the selector applies to.
+                                          type: string
+                                        operator:
+                                          description: |-
+                                            operator represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: |-
+                                            values is an array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array is replaced during a strategic
+                                            merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    type: object
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              podSelector:
+                                description: |-
+                                  podSelector is a label selector which selects pods. This field follows standard label
+                                  selector semantics; if present but empty, it selects all pods.
+
+                                  If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                  the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                  Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                    items:
+                                      description: |-
+                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                        relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the selector applies to.
+                                          type: string
+                                        operator:
+                                          description: |-
+                                            operator represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: |-
+                                            values is an array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array is replaced during a strategic
+                                            merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    type: object
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                          type: array
+                      type: object
+                    type: array
+                  ingress:
+                    description: |-
+                      ingress is a list of ingress rules to be applied to the selected pods.
+                      Traffic is allowed to a pod if there are no NetworkPolicies selecting the pod
+                      (and cluster policy otherwise allows the traffic), OR if the traffic source is
+                      the pod's local node, OR if the traffic matches at least one ingress rule
+                      across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                      this field is empty then this NetworkPolicy does not allow any traffic (and serves
+                      solely to ensure that the pods it selects are isolated by default)
+                    items:
+                      description: |-
+                        NetworkPolicyIngressRule describes a particular set of traffic that is allowed to the pods
+                        matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and from.
+                      properties:
+                        from:
+                          description: |-
+                            from is a list of sources which should be able to access the pods selected for this rule.
+                            Items in this list are combined using a logical OR operation. If this field is
+                            empty or missing, this rule matches all sources (traffic not restricted by
+                            source). If this field is present and contains at least one item, this rule
+                            allows traffic only if the traffic matches at least one item in the from list.
+                          items:
+                            description: |-
+                              NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                              fields are allowed
+                            properties:
+                              ipBlock:
+                                description: |-
+                                  ipBlock defines policy on a particular IPBlock. If this field is set then
+                                  neither of the other fields can be.
+                                properties:
+                                  cidr:
+                                    description: |-
+                                      cidr is a string representing the IPBlock
+                                      Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                    type: string
+                                  except:
+                                    description: |-
+                                      except is a slice of CIDRs that should not be included within an IPBlock
+                                      Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                      Except values will be rejected if they are outside the cidr range
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - cidr
+                                type: object
+                              namespaceSelector:
+                                description: |-
+                                  namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                  standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                  If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                  the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                  Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                    items:
+                                      description: |-
+                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                        relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the selector applies to.
+                                          type: string
+                                        operator:
+                                          description: |-
+                                            operator represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: |-
+                                            values is an array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array is replaced during a strategic
+                                            merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    type: object
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              podSelector:
+                                description: |-
+                                  podSelector is a label selector which selects pods. This field follows standard label
+                                  selector semantics; if present but empty, it selects all pods.
+
+                                  If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                  the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                  Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                    items:
+                                      description: |-
+                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                        relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the selector applies to.
+                                          type: string
+                                        operator:
+                                          description: |-
+                                            operator represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: |-
+                                            values is an array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array is replaced during a strategic
+                                            merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    type: object
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                          type: array
+                        ports:
+                          description: |-
+                            ports is a list of ports which should be made accessible on the pods selected for
+                            this rule. Each item in this list is combined using a logical OR. If this field is
+                            empty or missing, this rule matches all ports (traffic not restricted by port).
+                            If this field is present and contains at least one item, then this rule allows
+                            traffic only if the traffic matches at least one port in the list.
+                          items:
+                            description: NetworkPolicyPort describes a port to allow traffic on
+                            properties:
+                              endPort:
+                                description: |-
+                                  endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                  should be allowed by the policy. This field cannot be defined if the port field
+                                  is not defined or if the port field is defined as a named (string) port.
+                                  The endPort must be equal or greater than port.
+                                format: int32
+                                type: integer
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: |-
+                                  port represents the port on the given protocol. This can either be a numerical or named
+                                  port on a pod. If this field is not provided, this matches all port names and
+                                  numbers.
+                                  If present, only traffic on the specified protocol AND port will be matched.
+                                x-kubernetes-int-or-string: true
+                              protocol:
+                                description: |-
+                                  protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                  If not specified, this field defaults to TCP.
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    type: array
+                  podSelector:
+                    description: |-
+                      podSelector selects the pods to which this NetworkPolicy object applies.
+                      The array of ingress rules is applied to any pods selected by this field.
+                      Multiple network policies can select the same set of pods. In this case,
+                      the ingress rules for each are combined additively.
+                      This field is NOT optional and follows standard label selector semantics.
+                      An empty podSelector matches all pods in this namespace.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                        items:
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced during a strategic
+                                merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  policyTypes:
+                    description: |-
+                      policyTypes is a list of rule types that the NetworkPolicy relates to.
+                      Valid options are ["Ingress"], ["Egress"], or ["Ingress", "Egress"].
+                      If this field is not specified, it will default based on the existence of ingress or egress rules;
+                      policies that contain an egress section are assumed to affect egress, and all policies
+                      (whether or not they contain an ingress section) are assumed to affect ingress.
+                      If you want to write an egress-only policy, you must explicitly specify policyTypes [ "Egress" ].
+                      Likewise, if you want to write a policy that specifies that no egress is allowed,
+                      you must specify a policyTypes value that include "Egress" (since such a policy would not include
+                      an egress section and would otherwise default to just [ "Ingress" ]).
+                      This field is beta-level in 1.8
+                    items:
+                      description: |-
+                        PolicyType string describes the NetworkPolicy type
+                        This type is beta-level in 1.8
+                      type: string
+                    type: array
+                required:
+                - podSelector
+                type: object
               resourceTemplates:
                 description: Specifies the template for various resources that the operator controls
                 items:
@@ -14430,6 +14869,7 @@ rules:
   - networking.k8s.io
   resources:
   - ingresses
+  - networkpolicies
   verbs:
   - create
   - delete

--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -142,6 +142,7 @@ rules:
   - networking.k8s.io
   resources:
   - ingresses
+  - networkpolicies
   verbs:
   - create
   - delete

--- a/deploy/crds/broker_broker_crd.yaml
+++ b/deploy/crds/broker_broker_crd.yaml
@@ -4497,6 +4497,445 @@ spec:
               ingressDomain:
                 description: The default ingress domain. It is required when any acceptor, connector or console uses the ingress mode and does not specify an IngressHost.
                 type: string
+              networkPolicy:
+                description: |-
+                  Optional NetworkPolicy spec for the broker pods. When set, the operator
+                  uses this spec directly instead of auto-generating a NetworkPolicy.
+                properties:
+                  egress:
+                    description: |-
+                      egress is a list of egress rules to be applied to the selected pods. Outgoing traffic
+                      is allowed if there are no NetworkPolicies selecting the pod (and cluster policy
+                      otherwise allows the traffic), OR if the traffic matches at least one egress rule
+                      across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                      this field is empty then this NetworkPolicy limits all outgoing traffic (and serves
+                      solely to ensure that the pods it selects are isolated by default).
+                      This field is beta-level in 1.8
+                    items:
+                      description: |-
+                        NetworkPolicyEgressRule describes a particular set of traffic that is allowed out of pods
+                        matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and to.
+                        This type is beta-level in 1.8
+                      properties:
+                        ports:
+                          description: |-
+                            ports is a list of destination ports for outgoing traffic.
+                            Each item in this list is combined using a logical OR. If this field is
+                            empty or missing, this rule matches all ports (traffic not restricted by port).
+                            If this field is present and contains at least one item, then this rule allows
+                            traffic only if the traffic matches at least one port in the list.
+                          items:
+                            description: NetworkPolicyPort describes a port to allow traffic on
+                            properties:
+                              endPort:
+                                description: |-
+                                  endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                  should be allowed by the policy. This field cannot be defined if the port field
+                                  is not defined or if the port field is defined as a named (string) port.
+                                  The endPort must be equal or greater than port.
+                                format: int32
+                                type: integer
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: |-
+                                  port represents the port on the given protocol. This can either be a numerical or named
+                                  port on a pod. If this field is not provided, this matches all port names and
+                                  numbers.
+                                  If present, only traffic on the specified protocol AND port will be matched.
+                                x-kubernetes-int-or-string: true
+                              protocol:
+                                description: |-
+                                  protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                  If not specified, this field defaults to TCP.
+                                type: string
+                            type: object
+                          type: array
+                        to:
+                          description: |-
+                            to is a list of destinations for outgoing traffic of pods selected for this rule.
+                            Items in this list are combined using a logical OR operation. If this field is
+                            empty or missing, this rule matches all destinations (traffic not restricted by
+                            destination). If this field is present and contains at least one item, this rule
+                            allows traffic only if the traffic matches at least one item in the to list.
+                          items:
+                            description: |-
+                              NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                              fields are allowed
+                            properties:
+                              ipBlock:
+                                description: |-
+                                  ipBlock defines policy on a particular IPBlock. If this field is set then
+                                  neither of the other fields can be.
+                                properties:
+                                  cidr:
+                                    description: |-
+                                      cidr is a string representing the IPBlock
+                                      Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                    type: string
+                                  except:
+                                    description: |-
+                                      except is a slice of CIDRs that should not be included within an IPBlock
+                                      Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                      Except values will be rejected if they are outside the cidr range
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - cidr
+                                type: object
+                              namespaceSelector:
+                                description: |-
+                                  namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                  standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                  If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                  the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                  Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                    items:
+                                      description: |-
+                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                        relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the selector applies to.
+                                          type: string
+                                        operator:
+                                          description: |-
+                                            operator represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: |-
+                                            values is an array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array is replaced during a strategic
+                                            merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    type: object
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              podSelector:
+                                description: |-
+                                  podSelector is a label selector which selects pods. This field follows standard label
+                                  selector semantics; if present but empty, it selects all pods.
+
+                                  If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                  the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                  Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                    items:
+                                      description: |-
+                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                        relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the selector applies to.
+                                          type: string
+                                        operator:
+                                          description: |-
+                                            operator represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: |-
+                                            values is an array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array is replaced during a strategic
+                                            merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    type: object
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                          type: array
+                      type: object
+                    type: array
+                  ingress:
+                    description: |-
+                      ingress is a list of ingress rules to be applied to the selected pods.
+                      Traffic is allowed to a pod if there are no NetworkPolicies selecting the pod
+                      (and cluster policy otherwise allows the traffic), OR if the traffic source is
+                      the pod's local node, OR if the traffic matches at least one ingress rule
+                      across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                      this field is empty then this NetworkPolicy does not allow any traffic (and serves
+                      solely to ensure that the pods it selects are isolated by default)
+                    items:
+                      description: |-
+                        NetworkPolicyIngressRule describes a particular set of traffic that is allowed to the pods
+                        matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and from.
+                      properties:
+                        from:
+                          description: |-
+                            from is a list of sources which should be able to access the pods selected for this rule.
+                            Items in this list are combined using a logical OR operation. If this field is
+                            empty or missing, this rule matches all sources (traffic not restricted by
+                            source). If this field is present and contains at least one item, this rule
+                            allows traffic only if the traffic matches at least one item in the from list.
+                          items:
+                            description: |-
+                              NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                              fields are allowed
+                            properties:
+                              ipBlock:
+                                description: |-
+                                  ipBlock defines policy on a particular IPBlock. If this field is set then
+                                  neither of the other fields can be.
+                                properties:
+                                  cidr:
+                                    description: |-
+                                      cidr is a string representing the IPBlock
+                                      Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                    type: string
+                                  except:
+                                    description: |-
+                                      except is a slice of CIDRs that should not be included within an IPBlock
+                                      Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                      Except values will be rejected if they are outside the cidr range
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - cidr
+                                type: object
+                              namespaceSelector:
+                                description: |-
+                                  namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                  standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                  If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                  the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                  Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                    items:
+                                      description: |-
+                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                        relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the selector applies to.
+                                          type: string
+                                        operator:
+                                          description: |-
+                                            operator represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: |-
+                                            values is an array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array is replaced during a strategic
+                                            merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    type: object
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              podSelector:
+                                description: |-
+                                  podSelector is a label selector which selects pods. This field follows standard label
+                                  selector semantics; if present but empty, it selects all pods.
+
+                                  If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                  the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                  Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                    items:
+                                      description: |-
+                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                        relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the selector applies to.
+                                          type: string
+                                        operator:
+                                          description: |-
+                                            operator represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: |-
+                                            values is an array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array is replaced during a strategic
+                                            merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    type: object
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                          type: array
+                        ports:
+                          description: |-
+                            ports is a list of ports which should be made accessible on the pods selected for
+                            this rule. Each item in this list is combined using a logical OR. If this field is
+                            empty or missing, this rule matches all ports (traffic not restricted by port).
+                            If this field is present and contains at least one item, then this rule allows
+                            traffic only if the traffic matches at least one port in the list.
+                          items:
+                            description: NetworkPolicyPort describes a port to allow traffic on
+                            properties:
+                              endPort:
+                                description: |-
+                                  endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                  should be allowed by the policy. This field cannot be defined if the port field
+                                  is not defined or if the port field is defined as a named (string) port.
+                                  The endPort must be equal or greater than port.
+                                format: int32
+                                type: integer
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: |-
+                                  port represents the port on the given protocol. This can either be a numerical or named
+                                  port on a pod. If this field is not provided, this matches all port names and
+                                  numbers.
+                                  If present, only traffic on the specified protocol AND port will be matched.
+                                x-kubernetes-int-or-string: true
+                              protocol:
+                                description: |-
+                                  protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                  If not specified, this field defaults to TCP.
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    type: array
+                  podSelector:
+                    description: |-
+                      podSelector selects the pods to which this NetworkPolicy object applies.
+                      The array of ingress rules is applied to any pods selected by this field.
+                      Multiple network policies can select the same set of pods. In this case,
+                      the ingress rules for each are combined additively.
+                      This field is NOT optional and follows standard label selector semantics.
+                      An empty podSelector matches all pods in this namespace.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                        items:
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced during a strategic
+                                merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  policyTypes:
+                    description: |-
+                      policyTypes is a list of rule types that the NetworkPolicy relates to.
+                      Valid options are ["Ingress"], ["Egress"], or ["Ingress", "Egress"].
+                      If this field is not specified, it will default based on the existence of ingress or egress rules;
+                      policies that contain an egress section are assumed to affect egress, and all policies
+                      (whether or not they contain an ingress section) are assumed to affect ingress.
+                      If you want to write an egress-only policy, you must explicitly specify policyTypes [ "Egress" ].
+                      Likewise, if you want to write a policy that specifies that no egress is allowed,
+                      you must specify a policyTypes value that include "Egress" (since such a policy would not include
+                      an egress section and would otherwise default to just [ "Ingress" ]).
+                      This field is beta-level in 1.8
+                    items:
+                      description: |-
+                        PolicyType string describes the NetworkPolicy type
+                        This type is beta-level in 1.8
+                      type: string
+                    type: array
+                required:
+                - podSelector
+                type: object
               resourceTemplates:
                 description: Specifies the template for various resources that the operator controls
                 items:

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -142,6 +142,7 @@ rules:
   - networking.k8s.io
   resources:
   - ingresses
+  - networkpolicies
   verbs:
   - create
   - delete

--- a/docs/help/operator.md
+++ b/docs/help/operator.md
@@ -1129,6 +1129,74 @@ The operator supports a level of indirection when resolving versions, there are 
 The operator will validate the CR specifies both image and initImage or a Version. It will also validate that a specified version matches the internal list of supported versions.
 The CR Status sub resource will contain feedback via the Valid Condition if validation fails.
 
+## Operand NetworkPolicy
+
+The operator automatically creates a Kubernetes `NetworkPolicy` for each broker deployment.
+This policy controls which network traffic is allowed to reach the broker pods at L3/L4 level.
+
+### Default behaviour
+
+When a broker CR is reconciled, the operator generates a `NetworkPolicy` named `{cr-name}-netpol`
+in the same namespace as the broker. The policy opens ingress ports based on the acceptors declared
+in the CR. In restricted mode, only the Jolokia (8778) and Prometheus (8888) agent ports are opened
+and all other ports are blocked unless explicitly listed. Egress is left unrestricted by default.
+
+Ports configured exclusively through broker properties (rather than the CR `spec.acceptors` field)
+are **not** automatically detected. If you rely on broker properties to define additional acceptors,
+you must open the corresponding ports yourself using a `ResourceTemplate` (see
+[Custom Modifications via a Strategic Merge Patch](#custom-modifications-via-a-strategic-merge-patch)).
+
+### Overriding the generated NetworkPolicy
+
+If the auto-generated policy does not fit your requirements, you can provide a full `NetworkPolicySpec`
+directly on the Broker CR using `spec.networkPolicy`. When this field is set, the operator uses the
+provided spec as-is instead of generating one. This gives full control over ingress and egress rules.
+
+```yaml
+apiVersion: arkmq.org/v1beta2
+kind: Broker
+metadata:
+  name: my-broker
+spec:
+  networkPolicy:
+    podSelector:
+      matchLabels:
+        ActiveMQArtemis: my-broker
+    policyTypes:
+      - Ingress
+    ingress:
+      - ports:
+          - port: 61616
+            protocol: TCP
+```
+
+### Disabling operand NetworkPolicy creation
+
+To disable the automatic creation of NetworkPolicies for all broker deployments managed by the
+operator, set the `DISABLE_OPERAND_NETWORK_POLICY` environment variable to `true` on the operator
+manager container:
+
+```yaml
+env:
+  - name: DISABLE_OPERAND_NETWORK_POLICY
+    value: "true"
+```
+
+When this variable is set, the operator will not create or manage any NetworkPolicy objects for
+broker pods. You are then responsible for managing network access to the brokers yourself, either
+through manually crafted NetworkPolicies or through your cluster's network plugin configuration.
+
+### Operator pod NetworkPolicy
+
+The operator ships its own `NetworkPolicy` (`controller-manager-netpol`) that restricts ingress to
+the health-probe (8081) and metrics (8383) ports. This policy is applied at install time regardless
+of the installation method (deploy scripts, OLM, or Helm charts) and is independent of the operand
+policy described above.
+
+For a hands-on walkthrough that demonstrates deploying a restricted broker with NetworkPolicy
+enforcement on a Calico-backed cluster, see the
+[NetworkPolicy tutorial](../tutorials/network_policy.md).
+
 ## Disabling reconcile with the `arkmq.org/block-reconcile` annotation
 
 In cases where a rollout of the stateful set is necessitated via a new feature or bug fix but not immediately desirable, potentially because of the necessary broker restart, it is possible to block the reconcile of a CR. Applying the `arkmq.org/block-reconcile` boolean annotation to a CR will indicate that the operator should not reconcile the CR. The CR status will reflect the blocked state via an additional `ReconcileBlocked` Condition. Once the annotation is removed or set to false on the CR, reconcile will resume.

--- a/docs/tutorials/network_policy.md
+++ b/docs/tutorials/network_policy.md
@@ -1,0 +1,1488 @@
+---
+title: "Using NetworkPolicies with broker operands"
+description: "Steps to deploy a broker with operator-managed NetworkPolicies, open extra ports via ResourceTemplates, and verify connectivity from a client pod"
+draft: false
+images: []
+menu:
+  docs:
+    parent: "tutorials"
+weight: 130
+---
+
+This tutorial shows how the Artemis Operator automatically creates a
+[NetworkPolicy](https://kubernetes.io/docs/concepts/services-networking/network-policies/)
+for every broker it manages, and how to extend that policy when you configure
+additional ports through broker properties as well as even more restrictive
+policies such as limiting the source of inbound traffic.
+
+**What is a NetworkPolicy?** A Kubernetes NetworkPolicy is an L3/L4 firewall for
+pods. It controls which traffic is allowed to reach a pod and which is not. When
+at least one NetworkPolicy selects a pod, all ingress traffic not explicitly
+allowed by a rule is denied.
+
+**Why does the operator create one?** To comply with security initiatives that
+require every workload to have a NetworkPolicy restricting ingress to only the
+ports it actually needs. The operator knows which ports it manages (the headless
+service defaults, acceptors, and connectors declared in the CR) and generates
+the policy accordingly.
+
+**What about broker properties?** Ports configured solely through broker
+properties are opaque to the operator. The operator cannot reliably parse them,
+so it does **not** open those ports automatically. If you define additional
+acceptors via broker properties, you must use a
+[ResourceTemplate](../help/operator.md#configuring-resourcetemplates) to tell
+the operator to patch the NetworkPolicy with those extra ports.
+
+This tutorial covers: starting a cluster with a CNI that enforces
+NetworkPolicies, setting up a PKI with cert-manager, deploying a locked-down
+broker with a broker-properties acceptor and a ResourceTemplate, verifying all
+five status conditions are `True`, and producing/consuming messages from a
+separate client pod to prove the NetworkPolicy is correctly configured.
+
+## Table of Contents
+
+* [Architecture Overview](#architecture-overview)
+* [Prerequisites](#prerequisites)
+* [Install the dependencies](#install-the-dependencies)
+* [Create Certificate Authority and Issuers](#create-certificate-authority-and-issuers)
+* [Deploy the Broker](#deploy-the-broker)
+* [Verify the NetworkPolicy](#verify-the-networkpolicy)
+* [Exchange Messages](#exchange-messages)
+* [Verify NetworkPolicy Enforcement](#verify-networkpolicy-enforcement)
+* [Troubleshooting](#troubleshooting)
+* [Cleanup](#cleanup)
+* [Conclusion](#conclusion)
+
+## Architecture Overview
+
+### NetworkPolicy Flow
+
+This diagram shows how the operator-generated NetworkPolicy restricts ingress
+to the broker pod, allowing only the declared ports:
+
+```mermaid
+graph LR
+    subgraph cluster ["Kubernetes Cluster (Calico CNI)"]
+        subgraph ns ["netpol-tutorial namespace"]
+            Operator["ArkMQ Operator"]
+            Broker["Artemis Broker<br/>Pod"]
+            NP["NetworkPolicy<br/>(auto-generated)"]
+            Client["Client Pod"]
+        end
+    end
+
+    Operator -->|"Creates & manages"| NP
+    Operator -->|"Manages"| Broker
+    NP -.->|"Selects & protects"| Broker
+    Client -->|"AMQPS:61617 ✅"| Broker
+    Client -->|"other ports ❌"| Broker
+
+    style NP fill:#ffcc02,stroke:#f57c00,stroke-width:2px
+    style Broker fill:#a5d6a7,stroke:#2e7d32,stroke-width:2px
+    style Client fill:#e1bee7,stroke:#8e24aa,stroke-width:2px
+```
+
+### Certificate Infrastructure
+
+Identical to the [Prometheus locked-down tutorial](prometheus_locked_down.md),
+we use cert-manager to build a chain of trust:
+
+```mermaid
+graph TB
+    subgraph ca_layer ["Certificate Authority Layer"]
+        SelfSigned["Self-Signed Root CA"]
+        RootCA["Root Certificate<br />(artemis.root.ca)"]
+        CAIssuer["CA Issuer"]
+    end
+
+    subgraph cert_layer ["Application Certificates"]
+        ServerCert["🖥️ Server<br />CN: activemq-artemis-<br />operand"]
+        OperatorCert["⚙️ Operator<br />CN: activemq-artemis-<br />operator"]
+        MessagingCert["💬 Messaging<br />CN: messaging-client"]
+    end
+
+    subgraph trust_layer ["Trust Distribution"]
+        TrustBundle["CA Trust Bundle<br />(distributed to all<br />namespaces)"]
+    end
+
+    SelfSigned --> RootCA
+    RootCA --> CAIssuer
+    CAIssuer --> ServerCert
+    CAIssuer --> OperatorCert
+    CAIssuer --> MessagingCert
+
+    RootCA -.-> TrustBundle
+    TrustBundle -.-> ServerCert
+    TrustBundle -.-> OperatorCert
+    TrustBundle -.-> MessagingCert
+
+    style ca_layer fill:#e1bee7,stroke:#8e24aa,stroke-width:2px
+    style cert_layer fill:#a5d6a7,stroke:#2e7d32,stroke-width:2px
+    style trust_layer fill:#ffcc02,stroke:#f57c00,stroke-width:2px
+```
+
+## Prerequisites
+
+### Required Tools
+
+* **kubectl** v1.28+ - Kubernetes command-line tool
+* **helm** v3.12+ - Package manager for Kubernetes
+* **minikube** v1.30+ (or alternatives like [kind](https://kind.sigs.k8s.io/)
+  v0.20+, [k3s](https://k3s.io/))
+
+### Minimum System Resources
+
+* **CPU:** 4 cores minimum
+* **RAM:** 8GB minimum (minikube will use ~6GB)
+* **Disk:** 20GB free space
+
+### Kubernetes Cluster
+
+You need access to a running Kubernetes cluster **with a CNI plugin that
+enforces NetworkPolicies**. The default minikube CNI (`bridge`/`kindnet`) does
+**not** enforce NetworkPolicies. This tutorial uses Calico.
+
+> **Important**: Without a NetworkPolicy-enforcing CNI, the NetworkPolicy
+> resources will exist in the cluster but have no effect. All traffic will be
+> allowed regardless of the rules.
+
+### Start minikube with Calico
+
+Start minikube with the `--cni=calico` flag so that NetworkPolicies are
+actually enforced:
+
+```{"stage":"init", "id":"minikube_start"}
+minikube start --profile netpol-tutorial --memory=6000 --cpus=2 --cni=calico
+minikube profile netpol-tutorial
+kubectl config use-context netpol-tutorial
+```
+```shell markdown_runner
+* [netpol-tutorial] minikube v1.37.0 on Fedora 43
+  - MINIKUBE_ROOTLESS=true
+* Automatically selected the kvm2 driver. Other choices: podman, qemu2, ssh
+* Starting "netpol-tutorial" primary control-plane node in "netpol-tutorial" cluster
+* Configuring Calico (Container Networking Interface) ...
+* Verifying Kubernetes components...
+  - Using image gcr.io/k8s-minikube/storage-provisioner:v5
+* Enabled addons: default-storageclass, storage-provisioner
+* Done! kubectl is now configured to use "netpol-tutorial" cluster and "default" namespace by default
+* minikube profile was successfully set to netpol-tutorial
+Switched to context "netpol-tutorial".
+```
+
+Wait for Calico to be fully operational. A short pause is needed because
+the Calico DaemonSet pods may not exist immediately after `minikube start`
+returns:
+
+```{"stage":"init", "runtime":"bash", "label":"wait for calico"}
+until kubectl get pod -l k8s-app=calico-node -n kube-system 2>/dev/null | grep -q calico; do sleep 2; done
+kubectl wait pod -l k8s-app=calico-node -n kube-system --for=condition=Ready --timeout=300s
+kubectl wait pod -l k8s-app=calico-kube-controllers -n kube-system --for=condition=Ready --timeout=300s
+```
+```shell markdown_runner
+pod/calico-node-hlnjk condition met
+pod/calico-kube-controllers-59556d9b4c-gtv5p condition met
++ grep -q calico
++ kubectl get pod -l k8s-app=calico-node -n kube-system
++ sleep 2
++ kubectl get pod -l k8s-app=calico-node -n kube-system
++ grep -q calico
++ sleep 2
++ kubectl get pod -l k8s-app=calico-node -n kube-system
++ grep -q calico
++ kubectl wait pod -l k8s-app=calico-node -n kube-system --for=condition=Ready --timeout=300s
++ kubectl wait pod -l k8s-app=calico-kube-controllers -n kube-system --for=condition=Ready --timeout=300s
++ echo '### ENV ###'
++ printenv
+```
+
+### Create the namespace
+
+All resources for this tutorial will be created in the `netpol-tutorial`
+namespace.
+
+```{"stage":"init", "runtime":"bash", "label":"create the namespace"}
+kubectl create namespace netpol-tutorial
+kubectl config set-context --current --namespace=netpol-tutorial
+until kubectl get serviceaccount default -n netpol-tutorial &> /dev/null; do sleep 1; done
+```
+```shell markdown_runner
+namespace/netpol-tutorial created
+Context "netpol-tutorial" modified.
++ kubectl create namespace netpol-tutorial
++ kubectl config set-context --current --namespace=netpol-tutorial
++ kubectl get serviceaccount default -n netpol-tutorial
++ echo '### ENV ###'
++ printenv
+```
+
+### Deploy the Operator
+
+Go to the root of the operator repo and install it into the `netpol-tutorial`
+namespace.
+
+```{"stage":"init", "rootdir":"$initial_dir"}
+./deploy/install_opr.sh
+```
+```shell markdown_runner
+Deploying operator to watch single namespace
+Client Version: 4.18.5
+Kustomize Version: v5.4.2
+Kubernetes Version: v1.34.0
+customresourcedefinition.apiextensions.k8s.io/activemqartemises.broker.amq.io created
+customresourcedefinition.apiextensions.k8s.io/activemqartemisaddresses.broker.amq.io created
+customresourcedefinition.apiextensions.k8s.io/activemqartemisscaledowns.broker.amq.io created
+customresourcedefinition.apiextensions.k8s.io/activemqartemissecurities.broker.amq.io created
+customresourcedefinition.apiextensions.k8s.io/brokers.arkmq.org created
+customresourcedefinition.apiextensions.k8s.io/brokerapps.arkmq.org created
+customresourcedefinition.apiextensions.k8s.io/brokerservices.arkmq.org created
+serviceaccount/arkmq-org-broker-controller-manager created
+role.rbac.authorization.k8s.io/arkmq-org-broker-operator-role created
+rolebinding.rbac.authorization.k8s.io/arkmq-org-broker-operator-rolebinding created
+role.rbac.authorization.k8s.io/arkmq-org-broker-leader-election-role created
+rolebinding.rbac.authorization.k8s.io/arkmq-org-broker-leader-election-rolebinding created
+networkpolicy.networking.k8s.io/arkmq-org-broker-controller-manager-netpol created
+deployment.apps/arkmq-org-broker-controller-manager created
+Warning: unrecognized format "int32"
+Warning: unrecognized format "int64"
+```
+
+Wait for the Operator to start (status: `running`).
+
+```{"stage":"init", "label":"wait for the operator to be running"}
+kubectl wait deployment arkmq-org-broker-controller-manager --for=create --timeout=240s
+kubectl wait pod --all --for=condition=Ready --namespace=netpol-tutorial --timeout=600s
+```
+```shell markdown_runner
+deployment.apps/arkmq-org-broker-controller-manager condition met
+pod/arkmq-org-broker-controller-manager-7bc7d7b7b-wk7wx condition met
+```
+
+## Install the dependencies
+
+### Install Cert-Manager
+
+```{"stage":"certs"}
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.13.2/cert-manager.yaml
+```
+```shell markdown_runner
+namespace/cert-manager created
+customresourcedefinition.apiextensions.k8s.io/certificaterequests.cert-manager.io created
+customresourcedefinition.apiextensions.k8s.io/certificates.cert-manager.io created
+customresourcedefinition.apiextensions.k8s.io/challenges.acme.cert-manager.io created
+customresourcedefinition.apiextensions.k8s.io/clusterissuers.cert-manager.io created
+customresourcedefinition.apiextensions.k8s.io/issuers.cert-manager.io created
+customresourcedefinition.apiextensions.k8s.io/orders.acme.cert-manager.io created
+serviceaccount/cert-manager-cainjector created
+serviceaccount/cert-manager created
+serviceaccount/cert-manager-webhook created
+configmap/cert-manager created
+configmap/cert-manager-webhook created
+clusterrole.rbac.authorization.k8s.io/cert-manager-cainjector created
+clusterrole.rbac.authorization.k8s.io/cert-manager-controller-issuers created
+clusterrole.rbac.authorization.k8s.io/cert-manager-controller-clusterissuers created
+clusterrole.rbac.authorization.k8s.io/cert-manager-controller-certificates created
+clusterrole.rbac.authorization.k8s.io/cert-manager-controller-orders created
+clusterrole.rbac.authorization.k8s.io/cert-manager-controller-challenges created
+clusterrole.rbac.authorization.k8s.io/cert-manager-controller-ingress-shim created
+clusterrole.rbac.authorization.k8s.io/cert-manager-cluster-view created
+clusterrole.rbac.authorization.k8s.io/cert-manager-view created
+clusterrole.rbac.authorization.k8s.io/cert-manager-edit created
+clusterrole.rbac.authorization.k8s.io/cert-manager-controller-approve:cert-manager-io created
+clusterrole.rbac.authorization.k8s.io/cert-manager-controller-certificatesigningrequests created
+clusterrole.rbac.authorization.k8s.io/cert-manager-webhook:subjectaccessreviews created
+clusterrolebinding.rbac.authorization.k8s.io/cert-manager-cainjector created
+clusterrolebinding.rbac.authorization.k8s.io/cert-manager-controller-issuers created
+clusterrolebinding.rbac.authorization.k8s.io/cert-manager-controller-clusterissuers created
+clusterrolebinding.rbac.authorization.k8s.io/cert-manager-controller-certificates created
+clusterrolebinding.rbac.authorization.k8s.io/cert-manager-controller-orders created
+clusterrolebinding.rbac.authorization.k8s.io/cert-manager-controller-challenges created
+clusterrolebinding.rbac.authorization.k8s.io/cert-manager-controller-ingress-shim created
+clusterrolebinding.rbac.authorization.k8s.io/cert-manager-controller-approve:cert-manager-io created
+clusterrolebinding.rbac.authorization.k8s.io/cert-manager-controller-certificatesigningrequests created
+clusterrolebinding.rbac.authorization.k8s.io/cert-manager-webhook:subjectaccessreviews created
+role.rbac.authorization.k8s.io/cert-manager-cainjector:leaderelection created
+role.rbac.authorization.k8s.io/cert-manager:leaderelection created
+role.rbac.authorization.k8s.io/cert-manager-webhook:dynamic-serving created
+rolebinding.rbac.authorization.k8s.io/cert-manager-cainjector:leaderelection created
+rolebinding.rbac.authorization.k8s.io/cert-manager:leaderelection created
+rolebinding.rbac.authorization.k8s.io/cert-manager-webhook:dynamic-serving created
+service/cert-manager created
+service/cert-manager-webhook created
+deployment.apps/cert-manager-cainjector created
+deployment.apps/cert-manager created
+deployment.apps/cert-manager-webhook created
+mutatingwebhookconfiguration.admissionregistration.k8s.io/cert-manager-webhook created
+validatingwebhookconfiguration.admissionregistration.k8s.io/cert-manager-webhook created
+Warning: unrecognized format "int32"
+Warning: unrecognized format "int64"
+```
+
+Wait for `cert-manager` to be ready.
+
+```{"stage":"certs", "label":"wait for cert-manager"}
+kubectl wait pod --all --for=condition=Ready --namespace=cert-manager --timeout=600s
+```
+```shell markdown_runner
+pod/cert-manager-5c994d7f66-vt5m8 condition met
+pod/cert-manager-cainjector-7f656b4cf5-v6lws condition met
+pod/cert-manager-webhook-5f65679fbf-p9vdz condition met
+```
+
+### Install Trust Manager
+
+```bash {"stage":"init", "label":"add jetstack helm repo", "runtime":"bash"}
+helm repo add jetstack https://charts.jetstack.io --force-update
+```
+```shell markdown_runner
+"jetstack" has been added to your repositories
++ helm repo add jetstack https://charts.jetstack.io --force-update
++ echo '### ENV ###'
++ printenv
+```
+
+```bash {"stage":"init", "label":"install trust-manager", "runtime":"bash"}
+helm upgrade trust-manager jetstack/trust-manager --install --namespace cert-manager --set secretTargets.enabled=true --set secretTargets.authorizedSecretsAll=true --wait
+```
+```shell markdown_runner
+Release "trust-manager" does not exist. Installing it now.
+NAME: trust-manager
+LAST DEPLOYED: Tue Apr 14 16:01:29 2026
+NAMESPACE: cert-manager
+STATUS: deployed
+REVISION: 1
+TEST SUITE: None
+NOTES:
+⚠️  WARNING: Consider increasing the Helm value `replicaCount` to 2 if you require high availability.
+⚠️  WARNING: Consider setting the Helm value `podDisruptionBudget.enabled` to true if you require high availability.
+
+trust-manager v0.22.0 has been deployed successfully!
+Your installation includes a default CA package, using the following
+default CA package image:
+
+:
+
+It's imperative that you keep the default CA package image up to date.
+To find out more about securely running trust-manager and to get started
+with creating your first bundle, check out the documentation on the
+cert-manager website:
+
+https://cert-manager.io/docs/projects/trust-manager/
++ helm upgrade trust-manager jetstack/trust-manager --install --namespace cert-manager --set secretTargets.enabled=true --set secretTargets.authorizedSecretsAll=true --wait
+I0414 16:01:29.890462  393579 warnings.go:110] "Warning: unrecognized format \"int64\""
++ echo '### ENV ###'
++ printenv
+```
+
+Wait for `trust bundles crd` to be ready.
+
+```{"stage":"certs", "label":"wait for trust-bundles-crd creation"}
+kubectl wait crd bundles.trust.cert-manager.io --for=create --timeout=240s
+kubectl wait pod --all --for=condition=Ready --namespace=cert-manager --timeout=600s
+```
+```shell markdown_runner
+customresourcedefinition.apiextensions.k8s.io/bundles.trust.cert-manager.io condition met
+pod/cert-manager-5c994d7f66-vt5m8 condition met
+pod/cert-manager-cainjector-7f656b4cf5-v6lws condition met
+pod/cert-manager-webhook-5f65679fbf-p9vdz condition met
+pod/trust-manager-c55bfb775-tjrxb condition met
+```
+
+## Create Certificate Authority and Issuers
+
+This section is identical to the
+[Prometheus locked-down tutorial](prometheus_locked_down.md#create-certificate-authority-and-issuers).
+We create a self-signed root CA, distribute it via trust-manager, and create a
+ClusterIssuer that signs all our certificates.
+
+### Create a Root CA
+
+```{"stage":"certs", "runtime":"bash", "label":"create root issuer"}
+kubectl apply -f - <<EOF
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: selfsigned-root-issuer
+spec:
+  selfSigned: {}
+EOF
+```
+```shell markdown_runner
+clusterissuer.cert-manager.io/selfsigned-root-issuer created
++ kubectl apply -f -
++ echo '### ENV ###'
++ printenv
+```
+
+```{"stage":"certs", "runtime":"bash", "label":"create root certificate"}
+kubectl apply -f - <<EOF
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: root-ca
+  namespace: cert-manager
+spec:
+  isCA: true
+  commonName: artemis.root.ca
+  secretName: root-ca-secret
+  issuerRef:
+    name: selfsigned-root-issuer
+    kind: ClusterIssuer
+    group: cert-manager.io
+EOF
+```
+```shell markdown_runner
+certificate.cert-manager.io/root-ca created
++ kubectl apply -f -
++ echo '### ENV ###'
++ printenv
+```
+
+```bash {"stage":"certs", "label":"wait for root-ca ready", "runtime":"bash"}
+kubectl wait certificate root-ca -n cert-manager --for=condition=Ready --timeout=300s
+```
+```shell markdown_runner
+certificate.cert-manager.io/root-ca condition met
++ kubectl wait certificate root-ca -n cert-manager --for=condition=Ready --timeout=300s
++ echo '### ENV ###'
++ printenv
+```
+
+### Create a CA Bundle
+
+The trust-manager webhook may take a moment to start accepting requests after
+the pod is `Ready`. The `until` loop retries until the webhook responds.
+
+```bash {"stage":"certs", "label":"create ca bundle", "runtime":"bash"}
+until kubectl apply -f - <<EOF
+apiVersion: trust.cert-manager.io/v1alpha1
+kind: Bundle
+metadata:
+  name: activemq-artemis-manager-ca
+  namespace: cert-manager
+spec:
+  sources:
+  - secret:
+      name: root-ca-secret
+      key: "tls.crt"
+  target:
+    secret:
+      key: "ca.pem"
+EOF
+do echo "Waiting for trust-manager webhook..." && sleep 5; done
+```
+```shell markdown_runner
+Waiting for trust-manager webhook...
+bundle.trust.cert-manager.io/activemq-artemis-manager-ca created
++ kubectl apply -f -
+Error from server (InternalError): error when creating "STDIN": Internal error occurred: failed calling webhook "trust.cert-manager.io": failed to call webhook: Post "https://trust-manager.cert-manager.svc:443/validate-trust-cert-manager-io-v1alpha1-bundle?timeout=5s": dial tcp 10.100.249.142:443: connect: connection refused
++ echo 'Waiting for trust-manager webhook...'
++ sleep 5
++ kubectl apply -f -
++ echo '### ENV ###'
++ printenv
+```
+
+```bash {"stage":"certs", "label":"wait for ca bundle", "runtime":"bash"}
+kubectl wait bundle activemq-artemis-manager-ca -n cert-manager --for=condition=Synced --timeout=300s
+```
+```shell markdown_runner
+bundle.trust.cert-manager.io/activemq-artemis-manager-ca condition met
++ kubectl wait bundle activemq-artemis-manager-ca -n cert-manager --for=condition=Synced --timeout=300s
++ echo '### ENV ###'
++ printenv
+```
+
+### Create a Cluster Issuer
+
+```{"stage":"certs", "runtime":"bash", "label":"create ca issuer"}
+kubectl apply -f - <<EOF
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: ca-issuer
+spec:
+  ca:
+    secretName: root-ca-secret
+EOF
+```
+```shell markdown_runner
+clusterissuer.cert-manager.io/ca-issuer created
++ kubectl apply -f -
++ echo '### ENV ###'
++ printenv
+```
+
+## Deploy the Broker
+
+### Create Broker and Client Certificates
+
+We need two certificates:
+
+1. A server certificate for the broker pod (`broker-cert`)
+2. A client certificate for the operator to authenticate with the broker
+   (`activemq-artemis-manager-cert`)
+
+```{"stage":"deploy", "runtime":"bash", "label":"create broker and client certs"}
+kubectl apply -f - <<EOF
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: broker-cert
+  namespace: netpol-tutorial
+spec:
+  secretName: broker-cert
+  commonName: activemq-artemis-operand
+  dnsNames:
+    - artemis-broker-ss-0.artemis-broker-hdls-svc.netpol-tutorial.svc.cluster.local
+    - '*.artemis-broker-hdls-svc.netpol-tutorial.svc.cluster.local'
+    - artemis-broker-messaging-svc.cluster.local
+    - artemis-broker-messaging-svc
+  issuerRef:
+    name: ca-issuer
+    kind: ClusterIssuer
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: activemq-artemis-manager-cert
+  namespace: netpol-tutorial
+spec:
+  secretName: activemq-artemis-manager-cert
+  commonName: activemq-artemis-operator
+  issuerRef:
+    name: ca-issuer
+    kind: ClusterIssuer
+EOF
+```
+```shell markdown_runner
+certificate.cert-manager.io/broker-cert created
+certificate.cert-manager.io/activemq-artemis-manager-cert created
++ kubectl apply -f -
++ echo '### ENV ###'
++ printenv
+```
+
+Wait for the secrets to be created.
+
+```{"stage":"deploy", "runtime":"bash", "label":"wait for secrets"}
+kubectl wait --for=condition=Ready certificate broker-cert -n netpol-tutorial --timeout=300s
+kubectl wait --for=condition=Ready certificate activemq-artemis-manager-cert -n netpol-tutorial --timeout=300s
+```
+```shell markdown_runner
+certificate.cert-manager.io/broker-cert condition met
+certificate.cert-manager.io/activemq-artemis-manager-cert condition met
++ kubectl wait --for=condition=Ready certificate broker-cert -n netpol-tutorial --timeout=300s
++ kubectl wait --for=condition=Ready certificate activemq-artemis-manager-cert -n netpol-tutorial --timeout=300s
++ echo '### ENV ###'
++ printenv
+```
+
+### Create the AMQPS acceptor TLS configuration
+
+Create a PEMCFG file that tells the broker where to find its TLS certificate and
+key for the AMQPS acceptor.
+
+```bash {"stage":"deploy", "label":"acceptor pemcfg secret", "runtime":"bash"}
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: amqps-pem
+  namespace: netpol-tutorial
+type: Opaque
+stringData:
+  _amqps.pemcfg: |
+    source.key=/amq/extra/secrets/broker-cert/tls.key
+    source.cert=/amq/extra/secrets/broker-cert/tls.crt
+EOF
+```
+```shell markdown_runner
+secret/amqps-pem created
++ kubectl apply -f -
++ echo '### ENV ###'
++ printenv
+```
+
+### Create the JAAS configuration for messaging clients
+
+Create two secrets for the JAAS login module:
+
+1. **`artemis-broker-jaas-creds`** - Contains the JAAS credential mapping files
+   (`cert-users` and `cert-roles`). These are plain text files, **not** broker
+   properties, so they must live in a separate secret without the `-bp` suffix.
+   Placing them in a `-bp` secret would cause the operator to treat them as
+   broker-property files and report `BrokerPropertiesApplied: Unknown`.
+
+2. **`artemis-broker-jaas-config-bp`** - Contains the broker properties that
+   configure the JAAS login module. The `-bp` suffix tells the operator to apply
+   these.
+
+```{"stage":"deploy", "runtime":"bash", "label":"create jaas creds secret"}
+kubectl apply -f - <<'EOF'
+apiVersion: v1
+kind: Secret
+metadata:
+  name: artemis-broker-jaas-creds
+  namespace: netpol-tutorial
+stringData:
+  cert-users: "messaging-client=/.*messaging-client.*/"
+  cert-roles: "messaging=messaging-client"
+EOF
+```
+```shell markdown_runner
+secret/artemis-broker-jaas-creds created
++ kubectl apply -f -
++ echo '### ENV ###'
++ printenv
+```
+
+```{"stage":"deploy", "runtime":"bash", "label":"create jaas config bp secret"}
+kubectl apply -f - <<'EOF'
+apiVersion: v1
+kind: Secret
+metadata:
+  name: artemis-broker-jaas-config-bp
+  namespace: netpol-tutorial
+stringData:
+  jaas-config-bp.properties: |
+    jaasConfigs."activemq".modules.cert.loginModuleClass=org.apache.activemq.artemis.spi.core.security.jaas.TextFileCertificateLoginModule
+    jaasConfigs."activemq".modules.cert.controlFlag=required
+    jaasConfigs."activemq".modules.cert.params.debug=true
+    jaasConfigs."activemq".modules.cert.params."org.apache.activemq.jaas.textfiledn.role"=cert-roles
+    jaasConfigs."activemq".modules.cert.params."org.apache.activemq.jaas.textfiledn.user"=cert-users
+    jaasConfigs."activemq".modules.cert.params.baseDir=/amq/extra/secrets/artemis-broker-jaas-creds
+EOF
+```
+```shell markdown_runner
+secret/artemis-broker-jaas-config-bp created
++ kubectl apply -f -
++ echo '### ENV ###'
++ printenv
+```
+
+### Deploy the Broker Custom Resource
+
+Now deploy the `Broker` custom resource. This broker has:
+
+* `restricted: true` for certificate-based authentication
+* An AMQPS acceptor on port **61617** configured entirely through **broker
+  properties**
+* A **ResourceTemplate** that patches the operator-generated NetworkPolicy to
+  open port 61617 and restrict Jolokia to the operator pod only
+
+**Why the ResourceTemplate?** The operator generates a NetworkPolicy with only
+the ports it knows about from the CR's explicit fields (headless service
+defaults, `spec.acceptors`, `spec.connectors`). Ports defined solely through
+broker properties are invisible to the operator. The ResourceTemplate patches
+the NetworkPolicy to include port 61617. Also by default the network policy
+doesn't restrict what pod is allowed to access a given port, we're using this
+template as an opportunity to demonstrate the advanced capabilities offered by
+the network policies.
+
+**Important:** ResourceTemplate patches on `spec.ingress` **replace** the entire
+list (there is no merge key on `NetworkPolicyIngressRule`). You must therefore
+list **all** desired ingress rules in the patch, not just the extra one.
+
+The default ports for a non-restricted broker are:
+
+| Port  | Service            |
+|-------|--------------------|
+| 7800  | JGroups clustering |
+| 8161  | Console / Jolokia (limiting access from the operator pod)  |
+| 8778  | Jolokia agent      |
+| 61616 | All protocols      |
+
+Since we use `restricted: true`, the operator's base NetworkPolicy only opens
+8778 (Jolokia) and 8888 (Prometheus). The ResourceTemplate replaces those rules
+with three entries:
+
+* **8778 (Jolokia)** -- restricted via a `from` pod selector so that only the
+  operator pod (`control-plane: controller-manager`) can reach it
+* **8888 (Prometheus)** -- open to any source (all namespaces and external traffic)
+* **61617 (AMQPS acceptor)** -- open to any source (all namespaces and external traffic)
+
+```{"stage":"deploy", "runtime":"bash", "label":"deploy broker cr"}
+kubectl apply -f - <<'EOF'
+apiVersion: broker.arkmq.org/v1beta2
+kind: Broker
+metadata:
+  name: artemis-broker
+  namespace: netpol-tutorial
+spec:
+  restricted: true
+  brokerProperties:
+    - "messageCounterSamplePeriod=500"
+    # Create a queue for messaging
+    - "addressConfigurations.APP_JOBS.routingTypes=ANYCAST"
+    - "addressConfigurations.APP_JOBS.queueConfigs.APP_JOBS.routingType=ANYCAST"
+    # Define a new 'messaging' role with permissions for the APP_JOBS address
+    - "securityRoles.APP_JOBS.messaging.browse=true"
+    - "securityRoles.APP_JOBS.messaging.consume=true"
+    - "securityRoles.APP_JOBS.messaging.send=true"
+    - "securityRoles.APP_JOBS.messaging.view=true"
+    # AMQPS acceptor configured via broker properties (not CR spec.acceptors)
+    - "acceptorConfigurations.\"amqps\".factoryClassName=org.apache.activemq.artemis.core.remoting.impl.netty.NettyAcceptorFactory"
+    - "acceptorConfigurations.\"amqps\".params.host=0.0.0.0"
+    - "acceptorConfigurations.\"amqps\".params.port=61617"
+    - "acceptorConfigurations.\"amqps\".params.protocols=amqp"
+    - "acceptorConfigurations.\"amqps\".params.securityDomain=activemq"
+    - "acceptorConfigurations.\"amqps\".params.sslEnabled=true"
+    - "acceptorConfigurations.\"amqps\".params.needClientAuth=true"
+    - "acceptorConfigurations.\"amqps\".params.saslMechanisms=EXTERNAL"
+    - "acceptorConfigurations.\"amqps\".params.keyStoreType=PEMCFG"
+    - "acceptorConfigurations.\"amqps\".params.keyStorePath=/amq/extra/secrets/amqps-pem/_amqps.pemcfg"
+    - "acceptorConfigurations.\"amqps\".params.trustStoreType=PEMCA"
+    - "acceptorConfigurations.\"amqps\".params.trustStorePath=/amq/extra/secrets/activemq-artemis-manager-ca/ca.pem"
+  deploymentPlan:
+    extraMounts:
+      secrets: [artemis-broker-jaas-config-bp, artemis-broker-jaas-creds, amqps-pem]
+  resourceTemplates:
+    - selector:
+        kind: NetworkPolicy
+      # This patch REPLACES the entire spec.ingress list because
+      # NetworkPolicyIngressRule has no strategic merge key.
+      # All desired ports must be listed -- not just the extra one.
+      patch:
+        kind: NetworkPolicy
+        apiVersion: networking.k8s.io/v1
+        spec:
+          ingress:
+            # Jolokia: only the operator pod may reach it
+            - from:
+                - podSelector:
+                    matchLabels:
+                      control-plane: controller-manager
+                      name: arkmq-org-broker-operator
+              ports:
+                - port: 8778
+                  protocol: TCP
+            # Prometheus agent + AMQPS acceptor: open to any source (all namespaces + external)
+            - ports:
+                - port: 8888
+                  protocol: TCP
+                - port: 61617
+                  protocol: TCP
+EOF
+```
+```shell markdown_runner
+broker.arkmq.org/artemis-broker created
++ kubectl apply -f -
++ echo '### ENV ###'
++ printenv
+```
+
+Wait for the broker to be ready.
+
+```{"stage":"deploy"}
+kubectl wait Broker artemis-broker --for=condition=Ready --namespace=netpol-tutorial --timeout=300s
+```
+```shell markdown_runner
+broker.arkmq.org/artemis-broker condition met
+```
+
+## Verify the NetworkPolicy
+
+### Check all five status conditions
+
+A healthy broker should have all five conditions set to `True`:
+
+* **Valid** - CR passed validation
+* **Deployed** - All pods are ready
+* **Ready** - Resource is fully ready
+* **BrokerPropertiesApplied** - Broker properties configuration applied
+* **BrokerVersionAligned** - Broker image version matches the operator's known versions
+
+Some conditions take a few reconciliation cycles to transition from `Unknown`
+to `True`, so we poll until they settle.
+
+```{"stage":"verify", "runtime":"bash", "label":"assert all conditions true"}
+TIMEOUT=120
+INTERVAL=5
+ELAPSED=0
+
+while [ $ELAPSED -lt $TIMEOUT ]; do
+  CONDITIONS=$(kubectl get Broker artemis-broker -n netpol-tutorial -o json \
+    | jq -r '.status.conditions[] | "\(.type): \(.status)"')
+  TOTAL_COUNT=$(echo "$CONDITIONS" | wc -l)
+  TRUE_COUNT=$(echo "$CONDITIONS" | grep -c "True" || true)
+
+  if [ "$TOTAL_COUNT" -gt 0 ] && [ "$TRUE_COUNT" -eq "$TOTAL_COUNT" ]; then
+    echo "$CONDITIONS"
+    echo ""
+    echo "Status: ${TRUE_COUNT}/${TOTAL_COUNT} conditions True"
+    echo "All conditions are True"
+    exit 0
+  fi
+
+  echo "  ${TRUE_COUNT}/${TOTAL_COUNT} True so far, retrying in ${INTERVAL}s..."
+  sleep $INTERVAL
+  ELAPSED=$((ELAPSED + INTERVAL))
+done
+
+echo ""
+echo "Final state after ${TIMEOUT}s:"
+echo "$CONDITIONS"
+echo ""
+echo "ERROR: Not all conditions became True within ${TIMEOUT}s (${TRUE_COUNT}/${TOTAL_COUNT})"
+exit 1
+```
+```shell markdown_runner
+  3/4 True so far, retrying in 5s...
+  3/5 True so far, retrying in 5s...
+  3/5 True so far, retrying in 5s...
+  3/5 True so far, retrying in 5s...
+Valid: True
+BrokerPropertiesApplied: True
+Deployed: True
+Ready: True
+BrokerVersionAligned: True
+
+Status: 5/5 conditions True
+All conditions are True
+
++ TIMEOUT=120
++ INTERVAL=5
++ ELAPSED=0
++ '[' 0 -lt 120 ']'
+++ kubectl get Broker artemis-broker -n netpol-tutorial -o json
+++ jq -r '.status.conditions[] | "\(.type): \(.status)"'
++ CONDITIONS=$'Valid: True\nBrokerPropertiesApplied: Unknown\nDeployed: True\nReady: True'
+++ echo $'Valid: True\nBrokerPropertiesApplied: Unknown\nDeployed: True\nReady: True'
+++ wc -l
++ TOTAL_COUNT=4
+++ echo $'Valid: True\nBrokerPropertiesApplied: Unknown\nDeployed: True\nReady: True'
+++ grep -c True
++ TRUE_COUNT=3
++ '[' 4 -gt 0 ']'
++ '[' 3 -eq 4 ']'
++ echo '  3/4 True so far, retrying in 5s...'
++ sleep 5
++ ELAPSED=5
++ '[' 5 -lt 120 ']'
+++ kubectl get Broker artemis-broker -n netpol-tutorial -o json
+++ jq -r '.status.conditions[] | "\(.type): \(.status)"'
++ CONDITIONS=$'Valid: True\nBrokerPropertiesApplied: Unknown\nDeployed: True\nReady: True\nBrokerVersionAligned: Unknown'
+++ echo $'Valid: True\nBrokerPropertiesApplied: Unknown\nDeployed: True\nReady: True\nBrokerVersionAligned: Unknown'
+++ wc -l
++ TOTAL_COUNT=5
+++ echo $'Valid: True\nBrokerPropertiesApplied: Unknown\nDeployed: True\nReady: True\nBrokerVersionAligned: Unknown'
+++ grep -c True
++ TRUE_COUNT=3
++ '[' 5 -gt 0 ']'
++ '[' 3 -eq 5 ']'
++ echo '  3/5 True so far, retrying in 5s...'
++ sleep 5
++ ELAPSED=10
++ '[' 10 -lt 120 ']'
+++ kubectl get Broker artemis-broker -n netpol-tutorial -o json
+++ jq -r '.status.conditions[] | "\(.type): \(.status)"'
++ CONDITIONS=$'Valid: True\nBrokerPropertiesApplied: Unknown\nDeployed: True\nReady: True\nBrokerVersionAligned: Unknown'
+++ echo $'Valid: True\nBrokerPropertiesApplied: Unknown\nDeployed: True\nReady: True\nBrokerVersionAligned: Unknown'
+++ wc -l
++ TOTAL_COUNT=5
+++ echo $'Valid: True\nBrokerPropertiesApplied: Unknown\nDeployed: True\nReady: True\nBrokerVersionAligned: Unknown'
+++ grep -c True
++ TRUE_COUNT=3
++ '[' 5 -gt 0 ']'
++ '[' 3 -eq 5 ']'
++ echo '  3/5 True so far, retrying in 5s...'
++ sleep 5
++ ELAPSED=15
++ '[' 15 -lt 120 ']'
+++ kubectl get Broker artemis-broker -n netpol-tutorial -o json
+++ jq -r '.status.conditions[] | "\(.type): \(.status)"'
++ CONDITIONS=$'Valid: True\nBrokerPropertiesApplied: Unknown\nDeployed: True\nReady: True\nBrokerVersionAligned: Unknown'
+++ echo $'Valid: True\nBrokerPropertiesApplied: Unknown\nDeployed: True\nReady: True\nBrokerVersionAligned: Unknown'
+++ wc -l
++ TOTAL_COUNT=5
+++ echo $'Valid: True\nBrokerPropertiesApplied: Unknown\nDeployed: True\nReady: True\nBrokerVersionAligned: Unknown'
+++ grep -c True
++ TRUE_COUNT=3
++ '[' 5 -gt 0 ']'
++ '[' 3 -eq 5 ']'
++ echo '  3/5 True so far, retrying in 5s...'
++ sleep 5
++ ELAPSED=20
++ '[' 20 -lt 120 ']'
+++ kubectl get Broker artemis-broker -n netpol-tutorial -o json
+++ jq -r '.status.conditions[] | "\(.type): \(.status)"'
++ CONDITIONS=$'Valid: True\nBrokerPropertiesApplied: True\nDeployed: True\nReady: True\nBrokerVersionAligned: True'
+++ echo $'Valid: True\nBrokerPropertiesApplied: True\nDeployed: True\nReady: True\nBrokerVersionAligned: True'
+++ wc -l
++ TOTAL_COUNT=5
+++ echo $'Valid: True\nBrokerPropertiesApplied: True\nDeployed: True\nReady: True\nBrokerVersionAligned: True'
+++ grep -c True
++ TRUE_COUNT=5
++ '[' 5 -gt 0 ']'
++ '[' 5 -eq 5 ']'
++ echo $'Valid: True\nBrokerPropertiesApplied: True\nDeployed: True\nReady: True\nBrokerVersionAligned: True'
++ echo ''
++ echo 'Status: 5/5 conditions True'
++ echo 'All conditions are True'
++ exit 0
+```
+
+### Inspect the generated NetworkPolicy
+
+The operator created a NetworkPolicy named `artemis-broker-netpol` that
+restricts ingress to the broker pods. The ResourceTemplate has patched it to
+include port 61617 alongside the restricted-mode defaults.
+
+```{"stage":"verify", "runtime":"bash", "label":"inspect network policy"}
+kubectl get networkpolicy artemis-broker-netpol -n netpol-tutorial -o yaml
+```
+```shell markdown_runner
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  creationTimestamp: "2026-04-14T14:01:53Z"
+  generation: 1
+  name: artemis-broker-netpol
+  namespace: netpol-tutorial
+  ownerReferences:
+  - apiVersion: broker.arkmq.org/v1beta2
+    controller: true
+    kind: Broker
+    name: artemis-broker
+    uid: cb99f033-158c-496e-9827-8f156c25b97e
+  resourceVersion: "1121"
+  uid: 87e03ea2-07c1-4bf0-865c-6531c15cc863
+spec:
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          control-plane: controller-manager
+          name: arkmq-org-broker-operator
+    ports:
+    - port: 8778
+      protocol: TCP
+  - ports:
+    - port: 8888
+      protocol: TCP
+    - port: 61617
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      ActiveMQArtemis: artemis-broker
+  policyTypes:
+  - Ingress
++ kubectl get networkpolicy artemis-broker-netpol -n netpol-tutorial -o yaml
++ echo '### ENV ###'
++ printenv
+```
+
+## Exchange Messages
+
+With the broker running and the NetworkPolicy in place, verify that messaging
+works end-to-end from a client pod through the NetworkPolicy-allowed port.
+
+### Create a Client Certificate
+
+Create a dedicated certificate for the messaging client with
+`CN=messaging-client`, matching the JAAS configuration.
+
+```{"stage":"messaging", "runtime":"bash", "label":"create client cert"}
+kubectl apply -f - <<EOF
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: messaging-client-cert
+  namespace: netpol-tutorial
+spec:
+  secretName: messaging-client-cert
+  commonName: messaging-client
+  issuerRef:
+    name: ca-issuer
+    kind: ClusterIssuer
+EOF
+```
+```shell markdown_runner
+certificate.cert-manager.io/messaging-client-cert created
++ kubectl apply -f -
++ echo '### ENV ###'
++ printenv
+```
+
+```{"stage":"messaging", "runtime":"bash", "label":"wait for client cert"}
+kubectl wait certificate messaging-client-cert -n netpol-tutorial --for=condition=Ready --timeout=300s
+```
+```shell markdown_runner
+certificate.cert-manager.io/messaging-client-cert condition met
++ kubectl wait certificate messaging-client-cert -n netpol-tutorial --for=condition=Ready --timeout=300s
++ echo '### ENV ###'
++ printenv
+```
+
+### Create Client Keystore Configuration
+
+```bash {"stage":"messaging", "label":"create pemcfg secret", "runtime":"bash"}
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cert-pemcfg
+  namespace: netpol-tutorial
+type: Opaque
+stringData:
+  tls.pemcfg: |
+    source.key=/app/tls/client/tls.key
+    source.cert=/app/tls/client/tls.crt
+  java.security: security.provider.6=de.dentrassi.crypto.pem.PemKeyStoreProvider
+EOF
+```
+```shell markdown_runner
+secret/cert-pemcfg created
++ kubectl apply -f -
++ echo '### ENV ###'
++ printenv
+```
+
+### Expose the Messaging Acceptor
+
+Create a Kubernetes `Service` to expose the broker's AMQPS acceptor port
+(`61617`). This is required so the client pods can address the broker by service
+name.
+
+```bash {"stage":"messaging", "label":"create messaging service", "runtime":"bash"}
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Service
+metadata:
+  name: artemis-broker-messaging-svc
+  namespace: netpol-tutorial
+spec:
+  selector:
+    ActiveMQArtemis: artemis-broker
+  ports:
+  - name: amqps
+    port: 61617
+    targetPort: 61617
+    protocol: TCP
+EOF
+```
+```shell markdown_runner
+service/artemis-broker-messaging-svc created
++ kubectl apply -f -
++ echo '### ENV ###'
++ printenv
+```
+
+### Run Producer and Consumer Jobs
+
+Run two Kubernetes `Job`s: one produces 100 messages to the `APP_JOBS` queue,
+the other consumes them. Both authenticate using the `messaging-client-cert`
+and connect through the NetworkPolicy-allowed port 61617.
+
+```{"stage":"messaging", "runtime":"bash", "label":"get latest broker version"}
+export BROKER_VERSION=$(kubectl get Broker artemis-broker --namespace=netpol-tutorial -o json | jq .status.version.brokerVersion -r)
+echo "broker version: $BROKER_VERSION"
+```
+```shell markdown_runner
+broker version: 2.53.0
+++ kubectl get Broker artemis-broker --namespace=netpol-tutorial -o json
+++ jq .status.version.brokerVersion -r
++ export BROKER_VERSION=2.53.0
++ BROKER_VERSION=2.53.0
++ echo 'broker version: 2.53.0'
++ echo '### ENV ###'
++ printenv
+```
+
+```bash {"stage":"messaging", "label":"run producer and consumer", "runtime":"bash"}
+cat <<'EOT' > deploy.yml
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: producer
+  namespace: netpol-tutorial
+spec:
+  template:
+    spec:
+      containers:
+      - name: producer
+EOT
+cat <<EOT >> deploy.yml
+        image: quay.io/arkmq-org/arkmq-org-broker-kubernetes:artemis.${BROKER_VERSION}
+EOT
+cat <<'EOT' >> deploy.yml
+        command:
+        - "/bin/sh"
+        - "-c"
+        - exec java -classpath /opt/amq/lib/*:/opt/amq/lib/extra/* org.apache.activemq.artemis.cli.Artemis producer --protocol=AMQP --url 'amqps://artemis-broker-messaging-svc:61617?transport.trustStoreType=PEMCA&transport.trustStoreLocation=/app/tls/ca/ca.pem&transport.keyStoreType=PEMCFG&transport.keyStoreLocation=/app/tls/pem/tls.pemcfg' --message-count 100 --destination queue://APP_JOBS;
+        env:
+        - name: JDK_JAVA_OPTIONS
+          value: "-Djava.security.properties=/app/tls/pem/java.security"
+        volumeMounts:
+        - name: trust
+          mountPath: /app/tls/ca
+        - name: cert
+          mountPath: /app/tls/client
+        - name: pem
+          mountPath: /app/tls/pem
+      volumes:
+      - name: trust
+        secret:
+          secretName: activemq-artemis-manager-ca
+      - name: cert
+        secret:
+          secretName: messaging-client-cert
+      - name: pem
+        secret:
+          secretName: cert-pemcfg
+      restartPolicy: Never
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: consumer
+  namespace: netpol-tutorial
+spec:
+  template:
+    spec:
+      containers:
+      - name: consumer
+EOT
+cat <<EOT >> deploy.yml
+        image: quay.io/arkmq-org/arkmq-org-broker-kubernetes:artemis.${BROKER_VERSION}
+EOT
+cat <<'EOT' >> deploy.yml
+        command:
+        - "/bin/sh"
+        - "-c"
+        - exec java -classpath /opt/amq/lib/*:/opt/amq/lib/extra/* org.apache.activemq.artemis.cli.Artemis consumer --protocol=AMQP --url 'amqps://artemis-broker-messaging-svc:61617?transport.trustStoreType=PEMCA&transport.trustStoreLocation=/app/tls/ca/ca.pem&transport.keyStoreType=PEMCFG&transport.keyStoreLocation=/app/tls/pem/tls.pemcfg' --message-count 100 --destination queue://APP_JOBS --receive-timeout 30000;
+        env:
+        - name: JDK_JAVA_OPTIONS
+          value: "-Djava.security.properties=/app/tls/pem/java.security"
+        volumeMounts:
+        - name: trust
+          mountPath: /app/tls/ca
+        - name: cert
+          mountPath: /app/tls/client
+        - name: pem
+          mountPath: /app/tls/pem
+      volumes:
+      - name: trust
+        secret:
+          secretName: activemq-artemis-manager-ca
+      - name: cert
+        secret:
+          secretName: messaging-client-cert
+      - name: pem
+        secret:
+          secretName: cert-pemcfg
+      restartPolicy: Never
+EOT
+kubectl apply -f deploy.yml
+```
+```shell markdown_runner
+job.batch/producer created
+job.batch/consumer created
++ cat
++ cat
++ cat
++ cat
++ cat
++ kubectl apply -f deploy.yml
++ echo '### ENV ###'
++ printenv
+```
+
+Wait for both jobs to complete.
+
+```bash {"stage":"messaging", "label":"wait for jobs"}
+kubectl wait job producer -n netpol-tutorial --for=condition=Complete --timeout=240s
+kubectl wait job consumer -n netpol-tutorial --for=condition=Complete --timeout=240s
+```
+```shell markdown_runner
+job.batch/producer condition met
+job.batch/consumer condition met
+```
+
+Verify that all 100 messages were produced and consumed:
+
+```{"stage":"messaging", "runtime":"bash", "label":"verify message counts"}
+echo "Producer output:"
+kubectl logs job/producer -n netpol-tutorial | tail -3
+echo ""
+echo "Consumer output:"
+kubectl logs job/consumer -n netpol-tutorial | tail -3
+```
+```shell markdown_runner
+Producer output:
+Producer APP_JOBS, thread=0 Produced: 100 messages
+Producer APP_JOBS, thread=0 Elapsed time in second : 1 s
+Producer APP_JOBS, thread=0 Elapsed time in milli second : 1228 milli seconds
+
+Consumer output:
+Consumer APP_JOBS, thread=0 Elapsed time in milli second : 354 milli seconds
+Consumer APP_JOBS, thread=0 Consumed: 100 messages
+Consumer APP_JOBS, thread=0 Consumer thread finished
++ echo 'Producer output:'
++ kubectl logs job/producer -n netpol-tutorial
++ tail -3
++ echo ''
++ echo 'Consumer output:'
++ kubectl logs job/consumer -n netpol-tutorial
++ tail -3
++ echo '### ENV ###'
++ printenv
+```
+
+## Verify NetworkPolicy Enforcement
+
+This section confirms that the NetworkPolicy is not just present but actively
+enforced by the CNI. We deploy a plain client pod and verify that traffic to a
+port **not** in the NetworkPolicy is blocked, while traffic to an allowed port
+succeeds.
+
+### Deploy a test client pod
+
+```{"stage":"enforce", "runtime":"bash", "label":"deploy test client pod"}
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: netpol-test-client
+  namespace: netpol-tutorial
+spec:
+  containers:
+  - name: client
+    image: registry.access.redhat.com/ubi8/ubi:8.9
+    command: ["/bin/bash", "-c", "sleep infinity"]
+EOF
+
+kubectl wait pod netpol-test-client -n netpol-tutorial --for=condition=Ready --timeout=120s
+```
+```shell markdown_runner
+pod/netpol-test-client created
+pod/netpol-test-client condition met
++ kubectl apply -f -
++ kubectl wait pod netpol-test-client -n netpol-tutorial --for=condition=Ready --timeout=120s
++ echo '### ENV ###'
++ printenv
+```
+
+### Test allowed port (61617)
+
+Port 61617 is listed in the NetworkPolicy via the ResourceTemplate. A TCP
+connection from the client pod should succeed:
+
+```{"stage":"enforce", "runtime":"bash", "label":"test allowed port"}
+BROKER_FQDN=artemis-broker-ss-0.artemis-broker-hdls-svc.netpol-tutorial.svc.cluster.local
+kubectl exec netpol-test-client -n netpol-tutorial -- \
+  bash -c "timeout 10 bash -c 'echo > /dev/tcp/${BROKER_FQDN}/61617' 2>&1; echo EXIT_CODE=\$?"
+```
+```shell markdown_runner
+EXIT_CODE=0
++ BROKER_FQDN=artemis-broker-ss-0.artemis-broker-hdls-svc.netpol-tutorial.svc.cluster.local
++ kubectl exec netpol-test-client -n netpol-tutorial -- bash -c 'timeout 10 bash -c '\''echo > /dev/tcp/artemis-broker-ss-0.artemis-broker-hdls-svc.netpol-tutorial.svc.cluster.local/61617'\'' 2>&1; echo EXIT_CODE=$?'
++ echo '### ENV ###'
++ printenv
+```
+
+The output should contain `EXIT_CODE=0`, indicating a successful connection.
+
+### Test restricted Jolokia port (8778)
+
+The broker **is** listening on port 8778 (Jolokia), but the ResourceTemplate
+restricts it to the operator pod only via a `from` pod selector. Our test
+client pod does not carry the `control-plane: controller-manager` label, so the
+NetworkPolicy should block the connection:
+
+```{"stage":"enforce", "runtime":"bash", "label":"test blocked port"}
+BROKER_FQDN=artemis-broker-ss-0.artemis-broker-hdls-svc.netpol-tutorial.svc.cluster.local
+kubectl exec netpol-test-client -n netpol-tutorial -- \
+  bash -c "timeout 10 bash -c 'echo > /dev/tcp/${BROKER_FQDN}/8778' 2>&1; echo EXIT_CODE=\$?"
+```
+```shell markdown_runner
+EXIT_CODE=124
++ BROKER_FQDN=artemis-broker-ss-0.artemis-broker-hdls-svc.netpol-tutorial.svc.cluster.local
++ kubectl exec netpol-test-client -n netpol-tutorial -- bash -c 'timeout 10 bash -c '\''echo > /dev/tcp/artemis-broker-ss-0.artemis-broker-hdls-svc.netpol-tutorial.svc.cluster.local/8778'\'' 2>&1; echo EXIT_CODE=$?'
++ echo '### ENV ###'
++ printenv
+```
+
+The output should contain a non-zero `EXIT_CODE` (typically `EXIT_CODE=124` for
+a timeout or `EXIT_CODE=1` for connection refused).
+
+### Test Jolokia from the operator pod (8778)
+
+Now run the exact same connection test from the **operator** pod, which carries
+the `control-plane: controller-manager` label matched by the NetworkPolicy
+`from` selector. This should succeed:
+
+```{"stage":"enforce", "runtime":"bash", "label":"test jolokia from operator"}
+BROKER_FQDN=artemis-broker-ss-0.artemis-broker-hdls-svc.netpol-tutorial.svc.cluster.local
+OPERATOR_POD=$(kubectl get pod -n netpol-tutorial -l control-plane=controller-manager -o jsonpath='{.items[0].metadata.name}')
+
+echo "Testing TCP connection to Jolokia port 8778 from operator pod ${OPERATOR_POD}..."
+kubectl exec "${OPERATOR_POD}" -n netpol-tutorial -- \
+  bash -c "timeout 10 bash -c 'echo > /dev/tcp/${BROKER_FQDN}/8778' 2>&1; echo EXIT_CODE=\$?"
+```
+```shell markdown_runner
+Testing TCP connection to Jolokia port 8778 from operator pod arkmq-org-broker-controller-manager-7bc7d7b7b-wk7wx...
+EXIT_CODE=0
++ BROKER_FQDN=artemis-broker-ss-0.artemis-broker-hdls-svc.netpol-tutorial.svc.cluster.local
+++ kubectl get pod -n netpol-tutorial -l control-plane=controller-manager -o 'jsonpath={.items[0].metadata.name}'
++ OPERATOR_POD=arkmq-org-broker-controller-manager-7bc7d7b7b-wk7wx
++ echo 'Testing TCP connection to Jolokia port 8778 from operator pod arkmq-org-broker-controller-manager-7bc7d7b7b-wk7wx...'
++ kubectl exec arkmq-org-broker-controller-manager-7bc7d7b7b-wk7wx -n netpol-tutorial -- bash -c 'timeout 10 bash -c '\''echo > /dev/tcp/artemis-broker-ss-0.artemis-broker-hdls-svc.netpol-tutorial.svc.cluster.local/8778'\'' 2>&1; echo EXIT_CODE=$?'
++ echo '### ENV ###'
++ printenv
+```
+
+The output should contain `EXIT_CODE=0`. Same port, same broker -- but the
+operator pod is allowed through because it matches the `from` pod selector.
+This contrast confirms the NetworkPolicy restricts Jolokia to operator-only
+access.
+
+### Clean up the test client
+
+```{"stage":"enforce", "runtime":"bash", "label":"clean up test client"}
+kubectl delete pod netpol-test-client -n netpol-tutorial --ignore-not-found
+```
+```shell markdown_runner
+pod "netpol-test-client" deleted from netpol-tutorial namespace
++ kubectl delete pod netpol-test-client -n netpol-tutorial --ignore-not-found
++ echo '### ENV ###'
++ printenv
+```
+
+## Troubleshooting
+
+### NetworkPolicy Not Enforced
+
+**Problem:** Connections to blocked ports succeed anyway.
+
+**Cause:** The cluster's CNI does not enforce NetworkPolicies. The default
+minikube CNI (`bridge`/`kindnet`) does not support them.
+
+**Solution:** Start minikube with `--cni=calico`:
+```bash
+minikube start --cni=calico
+```
+
+Or on OpenShift, the default OVN-Kubernetes CNI enforces NetworkPolicies
+out of the box.
+
+### Broker Pod Not Starting
+
+**Problem:** Broker pod stays in `Pending` or `CrashLoopBackOff`.
+
+```bash
+kubectl describe pod -l ActiveMQArtemis=artemis-broker -n netpol-tutorial
+kubectl logs -l ActiveMQArtemis=artemis-broker -n netpol-tutorial --previous
+```
+
+**Common causes:**
+- Missing certificate secrets (`broker-cert`, `activemq-artemis-manager-cert`)
+- Missing JAAS configuration secret (`artemis-broker-jaas-config-bp`)
+- Invalid broker properties syntax
+
+### ResourceTemplate Not Applied
+
+**Problem:** NetworkPolicy exists but does not include the extra port.
+
+```bash
+kubectl get networkpolicy artemis-broker-netpol -n netpol-tutorial -o yaml
+```
+
+**Solution:** Verify the ResourceTemplate `selector.kind` is set to
+`NetworkPolicy` and the patch structure is valid YAML. Remember that the patch
+replaces the entire `spec.ingress` list.
+
+### Messaging Client Connection Errors
+
+**Problem:** Producer/Consumer jobs fail with SSL or connection errors.
+
+```bash
+kubectl logs job/producer -n netpol-tutorial
+kubectl logs job/consumer -n netpol-tutorial
+```
+
+**Common causes:**
+- Certificate not ready: `kubectl get certificate -n netpol-tutorial`
+- Wrong trust store path in the AMQP URL
+- Port 61617 not in the NetworkPolicy (check with `kubectl get networkpolicy
+  artemis-broker-netpol -o yaml`)
+
+### Certificate Issues
+
+**Problem:** Certificates stuck in "Pending" or "False" state.
+
+```bash
+kubectl describe certificate broker-cert -n netpol-tutorial
+kubectl get certificaterequests -n netpol-tutorial
+kubectl get pods -n cert-manager
+kubectl describe clusterissuer ca-issuer
+```
+
+### General Debugging
+
+```bash
+# All resources in the namespace
+kubectl get all -n netpol-tutorial
+
+# Events sorted by time
+kubectl get events -n netpol-tutorial --sort-by='.lastTimestamp'
+
+# Broker CR status
+kubectl get broker artemis-broker -n netpol-tutorial -o yaml
+
+# NetworkPolicy details
+kubectl describe networkpolicy artemis-broker-netpol -n netpol-tutorial
+```
+
+## Cleanup
+
+Delete the minikube cluster to leave a pristine environment.
+
+```{"stage":"teardown", "requires":"init/minikube_start"}
+minikube delete --profile netpol-tutorial
+```
+```shell markdown_runner
+* Deleting "netpol-tutorial" in kvm2 ...
+* Removed all traces of the "netpol-tutorial" cluster.
+```
+
+## Conclusion
+
+This tutorial demonstrated how the ActiveMQ Artemis Operator automatically
+manages NetworkPolicies for broker operands. You now understand:
+
+* **Automatic NetworkPolicy Generation:** The operator creates a NetworkPolicy
+  for each broker, restricting ingress to only the ports it manages.
+* **CNI Requirements:** NetworkPolicies require a CNI that enforces them (e.g.,
+  Calico, OVN-Kubernetes). The default minikube CNI does not enforce them.
+* **Broker Properties Limitation:** Ports configured solely through broker
+  properties are invisible to the operator. You must use a ResourceTemplate to
+  patch the NetworkPolicy with those extra ports.
+* **ResourceTemplate Behavior:** Patches on `spec.ingress` replace the entire
+  list. Always include all desired ports in the patch, not just the extra ones.
+* **Enforcement Verification:** You can verify NetworkPolicy enforcement by
+  testing connectivity from a separate pod to both allowed and blocked ports.
+
+### Key Takeaways
+
+| Scenario | Ports in NetworkPolicy |
+|----------|----------------------|
+| Default (non-restricted) broker | 7800, 8161, 8778, 61616 + any `spec.acceptors` / `spec.connectors` |
+| Restricted broker (`spec.restricted: true`) | 8778 (Jolokia), 8888 (Prometheus) |
+| Extra ports via broker properties | Must add via ResourceTemplate |
+
+### Production Considerations
+
+* **CNI Choice:** Ensure your production cluster uses a CNI that enforces
+  NetworkPolicies (OVN-Kubernetes on OpenShift, Calico on vanilla Kubernetes).
+* **Upgrade Path:** When upgrading the operator, existing NetworkPolicies will
+  be reconciled. Ensure ResourceTemplates are preserved across upgrades.
+* **Egress Policies:** This tutorial covers ingress only. For egress
+  restrictions, consider additional NetworkPolicies depending on your broker's
+  federation or mirroring configuration.
+* **Source Restrictions:** The current NetworkPolicy restricts ports but allows
+  ingress from any source. For tighter control (e.g., restricting Jolokia access
+  to the operator pod only), you can add `from` selectors via ResourceTemplates.

--- a/helm-charts/arkmq-org-broker-operator/templates/crds.yaml
+++ b/helm-charts/arkmq-org-broker-operator/templates/crds.yaml
@@ -13490,6 +13490,445 @@ spec:
                 ingressDomain:
                   description: The default ingress domain. It is required when any acceptor, connector or console uses the ingress mode and does not specify an IngressHost.
                   type: string
+                networkPolicy:
+                  description: |-
+                    Optional NetworkPolicy spec for the broker pods. When set, the operator
+                    uses this spec directly instead of auto-generating a NetworkPolicy.
+                  properties:
+                    egress:
+                      description: |-
+                        egress is a list of egress rules to be applied to the selected pods. Outgoing traffic
+                        is allowed if there are no NetworkPolicies selecting the pod (and cluster policy
+                        otherwise allows the traffic), OR if the traffic matches at least one egress rule
+                        across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                        this field is empty then this NetworkPolicy limits all outgoing traffic (and serves
+                        solely to ensure that the pods it selects are isolated by default).
+                        This field is beta-level in 1.8
+                      items:
+                        description: |-
+                          NetworkPolicyEgressRule describes a particular set of traffic that is allowed out of pods
+                          matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and to.
+                          This type is beta-level in 1.8
+                        properties:
+                          ports:
+                            description: |-
+                              ports is a list of destination ports for outgoing traffic.
+                              Each item in this list is combined using a logical OR. If this field is
+                              empty or missing, this rule matches all ports (traffic not restricted by port).
+                              If this field is present and contains at least one item, then this rule allows
+                              traffic only if the traffic matches at least one port in the list.
+                            items:
+                              description: NetworkPolicyPort describes a port to allow traffic on
+                              properties:
+                                endPort:
+                                  description: |-
+                                    endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                    should be allowed by the policy. This field cannot be defined if the port field
+                                    is not defined or if the port field is defined as a named (string) port.
+                                    The endPort must be equal or greater than port.
+                                  format: int32
+                                  type: integer
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: |-
+                                    port represents the port on the given protocol. This can either be a numerical or named
+                                    port on a pod. If this field is not provided, this matches all port names and
+                                    numbers.
+                                    If present, only traffic on the specified protocol AND port will be matched.
+                                  x-kubernetes-int-or-string: true
+                                protocol:
+                                  description: |-
+                                    protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                    If not specified, this field defaults to TCP.
+                                  type: string
+                              type: object
+                            type: array
+                          to:
+                            description: |-
+                              to is a list of destinations for outgoing traffic of pods selected for this rule.
+                              Items in this list are combined using a logical OR operation. If this field is
+                              empty or missing, this rule matches all destinations (traffic not restricted by
+                              destination). If this field is present and contains at least one item, this rule
+                              allows traffic only if the traffic matches at least one item in the to list.
+                            items:
+                              description: |-
+                                NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                                fields are allowed
+                              properties:
+                                ipBlock:
+                                  description: |-
+                                    ipBlock defines policy on a particular IPBlock. If this field is set then
+                                    neither of the other fields can be.
+                                  properties:
+                                    cidr:
+                                      description: |-
+                                        cidr is a string representing the IPBlock
+                                        Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                      type: string
+                                    except:
+                                      description: |-
+                                        except is a slice of CIDRs that should not be included within an IPBlock
+                                        Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                        Except values will be rejected if they are outside the cidr range
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                    - cidr
+                                  type: object
+                                namespaceSelector:
+                                  description: |-
+                                    namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                    standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                    If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                    the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                    Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                          - key
+                                          - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                podSelector:
+                                  description: |-
+                                    podSelector is a label selector which selects pods. This field follows standard label
+                                    selector semantics; if present but empty, it selects all pods.
+
+                                    If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                    the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                    Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                          - key
+                                          - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            type: array
+                        type: object
+                      type: array
+                    ingress:
+                      description: |-
+                        ingress is a list of ingress rules to be applied to the selected pods.
+                        Traffic is allowed to a pod if there are no NetworkPolicies selecting the pod
+                        (and cluster policy otherwise allows the traffic), OR if the traffic source is
+                        the pod's local node, OR if the traffic matches at least one ingress rule
+                        across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                        this field is empty then this NetworkPolicy does not allow any traffic (and serves
+                        solely to ensure that the pods it selects are isolated by default)
+                      items:
+                        description: |-
+                          NetworkPolicyIngressRule describes a particular set of traffic that is allowed to the pods
+                          matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and from.
+                        properties:
+                          from:
+                            description: |-
+                              from is a list of sources which should be able to access the pods selected for this rule.
+                              Items in this list are combined using a logical OR operation. If this field is
+                              empty or missing, this rule matches all sources (traffic not restricted by
+                              source). If this field is present and contains at least one item, this rule
+                              allows traffic only if the traffic matches at least one item in the from list.
+                            items:
+                              description: |-
+                                NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                                fields are allowed
+                              properties:
+                                ipBlock:
+                                  description: |-
+                                    ipBlock defines policy on a particular IPBlock. If this field is set then
+                                    neither of the other fields can be.
+                                  properties:
+                                    cidr:
+                                      description: |-
+                                        cidr is a string representing the IPBlock
+                                        Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                      type: string
+                                    except:
+                                      description: |-
+                                        except is a slice of CIDRs that should not be included within an IPBlock
+                                        Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                        Except values will be rejected if they are outside the cidr range
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                    - cidr
+                                  type: object
+                                namespaceSelector:
+                                  description: |-
+                                    namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                    standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                    If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                    the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                    Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                          - key
+                                          - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                podSelector:
+                                  description: |-
+                                    podSelector is a label selector which selects pods. This field follows standard label
+                                    selector semantics; if present but empty, it selects all pods.
+
+                                    If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                    the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                    Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                          - key
+                                          - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            type: array
+                          ports:
+                            description: |-
+                              ports is a list of ports which should be made accessible on the pods selected for
+                              this rule. Each item in this list is combined using a logical OR. If this field is
+                              empty or missing, this rule matches all ports (traffic not restricted by port).
+                              If this field is present and contains at least one item, then this rule allows
+                              traffic only if the traffic matches at least one port in the list.
+                            items:
+                              description: NetworkPolicyPort describes a port to allow traffic on
+                              properties:
+                                endPort:
+                                  description: |-
+                                    endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                    should be allowed by the policy. This field cannot be defined if the port field
+                                    is not defined or if the port field is defined as a named (string) port.
+                                    The endPort must be equal or greater than port.
+                                  format: int32
+                                  type: integer
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: |-
+                                    port represents the port on the given protocol. This can either be a numerical or named
+                                    port on a pod. If this field is not provided, this matches all port names and
+                                    numbers.
+                                    If present, only traffic on the specified protocol AND port will be matched.
+                                  x-kubernetes-int-or-string: true
+                                protocol:
+                                  description: |-
+                                    protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                    If not specified, this field defaults to TCP.
+                                  type: string
+                              type: object
+                            type: array
+                        type: object
+                      type: array
+                    podSelector:
+                      description: |-
+                        podSelector selects the pods to which this NetworkPolicy object applies.
+                        The array of ingress rules is applied to any pods selected by this field.
+                        Multiple network policies can select the same set of pods. In this case,
+                        the ingress rules for each are combined additively.
+                        This field is NOT optional and follows standard label selector semantics.
+                        An empty podSelector matches all pods in this namespace.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                          items:
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector applies to.
+                                type: string
+                              operator:
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                              - key
+                              - operator
+                            type: object
+                          type: array
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    policyTypes:
+                      description: |-
+                        policyTypes is a list of rule types that the NetworkPolicy relates to.
+                        Valid options are ["Ingress"], ["Egress"], or ["Ingress", "Egress"].
+                        If this field is not specified, it will default based on the existence of ingress or egress rules;
+                        policies that contain an egress section are assumed to affect egress, and all policies
+                        (whether or not they contain an ingress section) are assumed to affect ingress.
+                        If you want to write an egress-only policy, you must explicitly specify policyTypes [ "Egress" ].
+                        Likewise, if you want to write a policy that specifies that no egress is allowed,
+                        you must specify a policyTypes value that include "Egress" (since such a policy would not include
+                        an egress section and would otherwise default to just [ "Ingress" ]).
+                        This field is beta-level in 1.8
+                      items:
+                        description: |-
+                          PolicyType string describes the NetworkPolicy type
+                          This type is beta-level in 1.8
+                        type: string
+                      type: array
+                  required:
+                    - podSelector
+                  type: object
                 resourceTemplates:
                   description: Specifies the template for various resources that the operator controls
                   items:

--- a/helm-charts/arkmq-org-broker-operator/templates/operator-rbac.yaml
+++ b/helm-charts/arkmq-org-broker-operator/templates/operator-rbac.yaml
@@ -144,6 +144,7 @@ rules:
   - networking.k8s.io
   resources:
   - ingresses
+  - networkpolicies
   verbs:
   - create
   - delete

--- a/pkg/resources/networkpolicies/networkpolicy.go
+++ b/pkg/resources/networkpolicies/networkpolicy.go
@@ -1,0 +1,123 @@
+package networkpolicies
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	netv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	v1beta2 "github.com/arkmq-org/arkmq-org-broker-operator/api/v1beta2"
+	"github.com/arkmq-org/arkmq-org-broker-operator/pkg/resources/serviceports"
+	"github.com/arkmq-org/arkmq-org-broker-operator/pkg/utils/common"
+	"github.com/arkmq-org/arkmq-org-broker-operator/pkg/utils/selectors"
+)
+
+const (
+	RestrictedJolokiaPort    = 8778
+	RestrictedPrometheusPort = 8888
+)
+
+// NewNetworkPolicyForCR builds or updates a NetworkPolicy that restricts ingress
+// traffic to the broker pods, allowing only the ports the operator knows about.
+// When existing is non-nil its metadata is preserved so the update path keeps the
+// resource version; otherwise a fresh object is created.
+func NewNetworkPolicyForCR(existing *netv1.NetworkPolicy, cr *v1beta2.Broker) *netv1.NetworkPolicy {
+	var desired *netv1.NetworkPolicy
+	if existing != nil {
+		desired = existing
+	} else {
+		desired = &netv1.NetworkPolicy{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "networking.k8s.io/v1",
+				Kind:       "NetworkPolicy",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      cr.Name + "-netpol",
+				Namespace: cr.Namespace,
+			},
+		}
+	}
+
+	desired.Spec = netv1.NetworkPolicySpec{
+		PodSelector: metav1.LabelSelector{
+			MatchLabels: map[string]string{selectors.LabelResourceKey: cr.Name},
+		},
+		PolicyTypes: []netv1.PolicyType{netv1.PolicyTypeIngress},
+		Ingress: []netv1.NetworkPolicyIngressRule{
+			{
+				Ports: buildIngressPorts(cr),
+			},
+		},
+	}
+
+	return desired
+}
+
+// NewNetworkPolicyFromSpec builds a NetworkPolicy using the spec provided in the
+// Broker CR directly, bypassing auto-generation. When existing is non-nil its
+// metadata is preserved for the update path.
+func NewNetworkPolicyFromSpec(existing *netv1.NetworkPolicy, cr *v1beta2.Broker) *netv1.NetworkPolicy {
+	var desired *netv1.NetworkPolicy
+	if existing != nil {
+		desired = existing
+	} else {
+		desired = &netv1.NetworkPolicy{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "networking.k8s.io/v1",
+				Kind:       "NetworkPolicy",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      cr.Name + "-netpol",
+				Namespace: cr.Namespace,
+			},
+		}
+	}
+
+	desired.Spec = *cr.Spec.NetworkPolicy
+	return desired
+}
+
+// buildIngressPorts collects the TCP ports that the NetworkPolicy should allow.
+// In restricted mode only the operator-managed Jolokia and Prometheus agent ports
+// are included. Otherwise the default headless service ports are combined with any
+// acceptor ports declared in the CR, deduplicating as it goes.
+// Connector ports are excluded because they represent outbound connections; the
+// receiving broker's acceptor already opens the corresponding ingress port.
+// Ports configured solely through broker properties are intentionally excluded;
+// users must open those via ResourceTemplates.
+func buildIngressPorts(cr *v1beta2.Broker) []netv1.NetworkPolicyPort {
+	tcp := corev1.ProtocolTCP
+	seen := make(map[int32]bool)
+	var ports []netv1.NetworkPolicyPort
+
+	addPort := func(port int32) {
+		if port <= 0 || seen[port] {
+			return
+		}
+		seen[port] = true
+		p := intstr.FromInt32(port)
+		ports = append(ports, netv1.NetworkPolicyPort{
+			Protocol: &tcp,
+			Port:     &p,
+		})
+	}
+
+	restricted := common.IsRestricted(cr)
+
+	if restricted {
+		addPort(RestrictedJolokiaPort)
+		addPort(RestrictedPrometheusPort)
+	} else {
+		for _, sp := range *serviceports.GetDefaultPorts(false) {
+			addPort(sp.Port)
+		}
+	}
+
+	if !restricted {
+		for _, acceptor := range cr.Spec.Acceptors {
+			addPort(acceptor.Port)
+		}
+	}
+
+	return ports
+}

--- a/pkg/resources/networkpolicies/networkpolicy_test.go
+++ b/pkg/resources/networkpolicies/networkpolicy_test.go
@@ -1,0 +1,265 @@
+package networkpolicies
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	netv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	v1beta2 "github.com/arkmq-org/arkmq-org-broker-operator/api/v1beta2"
+)
+
+func TestNewNetworkPolicyForCR_DefaultBroker(t *testing.T) {
+	cr := &v1beta2.Broker{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-broker",
+			Namespace: "test-ns",
+		},
+		Spec: v1beta2.BrokerSpec{},
+	}
+
+	netpol := NewNetworkPolicyForCR(nil, cr)
+
+	assert.Equal(t, "my-broker-netpol", netpol.Name)
+	assert.Equal(t, "test-ns", netpol.Namespace)
+	assert.Equal(t, "NetworkPolicy", netpol.TypeMeta.Kind)
+	assert.Equal(t, "networking.k8s.io/v1", netpol.TypeMeta.APIVersion)
+
+	assert.Equal(t, "my-broker", netpol.Spec.PodSelector.MatchLabels["ActiveMQArtemis"])
+	assert.Contains(t, netpol.Spec.PolicyTypes, netv1.PolicyTypeIngress)
+	assert.NotContains(t, netpol.Spec.PolicyTypes, netv1.PolicyTypeEgress)
+
+	ports := collectPorts(netpol)
+	assert.Contains(t, ports, int32(7800))
+	assert.Contains(t, ports, int32(8161))
+	assert.Contains(t, ports, int32(8778))
+	assert.Contains(t, ports, int32(61616))
+}
+
+func TestNewNetworkPolicyForCR_WithAcceptors(t *testing.T) {
+	cr := &v1beta2.Broker{
+		ObjectMeta: metav1.ObjectMeta{Name: "broker", Namespace: "ns"},
+		Spec: v1beta2.BrokerSpec{
+			Acceptors: []v1beta2.AcceptorType{
+				{Name: "amqp", Port: 5672},
+				{Name: "mqtt", Port: 1883},
+			},
+		},
+	}
+
+	netpol := NewNetworkPolicyForCR(nil, cr)
+	ports := collectPorts(netpol)
+
+	assert.Contains(t, ports, int32(5672))
+	assert.Contains(t, ports, int32(1883))
+	assert.Contains(t, ports, int32(61616), "default port still present")
+}
+
+func TestNewNetworkPolicyForCR_ConnectorsExcluded(t *testing.T) {
+	cr := &v1beta2.Broker{
+		ObjectMeta: metav1.ObjectMeta{Name: "broker", Namespace: "ns"},
+		Spec: v1beta2.BrokerSpec{
+			Connectors: []v1beta2.ConnectorType{
+				{Name: "custom", Host: "localhost", Port: 61617},
+			},
+		},
+	}
+
+	netpol := NewNetworkPolicyForCR(nil, cr)
+	ports := collectPorts(netpol)
+
+	assert.NotContains(t, ports, int32(61617), "connector ports are outbound, not ingress")
+}
+
+func TestNewNetworkPolicyForCR_DeduplicatesPorts(t *testing.T) {
+	cr := &v1beta2.Broker{
+		ObjectMeta: metav1.ObjectMeta{Name: "broker", Namespace: "ns"},
+		Spec: v1beta2.BrokerSpec{
+			Acceptors: []v1beta2.AcceptorType{
+				{Name: "all", Port: 61616},
+			},
+		},
+	}
+
+	netpol := NewNetworkPolicyForCR(nil, cr)
+	ports := collectPorts(netpol)
+
+	count := 0
+	for _, p := range ports {
+		if p == 61616 {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count, "port 61616 should appear exactly once")
+}
+
+func TestNewNetworkPolicyForCR_Restricted(t *testing.T) {
+	restricted := true
+	cr := &v1beta2.Broker{
+		ObjectMeta: metav1.ObjectMeta{Name: "broker", Namespace: "ns"},
+		Spec: v1beta2.BrokerSpec{
+			Restricted: &restricted,
+		},
+	}
+
+	netpol := NewNetworkPolicyForCR(nil, cr)
+	ports := collectPorts(netpol)
+
+	assert.Contains(t, ports, int32(8778), "jolokia agent")
+	assert.Contains(t, ports, int32(8888), "prometheus agent")
+	assert.NotContains(t, ports, int32(7800), "no jgroups in restricted")
+	assert.NotContains(t, ports, int32(8161), "no console in restricted")
+	assert.NotContains(t, ports, int32(61616), "no all-protocols in restricted")
+	assert.Len(t, ports, 2)
+}
+
+func TestNewNetworkPolicyForCR_RestrictedIgnoresCRAcceptors(t *testing.T) {
+	restricted := true
+	cr := &v1beta2.Broker{
+		ObjectMeta: metav1.ObjectMeta{Name: "broker", Namespace: "ns"},
+		Spec: v1beta2.BrokerSpec{
+			Restricted: &restricted,
+			Acceptors: []v1beta2.AcceptorType{
+				{Name: "amqp", Port: 5672},
+			},
+		},
+	}
+
+	netpol := NewNetworkPolicyForCR(nil, cr)
+	ports := collectPorts(netpol)
+
+	assert.NotContains(t, ports, int32(5672), "CR acceptors ignored in restricted mode")
+	assert.Contains(t, ports, int32(8778))
+	assert.Contains(t, ports, int32(8888))
+}
+
+func TestNewNetworkPolicyForCR_ConsolePortInDefaults(t *testing.T) {
+	cr := &v1beta2.Broker{
+		ObjectMeta: metav1.ObjectMeta{Name: "broker", Namespace: "ns"},
+		Spec:       v1beta2.BrokerSpec{},
+	}
+
+	netpol := NewNetworkPolicyForCR(nil, cr)
+	ports := collectPorts(netpol)
+
+	assert.Contains(t, ports, int32(8161), "console port is always in defaults")
+}
+
+func TestNewNetworkPolicyForCR_ReusesExisting(t *testing.T) {
+	existing := &netv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "broker-netpol",
+			Namespace:       "ns",
+			ResourceVersion: "12345",
+		},
+	}
+
+	cr := &v1beta2.Broker{
+		ObjectMeta: metav1.ObjectMeta{Name: "broker", Namespace: "ns"},
+		Spec:       v1beta2.BrokerSpec{},
+	}
+
+	netpol := NewNetworkPolicyForCR(existing, cr)
+
+	assert.Equal(t, "12345", netpol.ResourceVersion, "should preserve existing resource version")
+	assert.Equal(t, "broker", netpol.Spec.PodSelector.MatchLabels["ActiveMQArtemis"])
+}
+
+func TestNewNetworkPolicyFromSpec_UsesProvidedSpec(t *testing.T) {
+	tcp := corev1.ProtocolTCP
+	p8778 := intstr.FromInt32(8778)
+	p61617 := intstr.FromInt32(61617)
+	spec := &netv1.NetworkPolicySpec{
+		PodSelector: metav1.LabelSelector{
+			MatchLabels: map[string]string{"ActiveMQArtemis": "my-broker"},
+		},
+		PolicyTypes: []netv1.PolicyType{netv1.PolicyTypeIngress},
+		Ingress: []netv1.NetworkPolicyIngressRule{
+			{
+				Ports: []netv1.NetworkPolicyPort{
+					{Protocol: &tcp, Port: &p8778},
+					{Protocol: &tcp, Port: &p61617},
+				},
+			},
+		},
+	}
+
+	cr := &v1beta2.Broker{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-broker", Namespace: "ns"},
+		Spec:       v1beta2.BrokerSpec{NetworkPolicy: spec},
+	}
+
+	netpol := NewNetworkPolicyFromSpec(nil, cr)
+
+	assert.Equal(t, "my-broker-netpol", netpol.Name)
+	assert.Equal(t, "ns", netpol.Namespace)
+	ports := collectPorts(netpol)
+	assert.Contains(t, ports, int32(8778))
+	assert.Contains(t, ports, int32(61617))
+	assert.Len(t, ports, 2)
+}
+
+func TestNewNetworkPolicyFromSpec_PreservesExistingMetadata(t *testing.T) {
+	existing := &netv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "my-broker-netpol",
+			Namespace:       "ns",
+			ResourceVersion: "99999",
+		},
+	}
+
+	tcp := corev1.ProtocolTCP
+	p8888 := intstr.FromInt32(8888)
+	spec := &netv1.NetworkPolicySpec{
+		PodSelector: metav1.LabelSelector{
+			MatchLabels: map[string]string{"ActiveMQArtemis": "my-broker"},
+		},
+		PolicyTypes: []netv1.PolicyType{netv1.PolicyTypeIngress},
+		Ingress: []netv1.NetworkPolicyIngressRule{
+			{
+				Ports: []netv1.NetworkPolicyPort{
+					{Protocol: &tcp, Port: &p8888},
+				},
+			},
+		},
+	}
+
+	cr := &v1beta2.Broker{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-broker", Namespace: "ns"},
+		Spec:       v1beta2.BrokerSpec{NetworkPolicy: spec},
+	}
+
+	netpol := NewNetworkPolicyFromSpec(existing, cr)
+
+	assert.Equal(t, "99999", netpol.ResourceVersion, "preserves resource version")
+	ports := collectPorts(netpol)
+	assert.Contains(t, ports, int32(8888))
+}
+
+func TestNewNetworkPolicyForCR_FallsBackWhenSpecNil(t *testing.T) {
+	cr := &v1beta2.Broker{
+		ObjectMeta: metav1.ObjectMeta{Name: "broker", Namespace: "ns"},
+		Spec:       v1beta2.BrokerSpec{},
+	}
+
+	netpol := NewNetworkPolicyForCR(nil, cr)
+	ports := collectPorts(netpol)
+
+	assert.Contains(t, ports, int32(61616), "auto-generated defaults when spec.networkPolicy is nil")
+	assert.Contains(t, ports, int32(8161))
+}
+
+func collectPorts(netpol *netv1.NetworkPolicy) []int32 {
+	var ports []int32
+	for _, rule := range netpol.Spec.Ingress {
+		for _, p := range rule.Ports {
+			if p.Port != nil {
+				ports = append(ports, int32(p.Port.IntValue()))
+			}
+		}
+	}
+	return ports
+}

--- a/pkg/resources/networkpolicies/suite_test.go
+++ b/pkg/resources/networkpolicies/suite_test.go
@@ -1,0 +1,13 @@
+package networkpolicies
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestNetworkpolicies(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Networkpolicies Suite")
+}

--- a/pkg/utils/common/common.go
+++ b/pkg/utils/common/common.go
@@ -701,6 +701,7 @@ func GetDeployedResources(instance *v1beta2.Broker, client rtclient.Client, onOp
 			&corev1.ConfigMapList{},
 			&policyv1.PodDisruptionBudgetList{},
 			&netv1.IngressList{},
+			&netv1.NetworkPolicyList{},
 		)
 	} else {
 		resourceMap, err = reader.ListAll(
@@ -710,6 +711,7 @@ func GetDeployedResources(instance *v1beta2.Broker, client rtclient.Client, onOp
 			&corev1.SecretList{},
 			&corev1.ConfigMapList{},
 			&policyv1.PodDisruptionBudgetList{},
+			&netv1.NetworkPolicyList{},
 		)
 	}
 	if err != nil {
@@ -872,6 +874,14 @@ func FindFirstDotPemKey(secret *corev1.Secret) (string, error) {
 	}
 
 	return "", fmt.Errorf("no keys with the suffix .pem found in the secret %s", secret.Name)
+}
+
+// OperandNetworkPolicyDisabled returns true when the DISABLE_OPERAND_NETWORK_POLICY
+// env var is set to "true", allowing administrators to opt out of operator-managed
+// NetworkPolicies for broker pods.
+func OperandNetworkPolicyDisabled() bool {
+	val, found := os.LookupEnv("DISABLE_OPERAND_NETWORK_POLICY")
+	return found && strings.EqualFold(val, "true")
 }
 
 func fromEnv(envVarName, defaultValue string) *string {

--- a/pkg/utils/common/common_test.go
+++ b/pkg/utils/common/common_test.go
@@ -190,6 +190,37 @@ var _ = Describe("Common Test", func() {
 			Expect(secret).To(BeNil())
 		})
 	})
+
+	Describe("OperandNetworkPolicyDisabled", func() {
+		AfterEach(func() {
+			os.Unsetenv("DISABLE_OPERAND_NETWORK_POLICY")
+		})
+
+		It("returns false when env var is unset", func() {
+			os.Unsetenv("DISABLE_OPERAND_NETWORK_POLICY")
+			Expect(OperandNetworkPolicyDisabled()).To(BeFalse())
+		})
+
+		It("returns true when env var is 'true'", func() {
+			os.Setenv("DISABLE_OPERAND_NETWORK_POLICY", "true")
+			Expect(OperandNetworkPolicyDisabled()).To(BeTrue())
+		})
+
+		It("returns true case-insensitively", func() {
+			os.Setenv("DISABLE_OPERAND_NETWORK_POLICY", "True")
+			Expect(OperandNetworkPolicyDisabled()).To(BeTrue())
+		})
+
+		It("returns false for non-true values", func() {
+			os.Setenv("DISABLE_OPERAND_NETWORK_POLICY", "false")
+			Expect(OperandNetworkPolicyDisabled()).To(BeFalse())
+		})
+
+		It("returns false for empty string", func() {
+			os.Setenv("DISABLE_OPERAND_NETWORK_POLICY", "")
+			Expect(OperandNetworkPolicyDisabled()).To(BeFalse())
+		})
+	})
 })
 
 // errorClient is a fake client that returns errors for Get operations


### PR DESCRIPTION
In order to secure network communications in the cluster, the operator is now providing a NetworkPolicy to only allow the known used ports to be used to reach the broker.

The NetworkPolicy is generated by inspecting the ArtemisCR, adding any acceptor, console or connector port if necessary. The operator does not parse the broker properties however and users declaring any acceptor using broker properties have to use ResourceTemplates to override the values of the NetworkPolicy.

## Backward Compatibility Considerations for NetworkPolicy Feature

### Operator upgrade (breaking for broker-properties users)

When upgrading from a version without NetworkPolicy support, the new reconciler will create a NetworkPolicy for every existing ActiveMQArtemis CR on the next reconciliation. The NP allows ingress only on ports the operator knows about: default headless service ports (7800, 8161, 8778, 61616), plus any ports declared in spec.acceptors and spec.connectors. Ports configured solely through spec.brokerProperties are not detected and will be blocked. Affected users must add a ResourceTemplate to open those ports in the NP. This is the most impactful concern.

### Operator downgrade (stale NP)

If downgrading to a previous operator version, the NetworkPolicy becomes orphaned -- the older reconciler doesn't manage it. However, the NP has an OwnerReference on the ActiveMQArtemis CR, so Kubernetes garbage collection will delete it when the CR is deleted. While the CR exists, the stale NP remains in place with its last-known port list.

### OCP/Kubernetes version compatibility

NetworkPolicy (networking.k8s.io/v1) is GA since Kubernetes 1.7. No version concern for any supported OpenShift release. On clusters without a
  policy-enforcing CNI, the NP object is created but has no effect.

Restricted mode: Only Jolokia (8778) and Prometheus (8888) ports are opened. This matches the existing restricted mode behavior where no user-facing acceptors/connectors are configured.

### Testing

End to end tests can only be executed on an openshift environment or on a minikube environment with a CNI backend that understands network policies.

### Documentation

A tutorial using the calisto CNI demonstrate how to extend the network policies over a
restricted broker by performing two changes:
- opening a port for an acceptor
- limiting the accessibility of the jolokia port to the operator pod

The tutorial contains demonstration of the actual packet rejections
based on the rules.