### PR TITLE
[#1356] adding network policies for the operator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
       
       - name: Install OLM
         run: |
-          ./bin/operator-sdk olm install
+          ./bin/operator-sdk olm install --version 0.32.0
           minikube kubectl -- wait pod -l app=catalog-operator --for=condition=Ready --namespace=olm --timeout=2m
           minikube kubectl -- wait pod -l app=olm-operator --for=condition=Ready --namespace=olm --timeout=2m
           minikube kubectl -- wait --for=condition=Established crd/catalogsources.operators.coreos.com --timeout=2m

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ GO_MODULE := github.com/arkmq-org/activemq-artemis-operator
 OS := $(shell go env GOOS)
 ARCH := $(shell go env GOARCH)
 OPM_VERSION := v1.55.0
-OPERATOR_SDK_VERSION := v1.28.0
+OPERATOR_SDK_VERSION := v1.42.2
 YQ_VERSION := v4.46.1
 
 HELM_CHART_NAME := $(BUNDLE_PACKAGE)

--- a/PROJECT
+++ b/PROJECT
@@ -4,7 +4,7 @@
 # More info: https://book.kubebuilder.io/reference/project-config.html
 domain: amq.io
 layout:
-- go.kubebuilder.io/v3
+- go.kubebuilder.io/v4
 plugins:
   manifests.sdk.operatorframework.io/v2: {}
   scorecard.sdk.operatorframework.io/v2: {}

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ The [building.md](docs/help/building.md) describes how to build operator and how
 
 The [bundle.md](docs/help/bundle.md) contains instructions for how to build operator bundle images and integrate it into [Operator Liftcycle Manager](https://olm.operatorframework.io/) framework.
 
+Minimum OLM version: 0.32.0 — The operator bundle includes a NetworkPolicy manifest. OLM versions prior to 0.32.0 do not support NetworkPolicy as a bundle resource and will reject the InstallPlan. On OpenShift, this corresponds to version 4.20 or later.
+
 ## Debugging operator inside a container
 
 Install delve in the `builder` container, i.e. `RUN go install github.com/go-delve/delve/cmd/dlv@latest`

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -7,9 +7,9 @@ LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=arkmq-org-broker-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=stable
 LABEL operators.operatorframework.io.bundle.channel.default.v1=stable
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.28.0
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.42.2
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
-LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
+LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v4
 
 # Labels for testing.
 LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1

--- a/bundle/manifests/arkmq-org-broker-controller-manager-netpol_networking.k8s.io_v1_networkpolicy.yaml
+++ b/bundle/manifests/arkmq-org-broker-controller-manager-netpol_networking.k8s.io_v1_networkpolicy.yaml
@@ -1,0 +1,38 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: arkmq-org-broker-controller-manager-netpol
+spec:
+  egress:
+  - ports:
+    - port: 53
+      protocol: UDP
+    - port: 53
+      protocol: TCP
+  - ports:
+    - port: 443
+      protocol: TCP
+    - port: 6443
+      protocol: TCP
+  - ports:
+    - port: 8161
+      protocol: TCP
+  - ports:
+    - port: 8778
+      protocol: TCP
+  ingress:
+  - ports:
+    - port: 8081
+      protocol: TCP
+  - ports:
+    - port: 8383
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+      name: arkmq-org-broker-operator
+  policyTypes:
+  - Ingress
+  - Egress

--- a/bundle/manifests/arkmq-org-broker-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/arkmq-org-broker-operator.clusterserviceversion.yaml
@@ -361,8 +361,8 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    operators.operatorframework.io/builder: operator-sdk-v1.28.0
-    operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+    operators.operatorframework.io/builder: operator-sdk-v1.42.2
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/arkmq-org/arkmq-org-broker-operator
     support: arkmq-org
   labels:
@@ -422,7 +422,7 @@ spec:
         path: queueConfiguration.autoDeleteMessageCount
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:number
-      - description: If the queue is configuration managed
+      - description: ' If the queue is configuration managed'
         displayName: Configuration Managed
         path: queueConfiguration.configurationManaged
         x-descriptors:
@@ -556,8 +556,9 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
       statusDescriptors:
-      - description: Current state of the resource Conditions represent the latest
-          available observations of an object's state
+      - description: |-
+          Current state of the resource
+          Conditions represent the latest available observations of an object's state
         displayName: Conditions
         path: conditions
         x-descriptors:
@@ -588,8 +589,9 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
       statusDescriptors:
-      - description: Current state of the resource Conditions represent the latest
-          available observations of an object's state
+      - description: |-
+          Current state of the resource
+          Conditions represent the latest available observations of an object's state
         displayName: Conditions
         path: conditions
         x-descriptors:
@@ -626,8 +628,9 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
       statusDescriptors:
-      - description: Current state of the resource Conditions represent the latest
-          available observations of an object's state
+      - description: |-
+          Current state of the resource
+          Conditions represent the latest available observations of an object's state
         displayName: Conditions
         path: conditions
         x-descriptors:
@@ -680,7 +683,7 @@ spec:
         path: queueConfiguration.autoDeleteMessageCount
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:number
-      - description: If the queue is configuration managed
+      - description: ' If the queue is configuration managed'
         displayName: Configuration Managed
         path: queueConfiguration.configurationManaged
         x-descriptors:
@@ -814,8 +817,9 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
       statusDescriptors:
-      - description: Current state of the resource Conditions represent the latest
-          available observations of an object's state
+      - description: |-
+          Current state of the resource
+          Conditions represent the latest available observations of an object's state
         displayName: Conditions
         path: conditions
         x-descriptors:
@@ -1464,7 +1468,7 @@ spec:
         path: connectors[0].sniHost
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - description: Whether or not to enable SSL on this port
+      - description: ' Whether or not to enable SSL on this port'
         displayName: SSL Enabled
         path: connectors[0].sslEnabled
         x-descriptors:
@@ -1615,27 +1619,33 @@ spec:
       - description: Specifies Extra Volume Claims Templates for the broker pods
         displayName: Extra Volume Claims Templates
         path: deploymentPlan.extraVolumeClaimTemplates
-      - description: 'Annotations is an unstructured key value map stored with a resource
-          that may be set by external tools to store and retrieve arbitrary metadata.
-          They are not queryable and should be preserved when modifying objects. More
-          info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations'
+      - description: |-
+          Annotations is an unstructured key value map stored with a resource that may be
+          set by external tools to store and retrieve arbitrary metadata. They are not
+          queryable and should be preserved when modifying objects.
+          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
         displayName: Annotations
         path: deploymentPlan.extraVolumeClaimTemplates[0].annotations
-      - description: 'Map of string keys and values that can be used to organize and
-          categorize (scope and select) objects. May match selectors of replication
-          controllers and services. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels'
+      - description: |-
+          Map of string keys and values that can be used to organize and categorize
+          (scope and select) objects. May match selectors of replication controllers
+          and services.
+          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
         displayName: Labels
         path: deploymentPlan.extraVolumeClaimTemplates[0].labels
-      - description: 'Name must be unique within a namespace. Is required when creating
-          resources, although some resources may allow a client to request the generation
-          of an appropriate name automatically. Name is primarily intended for creation
-          idempotence and configuration definition. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names'
+      - description: |-
+          Name must be unique within a namespace. Is required when creating resources, although
+          some resources may allow a client to request the generation of an appropriate name
+          automatically. Name is primarily intended for creation idempotence and configuration
+          definition.
+          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names
         displayName: Name
         path: deploymentPlan.extraVolumeClaimTemplates[0].name
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - description: 'Specifies the desired characteristics of a volume claim More
-          info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+      - description: |-
+          Specifies the desired characteristics of a volume claim
+          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
         displayName: Spec
         path: deploymentPlan.extraVolumeClaimTemplates[0].spec
       - description: Specifies mount options for extraVolumes
@@ -1814,8 +1824,9 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
       statusDescriptors:
-      - description: Current state of the resource Conditions represent the latest
-          available observations of an object's state
+      - description: |-
+          Current state of the resource
+          Conditions represent the latest available observations of an object's state
         displayName: Conditions
         path: conditions
         x-descriptors:
@@ -2029,7 +2040,7 @@ spec:
         path: connectors[0].sniHost
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - description: Whether or not to enable SSL on this port
+      - description: ' Whether or not to enable SSL on this port'
         displayName: SSL Enabled
         path: connectors[0].sslEnabled
         x-descriptors:
@@ -2122,8 +2133,9 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:podCount
       statusDescriptors:
-      - description: Current state of the resource Conditions represent the latest
-          available observations of an object's state
+      - description: |-
+          Current state of the resource
+          Conditions represent the latest available observations of an object's state
         displayName: Conditions
         path: conditions
         x-descriptors:
@@ -2285,7 +2297,7 @@ spec:
         path: connectors[0].sniHost
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - description: Whether or not to enable SSL on this port
+      - description: ' Whether or not to enable SSL on this port'
         displayName: SSL Enabled
         path: connectors[0].sslEnabled
         x-descriptors:
@@ -2400,8 +2412,9 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
       statusDescriptors:
-      - description: Current state of the resource Conditions represent the latest
-          available observations of an object's state
+      - description: |-
+          Current state of the resource
+          Conditions represent the latest available observations of an object's state
         displayName: Conditions
         path: conditions
         x-descriptors:
@@ -2926,7 +2939,7 @@ spec:
         path: connectors[0].sniHost
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - description: Whether or not to enable SSL on this port
+      - description: ' Whether or not to enable SSL on this port'
         displayName: SSL Enabled
         path: connectors[0].sslEnabled
         x-descriptors:
@@ -3054,8 +3067,9 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
       statusDescriptors:
-      - description: Current state of the resource Conditions represent the latest
-          available observations of an object's state
+      - description: |-
+          Current state of the resource
+          Conditions represent the latest available observations of an object's state
         displayName: Conditions
         path: conditions
         x-descriptors:
@@ -3585,7 +3599,7 @@ spec:
         path: connectors[0].sniHost
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - description: Whether or not to enable SSL on this port
+      - description: ' Whether or not to enable SSL on this port'
         displayName: SSL Enabled
         path: connectors[0].sslEnabled
         x-descriptors:
@@ -3729,8 +3743,9 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
       statusDescriptors:
-      - description: Current state of the resource Conditions represent the latest
-          available observations of an object's state
+      - description: |-
+          Current state of the resource
+          Conditions represent the latest available observations of an object's state
         displayName: Conditions
         path: conditions
         x-descriptors:
@@ -4289,7 +4304,7 @@ spec:
         path: connectors[0].sniHost
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - description: Whether or not to enable SSL on this port
+      - description: ' Whether or not to enable SSL on this port'
         displayName: SSL Enabled
         path: connectors[0].sslEnabled
         x-descriptors:
@@ -4471,8 +4486,9 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
       statusDescriptors:
-      - description: Current state of the resource Conditions represent the latest
-          available observations of an object's state
+      - description: |-
+          Current state of the resource
+          Conditions represent the latest available observations of an object's state
         displayName: Conditions
         path: conditions
         x-descriptors:
@@ -4503,8 +4519,9 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
       statusDescriptors:
-      - description: Current state of the resource Conditions represent the latest
-          available observations of an object's state
+      - description: |-
+          Current state of the resource
+          Conditions represent the latest available observations of an object's state
         displayName: Conditions
         path: conditions
         x-descriptors:
@@ -4526,8 +4543,9 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       statusDescriptors:
-      - description: Current state of the resource Conditions represent the latest
-          available observations of an object's state
+      - description: |-
+          Current state of the resource
+          Conditions represent the latest available observations of an object's state
         displayName: Conditions
         path: conditions
         x-descriptors:
@@ -5055,8 +5073,9 @@ spec:
         displayName: Hawtio Roles
         path: securitySettings.management.hawtioRoles
       statusDescriptors:
-      - description: Current state of the resource Conditions represent the latest
-          available observations of an object's state
+      - description: |-
+          Current state of the resource
+          Conditions represent the latest available observations of an object's state
         displayName: Conditions
         path: conditions
         x-descriptors:
@@ -5594,8 +5613,9 @@ spec:
         displayName: Hawtio Roles
         path: securitySettings.management.hawtioRoles
       statusDescriptors:
-      - description: Current state of the resource Conditions represent the latest
-          available observations of an object's state
+      - description: |-
+          Current state of the resource
+          Conditions represent the latest available observations of an object's state
         displayName: Conditions
         path: conditions
         x-descriptors:
@@ -5619,8 +5639,9 @@ spec:
       - displayName: ServiceSelector
         path: selector
       statusDescriptors:
-      - description: Current state of the resource Conditions represent the latest
-          available observations of an object's state
+      - description: |-
+          Current state of the resource
+          Conditions represent the latest available observations of an object's state
         displayName: Conditions
         path: conditions
         x-descriptors:
@@ -6269,7 +6290,7 @@ spec:
         path: connectors[0].sniHost
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - description: Whether or not to enable SSL on this port
+      - description: ' Whether or not to enable SSL on this port'
         displayName: SSL Enabled
         path: connectors[0].sslEnabled
         x-descriptors:
@@ -6420,27 +6441,33 @@ spec:
       - description: Specifies Extra Volume Claims Templates for the broker pods
         displayName: Extra Volume Claims Templates
         path: deploymentPlan.extraVolumeClaimTemplates
-      - description: 'Annotations is an unstructured key value map stored with a resource
-          that may be set by external tools to store and retrieve arbitrary metadata.
-          They are not queryable and should be preserved when modifying objects. More
-          info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations'
+      - description: |-
+          Annotations is an unstructured key value map stored with a resource that may be
+          set by external tools to store and retrieve arbitrary metadata. They are not
+          queryable and should be preserved when modifying objects.
+          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
         displayName: Annotations
         path: deploymentPlan.extraVolumeClaimTemplates[0].annotations
-      - description: 'Map of string keys and values that can be used to organize and
-          categorize (scope and select) objects. May match selectors of replication
-          controllers and services. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels'
+      - description: |-
+          Map of string keys and values that can be used to organize and categorize
+          (scope and select) objects. May match selectors of replication controllers
+          and services.
+          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
         displayName: Labels
         path: deploymentPlan.extraVolumeClaimTemplates[0].labels
-      - description: 'Name must be unique within a namespace. Is required when creating
-          resources, although some resources may allow a client to request the generation
-          of an appropriate name automatically. Name is primarily intended for creation
-          idempotence and configuration definition. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names'
+      - description: |-
+          Name must be unique within a namespace. Is required when creating resources, although
+          some resources may allow a client to request the generation of an appropriate name
+          automatically. Name is primarily intended for creation idempotence and configuration
+          definition.
+          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names
         displayName: Name
         path: deploymentPlan.extraVolumeClaimTemplates[0].name
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - description: 'Specifies the desired characteristics of a volume claim More
-          info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+      - description: |-
+          Specifies the desired characteristics of a volume claim
+          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
         displayName: Spec
         path: deploymentPlan.extraVolumeClaimTemplates[0].spec
       - description: Specifies mount options for extraVolumes
@@ -6619,8 +6646,9 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
       statusDescriptors:
-      - description: Current state of the resource Conditions represent the latest
-          available observations of an object's state
+      - description: |-
+          Current state of the resource
+          Conditions represent the latest available observations of an object's state
         displayName: Conditions
         path: conditions
         x-descriptors:
@@ -6700,8 +6728,9 @@ spec:
       - displayName: Resources
         path: resources
       statusDescriptors:
-      - description: Current state of the resource Conditions represent the latest
-          available observations of an object's state
+      - description: |-
+          Current state of the resource
+          Conditions represent the latest available observations of an object's state
         displayName: Conditions
         path: conditions
         x-descriptors:

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -6,9 +6,9 @@ annotations:
   operators.operatorframework.io.bundle.package.v1: arkmq-org-broker-operator
   operators.operatorframework.io.bundle.channels.v1: stable
   operators.operatorframework.io.bundle.channel.default.v1: stable
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.28.0
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.42.2
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
-  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
+  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v4
 
   # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,5 +1,6 @@
 resources:
 - manager.yaml
+- network_policy.yaml
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/config/manager/network_policy.yaml
+++ b/config/manager/network_policy.yaml
@@ -1,0 +1,44 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: controller-manager-netpol
+  labels:
+    control-plane: controller-manager
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+      name: arkmq-org-broker-operator
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Kubelet health and readiness probes
+    - ports:
+        - port: 8081
+          protocol: TCP
+    # Metrics endpoint
+    - ports:
+        - port: 8383
+          protocol: TCP
+  egress:
+    # Cluster DNS
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    # Kubernetes API server
+    - ports:
+        - port: 443
+          protocol: TCP
+        - port: 6443
+          protocol: TCP
+    # Broker Jolokia via console (non-restricted mode)
+    - ports:
+        - port: 8161
+          protocol: TCP
+    # Broker Jolokia via JVM agent (restricted mode)
+    - ports:
+        - port: 8778
+          protocol: TCP

--- a/config/manifests/bases/arkmq-org-broker-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/arkmq-org-broker-operator.clusterserviceversion.yaml
@@ -1129,7 +1129,7 @@ spec:
         path: queueConfiguration.autoDeleteMessageCount
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:number
-      - description: If the queue is configuration managed
+      - description: ' If the queue is configuration managed'
         displayName: Configuration Managed
         path: queueConfiguration.configurationManaged
         x-descriptors:
@@ -1263,8 +1263,9 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
       statusDescriptors:
-      - description: Current state of the resource Conditions represent the latest
-          available observations of an object's state
+      - description: |-
+          Current state of the resource
+          Conditions represent the latest available observations of an object's state
         displayName: Conditions
         path: conditions
         x-descriptors:
@@ -1317,7 +1318,7 @@ spec:
         path: queueConfiguration.autoDeleteMessageCount
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:number
-      - description: If the queue is configuration managed
+      - description: ' If the queue is configuration managed'
         displayName: Configuration Managed
         path: queueConfiguration.configurationManaged
         x-descriptors:
@@ -1451,8 +1452,9 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
       statusDescriptors:
-      - description: Current state of the resource Conditions represent the latest
-          available observations of an object's state
+      - description: |-
+          Current state of the resource
+          Conditions represent the latest available observations of an object's state
         displayName: Conditions
         path: conditions
         x-descriptors:
@@ -1489,8 +1491,9 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
       statusDescriptors:
-      - description: Current state of the resource Conditions represent the latest
-          available observations of an object's state
+      - description: |-
+          Current state of the resource
+          Conditions represent the latest available observations of an object's state
         displayName: Conditions
         path: conditions
         x-descriptors:
@@ -1521,8 +1524,9 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
       statusDescriptors:
-      - description: Current state of the resource Conditions represent the latest
-          available observations of an object's state
+      - description: |-
+          Current state of the resource
+          Conditions represent the latest available observations of an object's state
         displayName: Conditions
         path: conditions
         x-descriptors:
@@ -2171,7 +2175,7 @@ spec:
         path: connectors[0].sniHost
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - description: Whether or not to enable SSL on this port
+      - description: ' Whether or not to enable SSL on this port'
         displayName: SSL Enabled
         path: connectors[0].sslEnabled
         x-descriptors:
@@ -2322,27 +2326,33 @@ spec:
       - description: Specifies Extra Volume Claims Templates for the broker pods
         displayName: Extra Volume Claims Templates
         path: deploymentPlan.extraVolumeClaimTemplates
-      - description: 'Annotations is an unstructured key value map stored with a resource
-          that may be set by external tools to store and retrieve arbitrary metadata.
-          They are not queryable and should be preserved when modifying objects. More
-          info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations'
+      - description: |-
+          Annotations is an unstructured key value map stored with a resource that may be
+          set by external tools to store and retrieve arbitrary metadata. They are not
+          queryable and should be preserved when modifying objects.
+          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
         displayName: Annotations
         path: deploymentPlan.extraVolumeClaimTemplates[0].annotations
-      - description: 'Map of string keys and values that can be used to organize and
-          categorize (scope and select) objects. May match selectors of replication
-          controllers and services. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels'
+      - description: |-
+          Map of string keys and values that can be used to organize and categorize
+          (scope and select) objects. May match selectors of replication controllers
+          and services.
+          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
         displayName: Labels
         path: deploymentPlan.extraVolumeClaimTemplates[0].labels
-      - description: 'Name must be unique within a namespace. Is required when creating
-          resources, although some resources may allow a client to request the generation
-          of an appropriate name automatically. Name is primarily intended for creation
-          idempotence and configuration definition. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names'
+      - description: |-
+          Name must be unique within a namespace. Is required when creating resources, although
+          some resources may allow a client to request the generation of an appropriate name
+          automatically. Name is primarily intended for creation idempotence and configuration
+          definition.
+          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names
         displayName: Name
         path: deploymentPlan.extraVolumeClaimTemplates[0].name
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - description: 'Specifies the desired characteristics of a volume claim More
-          info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+      - description: |-
+          Specifies the desired characteristics of a volume claim
+          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
         displayName: Spec
         path: deploymentPlan.extraVolumeClaimTemplates[0].spec
       - description: Specifies mount options for extraVolumes
@@ -2521,8 +2531,9 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
       statusDescriptors:
-      - description: Current state of the resource Conditions represent the latest
-          available observations of an object's state
+      - description: |-
+          Current state of the resource
+          Conditions represent the latest available observations of an object's state
         displayName: Conditions
         path: conditions
         x-descriptors:
@@ -3128,7 +3139,7 @@ spec:
         path: connectors[0].sniHost
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - description: Whether or not to enable SSL on this port
+      - description: ' Whether or not to enable SSL on this port'
         displayName: SSL Enabled
         path: connectors[0].sslEnabled
         x-descriptors:
@@ -3310,8 +3321,9 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
       statusDescriptors:
-      - description: Current state of the resource Conditions represent the latest
-          available observations of an object's state
+      - description: |-
+          Current state of the resource
+          Conditions represent the latest available observations of an object's state
         displayName: Conditions
         path: conditions
         x-descriptors:
@@ -3841,7 +3853,7 @@ spec:
         path: connectors[0].sniHost
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - description: Whether or not to enable SSL on this port
+      - description: ' Whether or not to enable SSL on this port'
         displayName: SSL Enabled
         path: connectors[0].sslEnabled
         x-descriptors:
@@ -3985,8 +3997,9 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
       statusDescriptors:
-      - description: Current state of the resource Conditions represent the latest
-          available observations of an object's state
+      - description: |-
+          Current state of the resource
+          Conditions represent the latest available observations of an object's state
         displayName: Conditions
         path: conditions
         x-descriptors:
@@ -4516,7 +4529,7 @@ spec:
         path: connectors[0].sniHost
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - description: Whether or not to enable SSL on this port
+      - description: ' Whether or not to enable SSL on this port'
         displayName: SSL Enabled
         path: connectors[0].sslEnabled
         x-descriptors:
@@ -4644,8 +4657,9 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
       statusDescriptors:
-      - description: Current state of the resource Conditions represent the latest
-          available observations of an object's state
+      - description: |-
+          Current state of the resource
+          Conditions represent the latest available observations of an object's state
         displayName: Conditions
         path: conditions
         x-descriptors:
@@ -4812,7 +4826,7 @@ spec:
         path: connectors[0].sniHost
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - description: Whether or not to enable SSL on this port
+      - description: ' Whether or not to enable SSL on this port'
         displayName: SSL Enabled
         path: connectors[0].sslEnabled
         x-descriptors:
@@ -4927,8 +4941,9 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
       statusDescriptors:
-      - description: Current state of the resource Conditions represent the latest
-          available observations of an object's state
+      - description: |-
+          Current state of the resource
+          Conditions represent the latest available observations of an object's state
         displayName: Conditions
         path: conditions
         x-descriptors:
@@ -5090,7 +5105,7 @@ spec:
         path: connectors[0].sniHost
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - description: Whether or not to enable SSL on this port
+      - description: ' Whether or not to enable SSL on this port'
         displayName: SSL Enabled
         path: connectors[0].sslEnabled
         x-descriptors:
@@ -5183,8 +5198,9 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:podCount
       statusDescriptors:
-      - description: Current state of the resource Conditions represent the latest
-          available observations of an object's state
+      - description: |-
+          Current state of the resource
+          Conditions represent the latest available observations of an object's state
         displayName: Conditions
         path: conditions
         x-descriptors:
@@ -5210,8 +5226,9 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
       statusDescriptors:
-      - description: Current state of the resource Conditions represent the latest
-          available observations of an object's state
+      - description: |-
+          Current state of the resource
+          Conditions represent the latest available observations of an object's state
         displayName: Conditions
         path: conditions
         x-descriptors:
@@ -5233,8 +5250,9 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       statusDescriptors:
-      - description: Current state of the resource Conditions represent the latest
-          available observations of an object's state
+      - description: |-
+          Current state of the resource
+          Conditions represent the latest available observations of an object's state
         displayName: Conditions
         path: conditions
         x-descriptors:
@@ -5772,8 +5790,9 @@ spec:
         displayName: Hawtio Roles
         path: securitySettings.management.hawtioRoles
       statusDescriptors:
-      - description: Current state of the resource Conditions represent the latest
-          available observations of an object's state
+      - description: |-
+          Current state of the resource
+          Conditions represent the latest available observations of an object's state
         displayName: Conditions
         path: conditions
         x-descriptors:
@@ -6301,8 +6320,9 @@ spec:
         displayName: Hawtio Roles
         path: securitySettings.management.hawtioRoles
       statusDescriptors:
-      - description: Current state of the resource Conditions represent the latest
-          available observations of an object's state
+      - description: |-
+          Current state of the resource
+          Conditions represent the latest available observations of an object's state
         displayName: Conditions
         path: conditions
         x-descriptors:
@@ -6326,8 +6346,9 @@ spec:
       - displayName: ServiceSelector
         path: selector
       statusDescriptors:
-      - description: Current state of the resource Conditions represent the latest
-          available observations of an object's state
+      - description: |-
+          Current state of the resource
+          Conditions represent the latest available observations of an object's state
         displayName: Conditions
         path: conditions
         x-descriptors:
@@ -6976,7 +6997,7 @@ spec:
         path: connectors[0].sniHost
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - description: Whether or not to enable SSL on this port
+      - description: ' Whether or not to enable SSL on this port'
         displayName: SSL Enabled
         path: connectors[0].sslEnabled
         x-descriptors:
@@ -7127,27 +7148,33 @@ spec:
       - description: Specifies Extra Volume Claims Templates for the broker pods
         displayName: Extra Volume Claims Templates
         path: deploymentPlan.extraVolumeClaimTemplates
-      - description: 'Annotations is an unstructured key value map stored with a resource
-          that may be set by external tools to store and retrieve arbitrary metadata.
-          They are not queryable and should be preserved when modifying objects. More
-          info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations'
+      - description: |-
+          Annotations is an unstructured key value map stored with a resource that may be
+          set by external tools to store and retrieve arbitrary metadata. They are not
+          queryable and should be preserved when modifying objects.
+          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
         displayName: Annotations
         path: deploymentPlan.extraVolumeClaimTemplates[0].annotations
-      - description: 'Map of string keys and values that can be used to organize and
-          categorize (scope and select) objects. May match selectors of replication
-          controllers and services. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels'
+      - description: |-
+          Map of string keys and values that can be used to organize and categorize
+          (scope and select) objects. May match selectors of replication controllers
+          and services.
+          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
         displayName: Labels
         path: deploymentPlan.extraVolumeClaimTemplates[0].labels
-      - description: 'Name must be unique within a namespace. Is required when creating
-          resources, although some resources may allow a client to request the generation
-          of an appropriate name automatically. Name is primarily intended for creation
-          idempotence and configuration definition. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names'
+      - description: |-
+          Name must be unique within a namespace. Is required when creating resources, although
+          some resources may allow a client to request the generation of an appropriate name
+          automatically. Name is primarily intended for creation idempotence and configuration
+          definition.
+          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names
         displayName: Name
         path: deploymentPlan.extraVolumeClaimTemplates[0].name
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - description: 'Specifies the desired characteristics of a volume claim More
-          info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+      - description: |-
+          Specifies the desired characteristics of a volume claim
+          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
         displayName: Spec
         path: deploymentPlan.extraVolumeClaimTemplates[0].spec
       - description: Specifies mount options for extraVolumes
@@ -7326,8 +7353,9 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
       statusDescriptors:
-      - description: Current state of the resource Conditions represent the latest
-          available observations of an object's state
+      - description: |-
+          Current state of the resource
+          Conditions represent the latest available observations of an object's state
         displayName: Conditions
         path: conditions
         x-descriptors:
@@ -7407,8 +7435,9 @@ spec:
       - displayName: Resources
         path: resources
       statusDescriptors:
-      - description: Current state of the resource Conditions represent the latest
-          available observations of an object's state
+      - description: |-
+          Current state of the resource
+          Conditions represent the latest available observations of an object's state
         displayName: Conditions
         path: conditions
         x-descriptors:

--- a/deploy/arkmq-org-broker-operator.yaml
+++ b/deploy/arkmq-org-broker-operator.yaml
@@ -14666,3 +14666,43 @@ spec:
           type: RuntimeDefault
       serviceAccountName: arkmq-org-broker-controller-manager
       terminationGracePeriodSeconds: 10
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: arkmq-org-broker-controller-manager-netpol
+  namespace: arkmq-org-broker-operator
+spec:
+  egress:
+  - ports:
+    - port: 53
+      protocol: UDP
+    - port: 53
+      protocol: TCP
+  - ports:
+    - port: 443
+      protocol: TCP
+    - port: 6443
+      protocol: TCP
+  - ports:
+    - port: 8161
+      protocol: TCP
+  - ports:
+    - port: 8778
+      protocol: TCP
+  ingress:
+  - ports:
+    - port: 8081
+      protocol: TCP
+  - ports:
+    - port: 8383
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+      name: arkmq-org-broker-operator
+  policyTypes:
+  - Ingress
+  - Egress

--- a/deploy/cluster_wide_install_opr.sh
+++ b/deploy/cluster_wide_install_opr.sh
@@ -22,6 +22,7 @@ SERVICE_ACCOUNT_NS="$($KUBE_CLI get -f $DEPLOY_PATH/service_account.yaml -o json
 sed "s/namespace:.*/namespace: ${SERVICE_ACCOUNT_NS}/" $DEPLOY_PATH/cluster_role_binding.yaml | $KUBE_CLI apply -f -
 $KUBE_CLI create -f $DEPLOY_PATH/election_role.yaml
 $KUBE_CLI create -f $DEPLOY_PATH/election_role_binding.yaml
+$KUBE_CLI create -f $DEPLOY_PATH/network_policy.yaml
 cat $DEPLOY_PATH/operator.yaml | sed "/WATCH_NAMESPACE/,/metadata.namespace/ s/valueFrom:/value: '${WATCH_NAMESPACE}'/" |
   sed "/WATCH_NAMESPACE/,/metadata.namespace/ s/fieldRef:/fieldref.namespace/" |
   sed '/fieldref.namespace/,/metadata.namespace/d' | $KUBE_CLI apply -f -

--- a/deploy/install_opr.sh
+++ b/deploy/install_opr.sh
@@ -16,4 +16,5 @@ $KUBE_CLI create -f $DEPLOY_PATH/role.yaml
 $KUBE_CLI create -f $DEPLOY_PATH/role_binding.yaml
 $KUBE_CLI create -f $DEPLOY_PATH/election_role.yaml
 $KUBE_CLI create -f $DEPLOY_PATH/election_role_binding.yaml
+$KUBE_CLI create -f $DEPLOY_PATH/network_policy.yaml
 $KUBE_CLI create -f $DEPLOY_PATH/operator.yaml

--- a/deploy/network_policy.yaml
+++ b/deploy/network_policy.yaml
@@ -1,0 +1,38 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: arkmq-org-broker-controller-manager-netpol
+spec:
+  egress:
+  - ports:
+    - port: 53
+      protocol: UDP
+    - port: 53
+      protocol: TCP
+  - ports:
+    - port: 443
+      protocol: TCP
+    - port: 6443
+      protocol: TCP
+  - ports:
+    - port: 8161
+      protocol: TCP
+  - ports:
+    - port: 8778
+      protocol: TCP
+  ingress:
+  - ports:
+    - port: 8081
+      protocol: TCP
+  - ports:
+    - port: 8383
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+      name: arkmq-org-broker-operator
+  policyTypes:
+  - Ingress
+  - Egress

--- a/deploy/undeploy_all.sh
+++ b/deploy/undeploy_all.sh
@@ -18,4 +18,5 @@ $KUBE_CLI delete -f $DEPLOY_PATH/cluster_role.yaml
 $KUBE_CLI delete -f $DEPLOY_PATH/cluster_role_binding.yaml
 $KUBE_CLI delete -f $DEPLOY_PATH/election_role.yaml
 $KUBE_CLI delete -f $DEPLOY_PATH/election_role_binding.yaml
+$KUBE_CLI delete -f $DEPLOY_PATH/network_policy.yaml
 $KUBE_CLI delete -f $DEPLOY_PATH/operator.yaml

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -57,7 +57,7 @@ helm install my-arkmq-org-broker-operator oci://quay.io/arkmq-org/helm-charts/ar
 ```
 
 ### Install the operator from OperatorHub.io
-In order to install the operator from OperatorHub.io, first be sure that you have a Kubernetes cluster with [OLM](https://olm.operatorframework.io/) then run the following command:
+In order to install the operator from OperatorHub.io, first be sure that you have a Kubernetes cluster with [OLM](https://olm.operatorframework.io/) v0.32.0 or later (on OpenShift, version 4.20 or later). The operator bundle includes a NetworkPolicy manifest that requires OLM NetworkPolicy support. Then run the following command:
 ```shell
 kubectl create -f https://operatorhub.io/install/arkmq-org-broker-operator.yaml
 ```

--- a/docs/help/bundle.md
+++ b/docs/help/bundle.md
@@ -21,6 +21,8 @@ The [Operator Lifecycle Manager](https://olm.operatorframework.io/) can help use
 ### Install OLM
 Check out the latest [releases on github](https://github.com/operator-framework/operator-lifecycle-manager/releases) for release-specific install instructions.
 
+Minimum OLM version: 0.32.0 — The operator bundle includes a NetworkPolicy manifest. OLM versions prior to 0.32.0 do not support NetworkPolicy as a bundle resource and will reject the InstallPlan. On OpenShift, this corresponds to version 4.20 or later.
+
 ## Create a repository
 Create a repository that Kubernetes will uses to pull your catalog image. You can create a public one for free on quay.io, see [how to create a repo](https://docs.quay.io/guides/create-repo.html).
 

--- a/hack/static_manifest_gen.sh
+++ b/hack/static_manifest_gen.sh
@@ -83,6 +83,10 @@ function writeFile() {
       createFile "$destdir/service_account.yaml"
       ;;
 
+    NetworkPolicy)
+      createFile "$destdir/network_policy.yaml"
+      ;;
+
     Namespace)
       echo "Skipping ${resource_kind}:${resource_name}"
       makeSingleInstall

--- a/helm-charts/arkmq-org-broker-operator/templates/controller-manager-netpol.yaml
+++ b/helm-charts/arkmq-org-broker-operator/templates/controller-manager-netpol.yaml
@@ -1,0 +1,39 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: arkmq-org-broker-controller-manager-netpol
+  labels:
+    control-plane: controller-manager
+  {{- include "arkmq-org-broker-operator.labels" . | nindent 4 }}
+spec:
+  egress:
+  - ports:
+    - port: 53
+      protocol: UDP
+    - port: 53
+      protocol: TCP
+  - ports:
+    - port: 443
+      protocol: TCP
+    - port: 6443
+      protocol: TCP
+  - ports:
+    - port: 8161
+      protocol: TCP
+  - ports:
+    - port: 8778
+      protocol: TCP
+  ingress:
+  - ports:
+    - port: 8081
+      protocol: TCP
+  - ports:
+    - port: 8383
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+      name: arkmq-org-broker-operator
+  policyTypes:
+  - Ingress
+  - Egress


### PR DESCRIPTION
Ship a NetworkPolicy that restricts the operator pod's network access:
- Ingress: allow only kubelet health probes (8081) and metrics (8383)
- Egress: DNS (53), Kubernetes API (443/6443), broker Jolokia (8161/8778)

The policy is included in deploy scripts, OLM and Helm chart.

The minimum version of the operator sdk was increased in order for OLM
to support the network policies.

On OpenShift with OVN-Kubernetes, kubelet probe traffic traverses the
pod network and is subject to NetworkPolicy enforcement, so port 8081
must be explicitly allowed. Both 443 and 6443 are permitted for API
server access to support vanilla Kubernetes and OpenShift respectively.

**This makes the operator compatible with openshift 4.20+**