### PR TITLE
[#1356] Remove egress restrictions from operator NetworkPolicy

### DIFF
--- a/config/manager/network_policy.yaml
+++ b/config/manager/network_policy.yaml
@@ -11,7 +11,6 @@ spec:
       name: arkmq-org-broker-operator
   policyTypes:
     - Ingress
-    - Egress
   ingress:
     # Kubelet health and readiness probes
     - ports:
@@ -20,25 +19,4 @@ spec:
     # Metrics endpoint
     - ports:
         - port: 8383
-          protocol: TCP
-  egress:
-    # Cluster DNS
-    - ports:
-        - port: 53
-          protocol: UDP
-        - port: 53
-          protocol: TCP
-    # Kubernetes API server
-    - ports:
-        - port: 443
-          protocol: TCP
-        - port: 6443
-          protocol: TCP
-    # Broker Jolokia via console (non-restricted mode)
-    - ports:
-        - port: 8161
-          protocol: TCP
-    # Broker Jolokia via JVM agent (restricted mode)
-    - ports:
-        - port: 8778
           protocol: TCP

--- a/deploy/arkmq-org-broker-operator.yaml
+++ b/deploy/arkmq-org-broker-operator.yaml
@@ -14675,23 +14675,6 @@ metadata:
   name: arkmq-org-broker-controller-manager-netpol
   namespace: arkmq-org-broker-operator
 spec:
-  egress:
-  - ports:
-    - port: 53
-      protocol: UDP
-    - port: 53
-      protocol: TCP
-  - ports:
-    - port: 443
-      protocol: TCP
-    - port: 6443
-      protocol: TCP
-  - ports:
-    - port: 8161
-      protocol: TCP
-  - ports:
-    - port: 8778
-      protocol: TCP
   ingress:
   - ports:
     - port: 8081
@@ -14705,4 +14688,3 @@ spec:
       name: arkmq-org-broker-operator
   policyTypes:
   - Ingress
-  - Egress

--- a/deploy/network_policy.yaml
+++ b/deploy/network_policy.yaml
@@ -5,23 +5,6 @@ metadata:
     control-plane: controller-manager
   name: arkmq-org-broker-controller-manager-netpol
 spec:
-  egress:
-  - ports:
-    - port: 53
-      protocol: UDP
-    - port: 53
-      protocol: TCP
-  - ports:
-    - port: 443
-      protocol: TCP
-    - port: 6443
-      protocol: TCP
-  - ports:
-    - port: 8161
-      protocol: TCP
-  - ports:
-    - port: 8778
-      protocol: TCP
   ingress:
   - ports:
     - port: 8081
@@ -35,4 +18,3 @@ spec:
       name: arkmq-org-broker-operator
   policyTypes:
   - Ingress
-  - Egress

--- a/helm-charts/arkmq-org-broker-operator/templates/controller-manager-netpol.yaml
+++ b/helm-charts/arkmq-org-broker-operator/templates/controller-manager-netpol.yaml
@@ -6,23 +6,6 @@ metadata:
     control-plane: controller-manager
   {{- include "arkmq-org-broker-operator.labels" . | nindent 4 }}
 spec:
-  egress:
-  - ports:
-    - port: 53
-      protocol: UDP
-    - port: 53
-      protocol: TCP
-  - ports:
-    - port: 443
-      protocol: TCP
-    - port: 6443
-      protocol: TCP
-  - ports:
-    - port: 8161
-      protocol: TCP
-  - ports:
-    - port: 8778
-      protocol: TCP
   ingress:
   - ports:
     - port: 8081
@@ -36,4 +19,3 @@ spec:
       name: arkmq-org-broker-operator
   policyTypes:
   - Ingress
-  - Egress


### PR DESCRIPTION
## Summary

- Removes egress rules from the operator's NetworkPolicy, keeping only ingress restrictions (health probes on 8081, metrics on 8383)
- The egress rules listed specific ports for the Kubernetes API server (443, 6443), DNS (53), and broker management (8161, 8778), but these break on platforms where the API server listens on non-standard ports (e.g. minikube uses 8443), causing the operator pod to crash-loop
- Since target ports vary by platform and the operator needs unrestricted outbound access to function, egress restrictions are not viable

## Test plan

- [x] Verified on minikube with Calico CNI -- operator no longer crash-loops
- [ ] Verify on OpenShift CRC that operator starts and functions correctly
- [ ] Run full E2E test suite


Made with [Cursor](https://cursor.com)