### PR TITLE
[#1288] Update cert-manager version to v1.20.0 in tutorials

### DIFF
--- a/docs/tutorials/prometheus_locked_down.md
+++ b/docs/tutorials/prometheus_locked_down.md
@@ -399,7 +399,7 @@ Visit https://github.com/prometheus-operator/kube-prometheus for instructions on
 ### Install Cert-Manager
 
 ```{"stage":"certs"}
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.13.2/cert-manager.yaml
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.20.0/cert-manager.yaml
 ```
 ```shell markdown_runner
 namespace/cert-manager created

--- a/docs/tutorials/send_receive_ingress_pem.md
+++ b/docs/tutorials/send_receive_ingress_pem.md
@@ -118,7 +118,7 @@ pod/activemq-artemis-controller-manager-fdd64476f-2krkz condition met
 [Follow the official documentation.](https://cert-manager.io/docs/installation/)
 
 ```{"stage":"cert-manager"}
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.15.1/cert-manager.yaml
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.20.0/cert-manager.yaml
 ```
 ```shell markdown_runner
 namespace/cert-manager created


### PR DESCRIPTION
The tutorials referenced outdated cert-manager versions (v1.13.2 and v1.15.1) that are already EOL and no longer supported. Updated to v1.20.0, the latest supported release per https://cert-manager.io/docs/releases/.


fixes: [issue#1288](https://github.com/arkmq-org/activemq-artemis-operator/issues/1288)