### PR TITLE
[#1329] Deprecate ActiveMQArtemis CRD in favour of Broker CRD (brokers.broker.arkmq.org)

### DIFF
--- a/api/v1beta1/activemqartemis_types.go
+++ b/api/v1beta1/activemqartemis_types.go
@@ -771,6 +771,7 @@ type ExternalConfigStatus struct {
 //+operator-sdk:csv:customresourcedefinitions:resources={{"ConfigMap", "v1"}}
 //+operator-sdk:csv:customresourcedefinitions:resources={{"StatefulSet", "apps/v1"}}
 
+// +kubebuilder:deprecatedversion:warning="The ActiveMQArtemis CRD (activemqartemises.broker.amq.io) is deprecated. Use the Broker CRD (brokers.broker.arkmq.org) instead by updating apiVersion to broker.arkmq.org/v1beta2 and kind to Broker. The spec is compatible."
 // A stateful deployment of one or more brokers
 // +operator-sdk:csv:customresourcedefinitions:displayName="ActiveMQ Artemis"
 type ActiveMQArtemis struct {

--- a/bundle/manifests/broker.amq.io_activemqartemises.yaml
+++ b/bundle/manifests/broker.amq.io_activemqartemises.yaml
@@ -24,6 +24,10 @@ spec:
       jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: The ActiveMQArtemis CRD (activemqartemises.broker.amq.io)
+      is deprecated. Use the Broker CRD (brokers.broker.arkmq.org) instead by updating
+      apiVersion to broker.arkmq.org/v1beta2 and kind to Broker. The spec is compatible.
     name: v1beta1
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/broker.amq.io_activemqartemises.yaml
+++ b/config/crd/bases/broker.amq.io_activemqartemises.yaml
@@ -25,6 +25,10 @@ spec:
       jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: The ActiveMQArtemis CRD (activemqartemises.broker.amq.io)
+      is deprecated. Use the Broker CRD (brokers.broker.arkmq.org) instead by updating
+      apiVersion to broker.arkmq.org/v1beta2 and kind to Broker. The spec is compatible.
     name: v1beta1
     schema:
       openAPIV3Schema:

--- a/deploy/arkmq-org-broker-operator.yaml
+++ b/deploy/arkmq-org-broker-operator.yaml
@@ -676,6 +676,8 @@ spec:
       jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: The ActiveMQArtemis CRD (activemqartemises.broker.amq.io) is deprecated. Use the Broker CRD (brokers.broker.arkmq.org) instead by updating apiVersion to broker.arkmq.org/v1beta2 and kind to Broker. The spec is compatible.
     name: v1beta1
     schema:
       openAPIV3Schema:

--- a/deploy/crds/broker_activemqartemis_crd.yaml
+++ b/deploy/crds/broker_activemqartemis_crd.yaml
@@ -24,6 +24,8 @@ spec:
       jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: The ActiveMQArtemis CRD (activemqartemises.broker.amq.io) is deprecated. Use the Broker CRD (brokers.broker.arkmq.org) instead by updating apiVersion to broker.arkmq.org/v1beta2 and kind to Broker. The spec is compatible.
     name: v1beta1
     schema:
       openAPIV3Schema:

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -101,23 +101,23 @@ arkmq-org-broker-controller-manager-5ff459cd95-kn22m   1/1     Running   0      
 
 ## Deploying the broker
 
-Now that the operator is running and listening for changes related to our crd we can deploy our [artemis single example](../../examples/artemis/artemis_single.yaml)
+Now that the operator is running and listening for changes related to our crd we can deploy our [broker single example](../../examples/broker/broker_single.yaml)
 which looks like
 
 ```$yaml
-apiVersion: broker.amq.io/v1beta1
-kind: ActiveMQArtemis
+apiVersion: broker.arkmq.org/v1beta2
+kind: Broker
 metadata:
-  name: artemis-broker
-```  
+  name: my-broker
+```
 
 Note in particular the **spec.image** which identifies the container image to use to launch the AMQ Broker. If it's empty, 'placeholder' or not defined it will get the latest default image url from deploy/operator.yaml where a list of supported broker image are defined as environment variables.
 
 To deploy the broker simply execute
 
 ```$shell
-$ kubectl create -f examples/artemis/artemis_single.yaml -n arkmq-org-broker-operator
-activemqartemis.broker.amq.io/artemis-broker created
+$ kubectl create -f examples/broker/broker_single.yaml -n arkmq-org-broker-operator
+broker.broker.arkmq.org/my-broker created
 ```
 In a moment you should see one broker pod is created alongside the operator pod:
 
@@ -125,7 +125,7 @@ In a moment you should see one broker pod is created alongside the operator pod:
 $ kubectl get pod -n arkmq-org-broker-operator
 NAME                                                   READY   STATUS    RESTARTS   AGE
 arkmq-org-broker-controller-manager-5ff459cd95-kn22m   1/1     Running   0          128m
-artemis-broker-ss-0                                    1/1     Running   0          23m
+my-broker-ss-0                                         1/1     Running   0          23m
 ```
 
 ## Scaling
@@ -134,12 +134,12 @@ The spec.deploymentPlan.size controls how many broker pods you want to deploy to
 
 For example if you want to scale up the above deployment to 2 pods, modify the size to 2:
 
-examples/artemis/artemis_single.yaml
+examples/broker/broker_single.yaml
 ```$yaml
-apiVersion: broker.amq.io/v1beta1
-kind: ActiveMQArtemis
+apiVersion: broker.arkmq.org/v1beta2
+kind: Broker
 metadata:
-  name: artemis-broker
+  name: my-broker
 spec:
   deploymentPlan:
     size: 2
@@ -147,8 +147,8 @@ spec:
 and apply it:
 
 ```$shell
-$ kubectl apply -f examples/artemis/artemis_single.yaml -n arkmq-org-broker-operator
-activemqartemis.broker.amq.io/artemis-broker configured
+$ kubectl apply -f examples/broker/broker_single.yaml -n arkmq-org-broker-operator
+broker.broker.arkmq.org/my-broker configured
 ```
 
 and you will get 2 broker pods in the cluster
@@ -157,8 +157,8 @@ and you will get 2 broker pods in the cluster
 $ kubectl get pod -n arkmq-org-broker-operator
 NAME                                                   READY   STATUS    RESTARTS   AGE
 arkmq-org-broker-controller-manager-5ff459cd95-kn22m   1/1     Running   0          140m
-artemis-broker-ss-0                                    1/1     Running   0          35m
-artemis-broker-ss-1                                    1/1     Running   0          69s
+my-broker-ss-0                                         1/1     Running   0          35m
+my-broker-ss-1                                         1/1     Running   0          69s
 ```
 
 You can scale down the deployment in similar manner by reducing the size and apply it again.
@@ -173,8 +173,8 @@ By default if broker pods are scaled to more than one then the broker pods form 
 To undeploy the broker we simply execute
 
 ```$shell
-$ kubectl delete -f examples/artemis/artemis_single.yaml -n arkmq-org-broker-operator
-activemqartemis.broker.amq.io "artemis-broker" deleted
+$ kubectl delete -f examples/broker/broker_single.yaml -n arkmq-org-broker-operator
+broker.broker.arkmq.org "my-broker" deleted
 ```
 
 ## Managing Queues
@@ -253,8 +253,8 @@ An operand with version >= 2.43.0 is necessary when jgroups discovery (the defau
 
 
 ```$yaml
-apiVersion: broker.amq.io/v1beta1
-kind: ActiveMQArtemis
+apiVersion: broker.arkmq.org/v1beta1
+kind: Broker
 metadata:
   name: artemis-broker
 spec:
@@ -281,13 +281,13 @@ The drainer pod will contact one of the live pods in the cluster and drain the m
 After the draining is complete it shuts down itself.
 
 The message draining only works when you enabled persistence and messageMigration on broker custome resource.
-For example, you can deploy a cluster from our [broker cluster persistence example](../../examples/artemis/artemis_cluster_persistence.yaml)
+For example, you can deploy a cluster from our [broker cluster persistence example](../../examples/broker/broker_cluster_persistence.yaml)
 
 ```$yaml
-apiVersion: broker.amq.io/v1beta1
-kind: ActiveMQArtemis
+apiVersion: broker.arkmq.org/v1beta2
+kind: Broker
 metadata:
-  name: artemis-broker
+  name: my-broker
 spec:
   deploymentPlan:
     size: 2
@@ -298,8 +298,8 @@ spec:
 To demonstrate the message draining first deploy the above custom resource (assuming the operator is running):
 
 ```$shell
-$ kubectl create -f ./examples/artemis/artemis_cluster_persistence.yaml -n arkmq-org-broker-operator
-activemqartemis.broker.amq.io/artemis-broker created
+$ kubectl create -f ./examples/broker/broker_cluster_persistence.yaml -n arkmq-org-broker-operator
+broker.broker.arkmq.org/my-broker created
 ```
 
 You shall see 2 broker pods are created.
@@ -308,18 +308,18 @@ You shall see 2 broker pods are created.
 $ kubectl get pod -n arkmq-org-broker-operator
 NAME                                                   READY   STATUS    RESTARTS   AGE
 arkmq-org-broker-controller-manager-5ff459cd95-kn22m   1/1     Running   0          3h19m
-artemis-broker-ss-0                                    1/1     Running   0          89s
-artemis-broker-ss-1                                    1/1     Running   0          53s
+my-broker-ss-0                                         1/1     Running   0          89s
+my-broker-ss-1                                         1/1     Running   0          53s
 ```
 
 Now we'll use broker's cli tool to send some messages to each broker pod. 
 
-First send 100 messages to broker **artemis-broker-ss-0**:
+First send 100 messages to broker **my-broker-ss-0**:
 
 ```$shell
-$ kubectl exec artemis-broker-ss-0 -- amq-broker/bin/artemis producer --url tcp://artemis-broker-ss-0:61616 --message-count=100
-Defaulted container "artemis-broker-container" out of: artemis-broker-container, artemis-broker-container-init (init)
-Connection brokerURL = tcp://artemis-broker-ss-0:61616
+$ kubectl exec my-broker-ss-0 -- amq-broker/bin/artemis producer --url tcp://my-broker-ss-0:61616 --message-count=100
+Defaulted container "my-broker-container" out of: my-broker-container, my-broker-container-init (init)
+Connection brokerURL = tcp://my-broker-ss-0:61616
 Producer ActiveMQQueue[TEST], thread=0 Started to calculate elapsed time ...
 
 Producer ActiveMQQueue[TEST], thread=0 Produced: 100 messages
@@ -327,12 +327,12 @@ Producer ActiveMQQueue[TEST], thread=0 Elapsed time in second : 0 s
 Producer ActiveMQQueue[TEST], thread=0 Elapsed time in milli second : 409 milli seconds
 ```
 
-then send another 100 messages to broker **artemis-broker-ss-1**
+then send another 100 messages to broker **my-broker-ss-1**
 
 ```$shell
-$ kubectl exec artemis-broker-ss-1 -- amq-broker/bin/artemis producer --user x --password y --url tcp://artemis-broker-ss-1:61616 --message-count=100
-Defaulted container "artemis-broker-container" out of: artemis-broker-container, artemis-broker-container-init (init)
-Connection brokerURL = tcp://artemis-broker-ss-1:61616
+$ kubectl exec my-broker-ss-1 -- amq-broker/bin/artemis producer --user x --password y --url tcp://my-broker-ss-1:61616 --message-count=100
+Defaulted container "my-broker-container" out of: my-broker-container, my-broker-container-init (init)
+Connection brokerURL = tcp://my-broker-ss-1:61616
 Producer ActiveMQQueue[TEST], thread=0 Started to calculate elapsed time ...
 
 Producer ActiveMQQueue[TEST], thread=0 Produced: 100 messages
@@ -343,8 +343,8 @@ Producer ActiveMQQueue[TEST], thread=0 Elapsed time in milli second : 466 milli 
 Now each of the 2 brokers has 100 messages. 
 
 ```$shell
-$ kubectl exec artemis-broker-ss-0 --container artemis-broker-container -- amq-broker/bin/artemis queue stat
-Connection brokerURL = tcp://artemis-broker-ss-0.artemis-broker-hdls-svc.arkmq-org-broker-operator.svc.cluster.local:61616
+$ kubectl exec my-broker-ss-0 --container my-broker-container -- amq-broker/bin/artemis queue stat
+Connection brokerURL = tcp://my-broker-ss-0.my-broker-hdls-svc.arkmq-org-broker-operator.svc.cluster.local:61616
 |NAME                     |ADDRESS                  |CONSUMER_COUNT|MESSAGE_COUNT|MESSAGES_ADDED|DELIVERING_COUNT|MESSAGES_ACKED|SCHEDULED_COUNT|ROUTING_TYPE|
 |DLQ                      |DLQ                      |0             |0            |0             |0               |0             |0              |ANYCAST     |
 |ExpiryQueue              |ExpiryQueue              |0             |0            |0             |0               |0             |0              |ANYCAST     |
@@ -353,8 +353,8 @@ Connection brokerURL = tcp://artemis-broker-ss-0.artemis-broker-hdls-svc.arkmq-o
 ```
 
 ```$shell
-$ kubectl exec artemis-broker-ss-1 --container artemis-broker-container -- amq-broker/bin/artemis queue stat
-Connection brokerURL = tcp://artemis-broker-ss-1.artemis-broker-hdls-svc.arkmq-org-broker-operator.svc.cluster.local:61616
+$ kubectl exec my-broker-ss-1 --container my-broker-container -- amq-broker/bin/artemis queue stat
+Connection brokerURL = tcp://my-broker-ss-1.my-broker-hdls-svc.arkmq-org-broker-operator.svc.cluster.local:61616
 |NAME                     |ADDRESS                  |CONSUMER_COUNT|MESSAGE_COUNT|MESSAGES_ADDED|DELIVERING_COUNT|MESSAGES_ACKED|SCHEDULED_COUNT|ROUTING_TYPE|
 |DLQ                      |DLQ                      |0             |0            |0             |0               |0             |0              |ANYCAST     |
 |ExpiryQueue              |ExpiryQueue              |0             |0            |0             |0               |0             |0              |ANYCAST     |
@@ -362,13 +362,13 @@ Connection brokerURL = tcp://artemis-broker-ss-1.artemis-broker-hdls-svc.arkmq-o
 |activemq.management.2a...|activemq.management.2a...|1             |0            |0             |0               |0             |0              |MULTICAST   |
 ```
 
-Modify the ./examples/artemis/artemis_cluster_persistence.yaml to scale down to one broker
+Modify the ./examples/broker/broker_cluster_persistence.yaml to scale down to one broker
 
 ```$yaml
-apiVersion: broker.amq.io/v1beta1
-kind: ActiveMQArtemis
+apiVersion: broker.arkmq.org/v1beta2
+kind: Broker
 metadata:
-  name: artemis-broker
+  name: my-broker
 spec:
   deploymentPlan:
     size: 1
@@ -377,8 +377,8 @@ spec:
 ```
 and re-apply it:
 ```$shell
-$ kubectl apply -f ./examples/artemis/artemis_cluster_persistence.yaml -n arkmq-org-broker-operator
-activemqartemis.broker.amq.io/artemis-broker configured
+$ kubectl apply -f ./examples/broker/broker_cluster_persistence.yaml -n arkmq-org-broker-operator
+broker.broker.arkmq.org/my-broker configured
 ```
 
 The broker pods will be reduced to only one
@@ -387,16 +387,16 @@ The broker pods will be reduced to only one
 $ kubectl get pod -n arkmq-org-broker-operator
 NAME                                                   READY   STATUS    RESTARTS   AGE
 arkmq-org-broker-controller-manager-5ff459cd95-kn22m   1/1     Running   0          3h57m
-artemis-broker-ss-0                                    1/1     Running   0          39m
+my-broker-ss-0                                         1/1     Running   0          39m
 ```
 
-Now the messages on the broker pod **artemis-broker-ss-1** should have been all migrated to pod **artemis-broker-ss-0**.
+Now the messages on the broker pod **my-broker-ss-1** should have been all migrated to pod **my-broker-ss-0**.
 Use the broker cli tool again to check:
 
 ```$shell
-$ kubectl exec artemis-broker-ss-0 -- amq-broker/bin/artemis queue stat --url tcp://artemis-broker-ss-0:61616
-Defaulted container "artemis-broker-container" out of: artemis-broker-container, artemis-broker-container-init (init)
-Connection brokerURL = tcp://artemis-broker-ss-0:61616
+$ kubectl exec my-broker-ss-0 -- amq-broker/bin/artemis queue stat --url tcp://my-broker-ss-0:61616
+Defaulted container "my-broker-container" out of: my-broker-container, my-broker-container-init (init)
+Connection brokerURL = tcp://my-broker-ss-0:61616
 |NAME                     |ADDRESS                  |CONSUMER_COUNT |MESSAGE_COUNT |MESSAGES_ADDED |DELIVERING_COUNT |MESSAGES_ACKED |SCHEDULED_COUNT |ROUTING_TYPE |
 |$.artemis.internal.sf.my-cluster.941368e6-79c9-11ec-b4c8-0242ac11000b|$.artemis.internal.sf.my-cluster.941368e6-79c9-11ec-b4c8-0242ac11000b|0              |0             |0              |0                |0              |0               |MULTICAST    |
 |DLQ                      |DLQ                      |0              |0             |0              |0                |0              |0               |ANYCAST      |
@@ -408,7 +408,7 @@ You can see the queue TEST has 200 messages now.
 
 ## Using a operator extraMounts
 
-ActiveMQArtemis custom resource allows you to define extraMounts which will mount secrets and/or configmaps with 
+The Broker custom resource allows you to define extraMounts which will mount secrets and/or configmaps with
 configuration information as files to be used in the artemis configuration. One usage of extraMounts is to 
 redefine the log4j file used by artemis to log information. [Here](https://artemis.apache.org/components/artemis/documentation/latest/logging.html#logging) you can find details about artemis logging configuration.
 
@@ -445,18 +445,18 @@ Data
 logging.properties:  2687 bytes
 ```
 
-The next step is to define the extraMount in the ActiveMQArtemis custom resource like in our [example](../../examples/artemis/artemis_custom_logging_secret.yaml) and deploy it.
+The next step is to define the extraMount in the Broker custom resource like in our [example](../../examples/broker/broker_custom_logging_secret.yaml) and deploy it.
 
 ```$shell
-$ kubectl create -f ./examples/artemis/artemis_custom_logging_secret.yaml -n arkmq-org-broker-operator
-activemqartemis.broker.amq.io/artemis-broker-logging created
+$ kubectl create -f ./examples/broker/broker_custom_logging_secret.yaml -n arkmq-org-broker-operator
+broker.broker.arkmq.org/my-broker-logging created
 ```
 
 Then you should be able to see some audit log entries after the artemis start:
 
 ```$shell
-$ kubectl logs artemis-broker-logging-ss-0 -n arkmq-org-broker-operator |grep audit
-Defaulted container "artemis-broker-logging-container" out of: artemis-broker-logging-container, artemis-broker-logging-container-init (init)
+$ kubectl logs my-broker-logging-ss-0 -n arkmq-org-broker-operator |grep audit
+Defaulted container "my-broker-logging-container" out of: my-broker-logging-container, my-broker-logging-container-init (init)
 2023-11-08 20:02:46,914 INFO  [org.apache.activemq.audit.base] AMQ601019: User anonymous@internal is getting mbean info on target resource: org.apache.activemq.artemis.core.server.management.impl.HawtioSecurityControlImpl@7a26928a
 2023-11-08 20:02:47,115 INFO  [org.apache.activemq.audit.base] AMQ601019: User anonymous@internal is getting mbean info on target resource: org.apache.activemq.artemis.core.management.impl.JGroupsFileBroadcastGroupControlImpl@72725ee1
 2023-11-08 20:02:49,164 INFO  [org.apache.activemq.audit.base] AMQ601019: User anonymous@internal is getting mbean info on target resource: org.apache.activemq.artemis.core.management.impl.ClusterConnectionControlImpl@3cb8c8ce
@@ -471,7 +471,7 @@ $ kubectl create configmap newlog4j-logging-config --from-file=logging.propertie
 secret/newlog4j-logging-config created
 ```
 
-and use the [example](../../examples/artemis/artemis_custom_logging_configmap.yaml)
+and use the [example](../../examples/broker/broker_custom_logging_configmap.yaml)
 
 ## Undeploying the operator
 

--- a/docs/help/bundle.md
+++ b/docs/help/bundle.md
@@ -98,16 +98,16 @@ arkmq-org-broker-operator-source-g94fd                            1/1     Runnin
 
 ## Deploy a single Apache Artemis Broker
 
-The following command line deploys a single Apache Artemis Broker instance by applying the ActiveMQArtemis custom resource (CR) defined in artemis_single.yaml file:
+The following command line deploys a single Apache Artemis Broker instance by applying the Broker custom resource (CR) defined in broker_single.yaml file:
 
 ```$xslt
-$ kubectl apply -f examples/artemis/artemis_single.yaml
+$ kubectl apply -f examples/broker/broker_single.yaml
 ```
 
 To check the status of the broker, run:
 
-```$xslt 
-$ kubectl get ActivemqArtemis 
-NAME             READY   AGE
-artemis-broker   True    39s
+```$xslt
+$ kubectl get Broker
+NAME        READY   AGE
+my-broker   True    39s
 ```

--- a/docs/help/custom-resources.md
+++ b/docs/help/custom-resources.md
@@ -21,6 +21,7 @@ The following sub-sections detail the configuration items that you can set in Cu
 broker and addressing CRDs.
 
 ### Broker Custom Resource configuration reference
+
 A CR instance based on the main broker CRD enables you to configure brokers for deployment in a Kubernetes project, see the [arkmq-org/activemq-artemis-operator CRDs](https://doc.crds.dev/github.com/arkmq-org/activemq-artemis-operator). The following is the full CRD yaml file
 
 ```yaml
@@ -28,21 +29,23 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
-  name: activemqartemises.broker.amq.io
+    controller-gen.kubebuilder.io/version: v0.16.5
+  name: brokers.broker.arkmq.org
 spec:
-  group: broker.amq.io
+  group: broker.arkmq.org
   names:
-    kind: ActiveMQArtemis
-    listKind: ActiveMQArtemisList
-    plural: activemqartemises
-    singular: activemqartemis
+    kind: Broker
+    listKind: BrokerList
+    plural: brokers
+    shortNames:
+    - b
+    singular: broker
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - name: v1beta2
     schema:
       openAPIV3Schema:
-        description: ActiveMQArtemis is the Schema for the activemqartemises API
+        description: A stateful deployment of one or more brokers
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -57,7 +60,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: ActiveMQArtemisSpec defines the desired state of ActiveMQArtemis
+            description: BrokerSpec defines the desired state of Broker
             properties:
               acceptors:
                 description: Acceptor configuration
@@ -635,8 +638,8 @@ spec:
                         type: string
                     type: object
                 type: object
-              upgrades: This is deprecated in v1beta1, specifying the Version is sufficient.
-                description: ActiveMQArtemis App product upgrade flags
+              upgrades:
+                description: Specifies the upgrades (deprecated in favour of Version)
                 properties:
                   enabled:
                     description: Set to true to enable automatic micro version product
@@ -656,7 +659,7 @@ spec:
                 type: string
             type: object
           status:
-            description: ActiveMQArtemisStatus defines the observed state of ActiveMQArtemis
+            description: BrokerStatus defines the observed state of Broker
             properties:
               podStatus:
                 description: Pod Status

--- a/docs/help/operator.md
+++ b/docs/help/operator.md
@@ -25,10 +25,11 @@ The following CRD's are available for the Operator and can be found in the Opera
 
 | CRD                 | Description                                                    |           Name            | Shortname  |
 | :---                | :----:                                                         | :----:                    | :---:      |
-| **Main broker CRD** | Create and configure a broker deployment                       |     activemqartemises     |     aa     |
-| **Address CRD**     | Create addresses and queues for a broker deployment            | activemqartemisaddresses  |    aaa     |
-| **Scaledown CRD**   | Creates a Scaledown Controller for message migration           | activemqartemisscaledowns |    aad     |
-| **Security CRD**    | Configure the security and authentication method of the Broker | activemqartemissecurities |    aas     |
+| **Main broker CRD** | Create and configure a broker deployment                       |        brokers            |     b      |
+| **ActiveMQArtemis CRD** | Create and configure a broker deployment (deprecated)        |     activemqartemises     |     aa     |
+| **Address CRD**     | Create addresses and queues for a broker deployment (deprecated) | activemqartemisaddresses  |    aaa     |
+| **Scaledown CRD**   | Creates a Scaledown Controller for message migration (deprecated) | activemqartemisscaledowns |    aad     |
+| **Security CRD**    | Configure the security and authentication method of the Broker (deprecated) | activemqartemissecurities |    aas     |
 
 ### Additional resources
 
@@ -320,13 +321,13 @@ Using the Kubernetes command-line interface switch to the namespace you are usin
 $ kubectl config set-context $(kubectl config current-context) --namespace= <project-name>
 ```
 
-Open the sample CR file called broker_activemqartemis_v1beta1_cr.yaml that is included in the deploy/crs directory of the Operator
+Open the sample CR file called broker_broker_v1beta2_cr.yaml that is included in the deploy/crs directory of the Operator
 installation archive that you downloaded and extracted. For a basic broker deployment, the configuration might resemble 
 that shown below. This configuration is the default content of the broker_activemqartemis_cr.yaml sample CR.
 
 ```yaml
-apiVersion: broker.amq.io/v1beta1
-kind: ActiveMQArtemis
+apiVersion: broker.arkmq.org/v1beta2
+kind: Broker
 metadata:
   name: ex-aao
 spec:
@@ -432,8 +433,8 @@ Open the CR file that you used for your basic broker deployment.
 
 For a clustered deployment, ensure that the value of deploymentPlan.size is 2 or greater. For example:
 ```yaml
-apiVersion: broker.amq.io/v1beta1
-kind: ActiveMQArtemis
+apiVersion: broker.arkmq.org/v1beta2
+kind: Broker
 metadata:
   name: ex-aao
 spec:
@@ -631,8 +632,8 @@ spec:
 It is possible to configure tolerations on the deployed broker image. An example of a toleration would be something like:
 
 ```yaml
-apiVersion: broker.amq.io/v1beta1
-kind: ActiveMQArtemis
+apiVersion: broker.arkmq.org/v1beta2
+kind: Broker
 metadata:
   name: broker
   namespace: arkmq-org-broker-operator
@@ -652,8 +653,8 @@ The use of Taints and Tolerations is outside the scope of this document, for ful
 It is possible to configure Affinity for the container pods, An example of this would be:
 
 ```yaml
-apiVersion: broker.amq.io/v1beta1
-kind: ActiveMQArtemis
+apiVersion: broker.arkmq.org/v1beta2
+kind: Broker
 metadata:
   name: broker
   namespace: arkmq-org-broker-operator
@@ -677,8 +678,8 @@ Affinity is outside the scope of this document, for full documentation see the [
 It is possible to configure Node Selectors for the container pods, An example of this would be:
 
 ```yaml
-apiVersion: broker.amq.io/v1beta1
-kind: ActiveMQArtemis
+apiVersion: broker.arkmq.org/v1beta2
+kind: Broker
 metadata:
   name: broker
   namespace: arkmq-org-broker-operator
@@ -695,8 +696,8 @@ Node Selectors are outside the scope of this document, for full documentation se
 It is possible to configure PriorityClassName for the container pods, An example of this would be:
 
 ```yaml
-apiVersion: broker.amq.io/v1beta1
-kind: ActiveMQArtemis
+apiVersion: broker.arkmq.org/v1beta2
+kind: Broker
 metadata:
   name: broker
   namespace: arkmq-org-broker-operator
@@ -720,8 +721,8 @@ Pod Priority is outside the scope of this document, for full documentation see t
 Labels can be added to the pods by defining them like so:
 
 ```yaml
-apiVersion: broker.amq.io/v1beta1
-kind: ActiveMQArtemis
+apiVersion: broker.arkmq.org/v1beta2
+kind: Broker
 metadata:
   name: broker
   namespace: arkmq-org-broker-operator
@@ -739,8 +740,8 @@ Labels are outside the scope of this document, for full documentation see the [K
 Annotations can be added to the pods by defining them like so:
 
 ```yaml
-apiVersion: broker.amq.io/v1beta1
-kind: ActiveMQArtemis
+apiVersion: broker.arkmq.org/v1beta2
+kind: Broker
 metadata:
   name: broker
   namespace: arkmq-org-broker-operator
@@ -760,8 +761,8 @@ Note: the relevant variables supported by [`ingressHost`](https://github.com/ark
 In the following example, the annotation "someKey=someValue" is added to all Services
 
 ```yaml
-apiVersion: broker.amq.io/v1beta1
-kind: ActiveMQArtemis
+apiVersion: broker.arkmq.org/v1beta2
+kind: Broker
 metadata:
   name: broker
   namespace: arkmq-org-broker-operator
@@ -779,8 +780,8 @@ Occasionally it is necessary to make customisations to the spec of a managed res
 In the following example, the `spec.publishNotReadyAddresses` attribute of the services created by the operator is set to `false`:
 
 ```yaml
-apiVersion: broker.amq.io/v1beta1
-kind: ActiveMQArtemis
+apiVersion: broker.arkmq.org/v1beta2
+kind: Broker
 metadata:
   name: broker
 spec:
@@ -797,8 +798,8 @@ The string values in the `patch` field support the following variables: $(CR_NAM
 In the following example, a custom security context is added to the internal broker container of the managed StatefulSet by patching just the required attribute. Note: `name` is the mergeKey, it must match that of the managed container with the CR.Name prefix:
 
 ```yaml
-apiVersion: broker.amq.io/v1beta1
-kind: ActiveMQArtemis
+apiVersion: broker.arkmq.org/v1beta2
+kind: Broker
 metadata:
   name: broker
 spec:
@@ -822,8 +823,8 @@ As an advanced option, you can set environment variables for containers using a 
 For example, to have the JDK output what it sees as 'the system', provide a relevant JDK_JAVA_OPTIONS key in the env attribute.
 
 ```yaml
-apiVersion: broker.amq.io/v1beta1
-kind: ActiveMQArtemis
+apiVersion: broker.arkmq.org/v1beta2
+kind: Broker
 metadata:
   name: broker
   namespace: arkmq-org-broker-operator
@@ -917,8 +918,8 @@ stringData:
 ```
 
 ```yaml
-apiVersion: broker.amq.io/v1beta1
-kind: ActiveMQArtemis
+apiVersion: broker.arkmq.org/v1beta2
+kind: Broker
 metadata:
   name: ex-aao
 spec:
@@ -941,8 +942,8 @@ stringData:
 ```
 
 ```yaml
-apiVersion: broker.amq.io/v1beta1
-kind: ActiveMQArtemis
+apiVersion: broker.arkmq.org/v1beta2
+kind: Broker
 metadata:
   name: ex-aao
 spec:
@@ -983,8 +984,8 @@ stringData:
 and add the above secrets to extraMounts in the CR:
 
 ```yaml
-apiVersion: broker.amq.io/v1beta1
-kind: ActiveMQArtemis
+apiVersion: broker.arkmq.org/v1beta2
+kind: Broker
 metadata:
   name: ex-aao
 spec:
@@ -1013,8 +1014,8 @@ Then you need to give the name of the configmap or secret in the broker custom r
 
 `for configmap`
 ```yaml
-apiVersion: broker.amq.io/v1beta1
-kind: ActiveMQArtemis
+apiVersion: broker.arkmq.org/v1beta2
+kind: Broker
 metadata:
   name: broker
   namespace: arkmq-org-broker-operator
@@ -1028,8 +1029,8 @@ spec:
 ```
 `for secret`
 ```yaml
-apiVersion: broker.amq.io/v1beta1
-kind: ActiveMQArtemis
+apiVersion: broker.arkmq.org/v1beta2
+kind: Broker
 metadata:
   name: broker
   namespace: arkmq-org-broker-operator
@@ -1141,8 +1142,8 @@ To instruct the Operator to enable metrics for each broker Pod in a deployment, 
 In addition, you need to expose the console, for example
 
 ```yaml
-apiVersion: broker.amq.io/v1beta1
-kind: ActiveMQArtemis
+apiVersion: broker.arkmq.org/v1beta2
+kind: Broker
 metadata:
   name: artemis-with-metrics
 spec:
@@ -1157,8 +1158,8 @@ spec:
 JVM memory metrics are enabled by default. Use the `spec.brokerProperties` field to enable JVM GC and threads metrics, for further details see the following example:
 
 ```yaml
-apiVersion: broker.amq.io/v1beta1
-kind: ActiveMQArtemis
+apiVersion: broker.arkmq.org/v1beta2
+kind: Broker
 metadata:
   name: artemis-with-metrics
 spec:
@@ -1320,15 +1321,15 @@ The memory limit should be set high enough to accommodate the operator's working
 
 ## Configuring PodDisruptionBudget for broker deployment
 
-The ActiveMQArtemis custom resource offers a PodDisruptionBudget option
+The Broker custom resource offers a PodDisruptionBudget option
 for the broker pods deployed by the operator. When it is specified the operator
 will deploy a PodDisruptionBudget for the broker deployment.
 
 For example
 
 ```yaml
-apiVersion: broker.amq.io/v1beta1
-kind: ActiveMQArtemis
+apiVersion: broker.arkmq.org/v1beta2
+kind: Broker
 metadata:
   name: broker
   namespace: arkmq-org-broker-operator
@@ -1346,15 +1347,15 @@ so that the PodDisruptionBudget matches the broker StatefulSet.
 
 ## Configuring TopologySpreadConstraints for broker deployment
 
-The ActiveMQArtemis custom resource offers a TopologySpreadConstraints option
+The Broker custom resource offers a TopologySpreadConstraints option
 for the broker pods deployed by the operator. When it is specified the operator
 will deploy a TopologySpreadConstraints for the broker deployment.
 
 For example
 
 ```yaml
-apiVersion: broker.amq.io/v1beta1
-kind: ActiveMQArtemis
+apiVersion: broker.arkmq.org/v1beta2
+kind: Broker
 metadata:
   name: broker
   namespace: arkmq-org-broker-operator
@@ -1376,11 +1377,11 @@ When deploying the above custom resource the operator will spread matching pods 
 
 ## Container SecurityContext
 
-The ActiveMQArtemis custom resource offers a container level SecurityContext option for the broker that holds security configuration that will be applied to the containers.
+The Broker custom resource offers a container level SecurityContext option for the broker that holds security configuration that will be applied to the containers.
 
 ```yaml
-apiVersion: broker.amq.io/v1beta1
-kind: ActiveMQArtemis
+apiVersion: broker.arkmq.org/v1beta2
+kind: Broker
 metadata:
   name: broker
   namespace: arkmq-org-broker-operator
@@ -1404,8 +1405,8 @@ Additionally, environment variables `APPLICATION_NAME` and `PING_SVC_NAME` must 
 Here's an example configuration:
 
 ```yaml
-apiVersion: broker.amq.io/v1beta1
-kind: ActiveMQArtemis
+apiVersion: broker.arkmq.org/v1beta2
+kind: Broker
 metadata:
   name: broker
   namespace: arkmq-org-broker-operator
@@ -1484,8 +1485,8 @@ The above adminUser and adminPassword may be overridden and jolokia client in th
 For example when you have a broker cr named **amq** like this:
 
 ```yaml
-apiVersion: broker.amq.io/v1beta1
-kind: ActiveMQArtemis
+apiVersion: broker.arkmq.org/v1beta2
+kind: Broker
 metadata:
   name: amq
   namespace: default
@@ -1530,8 +1531,8 @@ spec:
 You can configure a broker CR to use it:
 
 ```yaml
-apiVersion: broker.amq.io/v1beta1
-kind: ActiveMQArtemis
+apiVersion: broker.arkmq.org/v1beta2
+kind: Broker
 metadata:
   name: artemis-broker
 spec:
@@ -1556,8 +1557,8 @@ For example if you configure to attach a PersistentVolumeClaim type volume calle
 The operator also supports configuration for each of the brokers of a custom resource to have a separate persistent volume. To do this you need to configure the CR using **spec.extraVolumeClaimTemplates** in your CR. For example:
 
 ```yaml
-apiVersion: broker.amq.io/v1beta1
-kind: ActiveMQArtemis
+apiVersion: broker.arkmq.org/v1beta2
+kind: Broker
 metadata:
   name: artemis-broker
 spec:
@@ -1683,8 +1684,8 @@ spec:
 Once you have the certificate and ca bundle ready you can configure the management console of the broker to used it:
 
 ```yaml
-apiVersion: broker.amq.io/v1beta1
-kind: ActiveMQArtemis
+apiVersion: broker.arkmq.org/v1beta2
+kind: Broker
 metadata:
   name: artemis-broker
 spec:
@@ -1704,8 +1705,8 @@ The above broker cr configures a broker that has a SSL/TLS secured management co
 With the certificate ready you can configure an acceptor and/or connector of the broker to use it:
 
 ```yaml
-apiVersion: broker.amq.io/v1beta1
-kind: ActiveMQArtemis
+apiVersion: broker.arkmq.org/v1beta2
+kind: Broker
 metadata:
   name: artemis-broker
 spec:
@@ -1727,8 +1728,8 @@ The above broker cr configures a broker that has a SSL/TLS secured acceptor call
 You can configure a connector with ssl parameters from a certificate in like manner, for example the following yaml configures a connector called `new-connector` with the certificated above mentioned:
 
 ```yaml
-apiVersion: broker.amq.io/v1beta1
-kind: ActiveMQArtemis
+apiVersion: broker.arkmq.org/v1beta2
+kind: Broker
 metadata:
   name: artemis-broker
 spec:
@@ -1750,7 +1751,7 @@ For details on how to use cert-manager to manage your certificates please refer 
 ### Secure cluster connections
 The internal cluster connections rely on the internal acceptor listening on the port `61616` and the internal connector with the name `artemis`. They can be secured with the following steps, create a secret with the secure stores, enable ssl in the internal acceptor by using the acceptor fields `sslEnabled` and `sslSecret`, and enable ssl in the internal connector by using broker properties
 
-The server certificate included in the secure stores must include a wildcard DNS name for the internal broker instances in the `Subject Alternative Name`, i.e. for an ActiveMQArtemis CR with name `ex-aao` deployed in the namespace `test` a key and trust store with a self -signed certificate could be generated with the following commands:
+The server certificate included in the secure stores must include a wildcard DNS name for the internal broker instances in the `Subject Alternative Name`, i.e. for a Broker CR with name `ex-aao` deployed in the namespace `test` a key and trust store with a self -signed certificate could be generated with the following commands:
 ```
 keytool -storetype jks -keystore server-keystore.jks -storepass artemis -keypass artemis -alias server -genkey -keyalg "RSA" -keysize 2048 -dname "CN=ActiveMQ Artemis Server, OU=Artemis, O=ActiveMQ, L=AMQ, S=AMQ, C=AMQ" -validity 365 -ext bc=ca:false -ext eku=sA -ext san=dns:*.ex-aao-hdls-svc.test.svc.cluster.local
 
@@ -1780,8 +1781,8 @@ kubectl create secret generic artemis-ssl-secret --namespace test \
 An Apache Artemis Broker instance with a secured internal acceptor and connector can be deployed by using the following command:
 ```
 kubectl apply -f - <<EOF
-apiVersion: broker.amq.io/v1beta1
-kind: ActiveMQArtemis
+apiVersion: broker.arkmq.org/v1beta2
+kind: Broker
 metadata:
   name: ex-aao
   namespace: test

--- a/docs/tutorials/cert-manager-and-trust-manager.md
+++ b/docs/tutorials/cert-manager-and-trust-manager.md
@@ -225,7 +225,7 @@ Replace **myproject** with actual namespace your brokers are installed in.
 Deploy a broker with (beeing on the root folder of this repository):
 
 ```shell
-kubectl apply -f examples/artemis/artemis_ssl_acceptor_cert_and_trust_managers.yaml -n myproject
+kubectl apply -f examples/broker/broker_ssl_acceptor_cert_and_trust_managers.yaml -n myproject
 ```
 
 ## Deploy a queue

--- a/docs/tutorials/external_mqtt_clients.md
+++ b/docs/tutorials/external_mqtt_clients.md
@@ -48,12 +48,12 @@ $ kubectl create secret generic my-tls-secret \
 --from-literal=trustStorePassword=securepass
 ```
 
-### Deploy ActiveMQArtemis with an mqtt acceptor
-Use the following command to deploy ActiveMQArtemis with an mqtt acceptor:
+### Deploy Broker with an mqtt acceptor
+Use the following command to deploy Broker with an mqtt acceptor:
 ```shell script
 $ kubectl apply -f - <<EOF
-apiVersion: broker.amq.io/v1beta1
-kind: ActiveMQArtemis
+apiVersion: broker.arkmq.org/v1beta2
+kind: Broker
 metadata:
   name: artemis-mqtt-ssl
 spec:

--- a/docs/tutorials/initcontainer.md
+++ b/docs/tutorials/initcontainer.md
@@ -72,8 +72,8 @@ After the `post-config.sh` script is executed, the broker instance is launched w
 3. When you have added the image to a repository, you need to configure the Operator to use the custom Init Container image. To do this, edit the CR file. For the `image` property, specify the custom image. For example:
 
     ```yaml
-    apiVersion: broker.amq.io/v2alpha4
-    kind: ActiveMQArtemis
+    apiVersion: broker.arkmq.org/v1beta2
+    kind: Broker
     metadata:
         name: ex-aao
         spec:

--- a/docs/tutorials/prometheus_locked_down.md
+++ b/docs/tutorials/prometheus_locked_down.md
@@ -193,7 +193,7 @@ The locked-down broker uses certificate-based authentication. This tutorial uses
     * Override via env: `BASE_PROMETHEUS_CERT_SECRET_NAME` (affects both
       CR-specific and shared secret names)
     * Example: If env is set to `custom-prometheus`, checks
-      `my-broker-custom-prometheus` then `custom-prometheus`
+      `artemis-broker-custom-prometheus` then `custom-prometheus`
     * CN in this tutorial: `prometheus` (gets metrics access)
 
 ## Prerequisites
@@ -313,7 +313,7 @@ Deploying operator to watch single namespace
 Client Version: 4.18.5
 Kustomize Version: v5.4.2
 Kubernetes Version: v1.33.1
-customresourcedefinition.apiextensions.k8s.io/activemqartemises.broker.amq.io created
+customresourcedefinition.apiextensions.k8s.io/brokers.broker.arkmq.org created
 customresourcedefinition.apiextensions.k8s.io/activemqartemisaddresses.broker.amq.io created
 customresourcedefinition.apiextensions.k8s.io/activemqartemisscaledowns.broker.amq.io created
 customresourcedefinition.apiextensions.k8s.io/activemqartemissecurities.broker.amq.io created
@@ -773,7 +773,7 @@ EOF
 secret/artemis-broker-jaas-config-bp created
 ```
 
-Now, deploy the `ActiveMQArtemis` custom resource with `spec.restricted: true`,
+Now, deploy the `Broker` custom resource with `spec.restricted: true`,
 along with the configuration for the acceptor.
 
 **Key Configuration Elements:**
@@ -787,8 +787,8 @@ For detailed explanation of broker properties, see the [broker configuration doc
 
 ```{"stage":"deploy", "runtime":"bash", "label":"deploy broker cr"}
 kubectl apply -f - <<'EOF'
-apiVersion: broker.amq.io/v1beta1
-kind: ActiveMQArtemis
+apiVersion: broker.arkmq.org/v1beta2
+kind: Broker
 metadata:
   name: artemis-broker
   namespace: locked-down-broker
@@ -824,16 +824,16 @@ spec:
 EOF
 ```
 ```shell markdown_runner
-activemqartemis.broker.amq.io/artemis-broker created
+broker.broker.arkmq.org/artemis-broker created
 ```
 
 Wait for the broker to be ready.
 
 ```{"stage":"deploy"}
-kubectl wait ActiveMQArtemis artemis-broker --for=condition=Ready --namespace=locked-down-broker --timeout=300s
+kubectl wait Broker artemis-broker --for=condition=Ready --namespace=locked-down-broker --timeout=300s
 ```
 ```shell markdown_runner
-activemqartemis.broker.amq.io/artemis-broker condition met
+broker.broker.arkmq.org/artemis-broker condition met
 ```
 
 ## Scrape the broker
@@ -1592,10 +1592,10 @@ queue, and the other will consume them. They are configured to use the
 `messaging-client-cert` to authenticate.
 
 Note that the image version used by the jobs should match the one deployed by
-the operator. We can get it from the `ActiveMQArtemis` CR status.
+the operator. We can get it from the `Broker` CR status.
 
 ```{"stage":"test_setup", "runtime":"bash", "label":"get latest broker version"}
-export BROKER_VERSION=$(kubectl get ActiveMQArtemis artemis-broker --namespace=locked-down-broker -o json | jq .status.version.brokerVersion -r)
+export BROKER_VERSION=$(kubectl get Broker artemis-broker --namespace=locked-down-broker -o json | jq .status.version.brokerVersion -r)
 echo broker version: $BROKER_VERSION
 ```
 ```shell markdown_runner
@@ -1893,7 +1893,7 @@ kubectl top pods -n locked-down-broker
 kubectl get events -n locked-down-broker --sort-by='.lastTimestamp'
 
 # Export configurations for analysis
-kubectl get activemqartemis artemis-broker -n locked-down-broker -o yaml
+kubectl get broker artemis-broker -n locked-down-broker -o yaml
 kubectl get prometheus artemis-prometheus -n locked-down-broker -o yaml
 ```
 

--- a/docs/tutorials/scaleup_and_scaledown.md
+++ b/docs/tutorials/scaleup_and_scaledown.md
@@ -70,7 +70,7 @@ Deploy the operator to the `myproject` namespace:
 ```
 ```shell markdown_runner
 Deploying operator to watch single namespace
-customresourcedefinition.apiextensions.k8s.io/activemqartemises.broker.amq.io created
+customresourcedefinition.apiextensions.k8s.io/brokers.broker.arkmq.org created
 customresourcedefinition.apiextensions.k8s.io/activemqartemisaddresses.broker.amq.io created
 customresourcedefinition.apiextensions.k8s.io/activemqartemisscaledowns.broker.amq.io created
 customresourcedefinition.apiextensions.k8s.io/activemqartemissecurities.broker.amq.io created
@@ -110,8 +110,8 @@ Create it using kubectl:
 
 ```{"stage":"deploy","id":"create_broker","runtime":"bash"}
 kubectl apply -f - -n myproject <<EOF
-apiVersion: broker.amq.io/v1beta1
-kind: ActiveMQArtemis
+apiVersion: broker.arkmq.org/v1beta2
+kind: Broker
 metadata:
   name: ex-aao
 spec:
@@ -127,7 +127,7 @@ spec:
 EOF
 ```
 ```shell markdown_runner
-activemqartemis.broker.amq.io/ex-aao created
+broker.broker.arkmq.org/ex-aao created
 ```
 
 The custom resource tells the operator to deploy one broker pod with **persistenceEnabled: true** and **messageMigration: true**.
@@ -139,10 +139,10 @@ The custom resource tells the operator to deploy one broker pod with **persisten
 Wait for the broker to be ready:
 
 ```{"stage":"deploy","id":"wait_broker"}
-kubectl wait ActiveMQArtemis ex-aao --for=condition=Ready --namespace=myproject --timeout=300s
+kubectl wait Broker ex-aao --for=condition=Ready --namespace=myproject --timeout=300s
 ```
 ```shell markdown_runner
-activemqartemis.broker.amq.io/ex-aao condition met
+broker.broker.arkmq.org/ex-aao condition met
 ```
 
 Check the pods:
@@ -161,19 +161,19 @@ ex-aao-ss-0                                           1/1     Running   0       
 In this step we will scale the broker pods from one to two 
 
 ```{"stage":"scale_up","id":"scale_to_2"}
-kubectl patch activemqartemis ex-aao -n myproject --type='json' -p='[{"op": "replace", "path": "/spec/deploymentPlan/size", "value": 2}]'
+kubectl patch broker ex-aao -n myproject --type='json' -p='[{"op": "replace", "path": "/spec/deploymentPlan/size", "value": 2}]'
 ```
 ```shell markdown_runner
-activemqartemis.broker.amq.io/ex-aao patched
+broker.broker.arkmq.org/ex-aao patched
 ```
 
 Wait for the scale up to complete:
 
 ```{"stage":"scale_up","id":"wait_scale_up"}
-kubectl wait ActiveMQArtemis ex-aao --for=condition=Ready --namespace=myproject --timeout=300s
+kubectl wait Broker ex-aao --for=condition=Ready --namespace=myproject --timeout=300s
 ```
 ```shell markdown_runner
-activemqartemis.broker.amq.io/ex-aao condition met
+broker.broker.arkmq.org/ex-aao condition met
 ```
 
 Check the pods:
@@ -231,19 +231,19 @@ When a broker pod is scaled down, the operator waits for it to forward all messa
 Now scale down the cluster from two pods to one
 
 ```{"stage":"scale_down","id":"scale_to_1"}
-kubectl patch activemqartemis ex-aao -n myproject --type='json' -p='[{"op": "replace", "path": "/spec/deploymentPlan/size", "value": 1}]'
+kubectl patch broker ex-aao -n myproject --type='json' -p='[{"op": "replace", "path": "/spec/deploymentPlan/size", "value": 1}]'
 ```
 ```shell markdown_runner
-activemqartemis.broker.amq.io/ex-aao patched
+broker.broker.arkmq.org/ex-aao patched
 ```
 
 Wait for the scale down and message migration to complete:
 
 ```{"stage":"scale_down","id":"wait_scale_down"}
-kubectl wait ActiveMQArtemis ex-aao --for=condition=Ready --namespace=myproject --timeout=300s
+kubectl wait Broker ex-aao --for=condition=Ready --namespace=myproject --timeout=300s
 ```
 ```shell markdown_runner
-activemqartemis.broker.amq.io/ex-aao condition met
+broker.broker.arkmq.org/ex-aao condition met
 ```
 
 Check the pods:

--- a/docs/tutorials/send_receive_ingress.md
+++ b/docs/tutorials/send_receive_ingress.md
@@ -207,8 +207,8 @@ export CERT_FOLDER=$(pwd)
 
 ```{"stage":"deploy", "runtime":"bash", "label":"deploy the broker"}
 kubectl apply -f - << EOF
-apiVersion: broker.amq.io/v1beta1
-kind: ActiveMQArtemis
+apiVersion: broker.arkmq.org/v1beta2
+kind: Broker
 metadata:
   name: send-receive
   namespace: send-receive-project
@@ -227,16 +227,16 @@ spec:
 EOF
 ```
 ```shell markdown_runner
-activemqartemis.broker.amq.io/send-receive created
+broker.broker.arkmq.org/send-receive created
 ```
 
 Wait for the Broker to be ready:
 
 ```{"stage":"deploy"}
-kubectl wait ActiveMQArtemis send-receive --for=condition=Ready --namespace=send-receive-project --timeout=240s
+kubectl wait Broker send-receive --for=condition=Ready --namespace=send-receive-project --timeout=240s
 ```
 ```shell markdown_runner
-activemqartemis.broker.amq.io/send-receive condition met
+broker.broker.arkmq.org/send-receive condition met
 ```
 
 #### Create a route to access the ingress:
@@ -256,7 +256,7 @@ send-receive-sslacceptor-0-svc-ing   nginx   send-receive-sslacceptor-0-svc-ing-
 #### Get the actual broker version
 
 ```{"stage":"test_setup", "runtime":"bash", "label":"get latest broker version"}
-export BROKER_VERSION=$(kubectl get ActiveMQArtemis send-receive --namespace=send-receive-project -o json | jq .status.version.brokerVersion -r)
+export BROKER_VERSION=$(kubectl get Broker send-receive --namespace=send-receive-project -o json | jq .status.version.brokerVersion -r)
 echo broker version: $BROKER_VERSION
 ```
 ```shell markdown_runner

--- a/docs/tutorials/send_receive_ingress_pem.md
+++ b/docs/tutorials/send_receive_ingress_pem.md
@@ -327,8 +327,8 @@ Get minikube's ip
 ```bash {"stage":"deploy", "runtime":"bash", "label":"deploy the broker"}
 INGRESS_HOST='ing.$(ITEM_NAME).$(CR_NAME)-$(BROKER_ORDINAL).$(CR_NAMESPACE).$(INGRESS_DOMAIN)'
 cat <<EOF > deploy.yml
-apiVersion: broker.amq.io/v1beta1
-kind: ActiveMQArtemis
+apiVersion: broker.arkmq.org/v1beta2
+kind: Broker
 metadata:
   name: send-receive
   namespace: send-receive-project
@@ -363,16 +363,16 @@ EOF
 kubectl apply -f deploy.yml
 ```
 ```shell markdown_runner
-activemqartemis.broker.amq.io/send-receive created
+broker.broker.arkmq.org/send-receive created
 ```
 
 Wait for the Broker to be ready:
 
 ```{"stage":"deploy"}
-kubectl wait ActiveMQArtemis send-receive --for=condition=Ready --namespace=send-receive-project --timeout=240s
+kubectl wait Broker send-receive --for=condition=Ready --namespace=send-receive-project --timeout=240s
 ```
 ```shell markdown_runner
-activemqartemis.broker.amq.io/send-receive condition met
+broker.broker.arkmq.org/send-receive condition met
 ```
 
 Check that the ingress is available and has an IP address:
@@ -402,7 +402,7 @@ open a working connection:
 #### Get the actual broker version
 
 ```{"stage":"test_setup", "runtime":"bash", "label":"get latest broker version"}
-export BROKER_VERSION=$(kubectl get ActiveMQArtemis send-receive --namespace=send-receive-project -o json | jq .status.version.brokerVersion -r)
+export BROKER_VERSION=$(kubectl get Broker send-receive --namespace=send-receive-project -o json | jq .status.version.brokerVersion -r)
 echo broker version: $BROKER_VERSION
 ```
 ```shell markdown_runner

--- a/docs/tutorials/send_receive_port_forwarding.md
+++ b/docs/tutorials/send_receive_port_forwarding.md
@@ -99,8 +99,8 @@ For this tutorial we need to:
 
 ```bash {"stage":"deploy", "runtime":"bash", "label":"deploy the broker"}
 kubectl apply -f - <<EOF
-apiVersion: broker.amq.io/v1beta1
-kind: ActiveMQArtemis
+apiVersion: broker.arkmq.org/v1beta2
+kind: Broker
 metadata:
   name: send-receive
   namespace: send-receive-project
@@ -116,16 +116,16 @@ spec:
 EOF
 ```
 ```shell markdown_runner
-activemqartemis.broker.amq.io/send-receive created
+broker.broker.arkmq.org/send-receive created
 ```
 
 Wait for the Broker to be ready:
 
 ```{"stage":"deploy"}
-kubectl wait ActiveMQArtemis send-receive --for=condition=Ready --namespace=send-receive-project --timeout=240s
+kubectl wait Broker send-receive --for=condition=Ready --namespace=send-receive-project --timeout=240s
 ```
 ```shell markdown_runner
-activemqartemis.broker.amq.io/send-receive condition met
+broker.broker.arkmq.org/send-receive condition met
 ```
 
 
@@ -134,7 +134,7 @@ activemqartemis.broker.amq.io/send-receive condition met
 #### Get the actual broker version
 
 ```{"stage":"test_setup", "runtime":"bash", "label":"get latest broker version"}
-export BROKER_VERSION=$(kubectl get ActiveMQArtemis send-receive --namespace=send-receive-project -o json | jq .status.version.brokerVersion -r)
+export BROKER_VERSION=$(kubectl get Broker send-receive --namespace=send-receive-project -o json | jq .status.version.brokerVersion -r)
 echo broker version: $BROKER_VERSION
 ```
 ```shell markdown_runner

--- a/docs/tutorials/ssl_broker_setup.md
+++ b/docs/tutorials/ssl_broker_setup.md
@@ -141,8 +141,8 @@ The **sslEnabled: true** tells the operator to make this acceptor to use SSL tra
 
 ```{"stage":"deploy", "runtime":"bash", "label":"deploy the broker"}
 kubectl apply -f - << EOF
-apiVersion: broker.amq.io/v1beta1
-kind: ActiveMQArtemis
+apiVersion: broker.arkmq.org/v1beta2
+kind: Broker
 metadata:
   name: ex-aao
 spec:
@@ -154,16 +154,16 @@ spec:
 EOF
 ```
 ```shell markdown_runner
-activemqartemis.broker.amq.io/ex-aao created
+broker.broker.arkmq.org/ex-aao created
 ```
 
 Wait for the Broker to be ready:
 
 ```{"stage":"deploy"}
-kubectl wait ActiveMQArtemis ex-aao --for=condition=Ready --namespace=ssl-broker-project --timeout=240s
+kubectl wait Broker ex-aao --for=condition=Ready --namespace=ssl-broker-project --timeout=240s
 ```
 ```shell markdown_runner
-activemqartemis.broker.amq.io/ex-aao condition met
+broker.broker.arkmq.org/ex-aao condition met
 ```
 
 ### Test messaging over a SSL connection

--- a/docs/tutorials/vault_broker_properties.md
+++ b/docs/tutorials/vault_broker_properties.md
@@ -83,7 +83,7 @@ customresourcedefinition.apiextensions.k8s.io/activemqartemises.broker.amq.io cr
 customresourcedefinition.apiextensions.k8s.io/activemqartemisaddresses.broker.amq.io created
 customresourcedefinition.apiextensions.k8s.io/activemqartemisscaledowns.broker.amq.io created
 customresourcedefinition.apiextensions.k8s.io/activemqartemissecurities.broker.amq.io created
-customresourcedefinition.apiextensions.k8s.io/brokers.arkmq.org created
+customresourcedefinition.apiextensions.k8s.io/brokers.broker.arkmq.org created
 serviceaccount/arkmq-org-broker-controller-manager created
 role.rbac.authorization.k8s.io/arkmq-org-broker-operator-role created
 rolebinding.rbac.authorization.k8s.io/arkmq-org-broker-operator-rolebinding created
@@ -254,8 +254,8 @@ Create the broker CR with Vault Agent Injector annotations. The template constru
 
 ```{"stage":"agent-injector", "runtime":"bash", "label":"deploy hashicorp broker"}
 kubectl apply -f - << EOF
-apiVersion: broker.amq.io/v1beta1
-kind: ActiveMQArtemis
+apiVersion: broker.arkmq.org/v1beta2
+kind: Broker
 metadata:
   name: hashicorp-broker
 spec:
@@ -278,16 +278,16 @@ spec:
 EOF
 ```
 ```shell markdown_runner
-activemqartemis.broker.amq.io/hashicorp-broker created
+broker.broker.arkmq.org/hashicorp-broker created
 ```
 
 Wait for the broker to be ready:
 
 ```{"stage":"agent-injector", "label":"wait for hashicorp broker"}
-kubectl wait ActiveMQArtemis hashicorp-broker --for=condition=Ready --namespace=vault-broker-project --timeout=300s
+kubectl wait Broker hashicorp-broker --for=condition=Ready --namespace=vault-broker-project --timeout=300s
 ```
 ```shell markdown_runner
-activemqartemis.broker.amq.io/hashicorp-broker condition met
+broker.broker.arkmq.org/hashicorp-broker condition met
 ```
 
 ### Verify Vault Agent Injector worked
@@ -412,8 +412,8 @@ Create the broker CR with an environment variable that gets injected from Vault.
 
 ```{"stage":"banzai", "runtime":"bash", "label":"deploy banzai broker"}
 kubectl apply -f - << EOF
-apiVersion: broker.amq.io/v1beta1
-kind: ActiveMQArtemis
+apiVersion: broker.arkmq.org/v1beta2
+kind: Broker
 metadata:
   name: banzai-broker
 spec:
@@ -432,16 +432,16 @@ spec:
 EOF
 ```
 ```shell markdown_runner
-activemqartemis.broker.amq.io/banzai-broker created
+broker.broker.arkmq.org/banzai-broker created
 ```
 
 Wait for the broker to be ready:
 
 ```{"stage":"banzai", "label":"wait for banzai broker"}
-kubectl wait ActiveMQArtemis banzai-broker --for=condition=Ready --namespace=vault-broker-project --timeout=300s
+kubectl wait Broker banzai-broker --for=condition=Ready --namespace=vault-broker-project --timeout=300s
 ```
 ```shell markdown_runner
-activemqartemis.broker.amq.io/banzai-broker condition met
+broker.broker.arkmq.org/banzai-broker condition met
 ```
 
 ### Verify Secret Injection Webhook worked
@@ -526,7 +526,7 @@ This tutorial demonstrates two approaches for injecting the **same Vault secret*
 
 1. **Vault Storage**: Same address name at `secret/data/broker` (`addressName=VAULT-TEST`)
 2. **Vault Auth**: Webhook uses `vault-broker-sa` service account with Kubernetes auth (same as HashiCorp approach)
-3. **Environment Variable**: ActiveMQArtemis CR defines `VAULT_ADDRESS_NAME` env var with `vault:secret/data/broker#addressName` reference
+3. **Environment Variable**: Broker CR defines `VAULT_ADDRESS_NAME` env var with `vault:secret/data/broker#addressName` reference
 4. **Banzai Webhook**: Mutating webhook intercepts pod creation, authenticates to Vault using Kubernetes auth, replaces `vault:` reference in env var with actual value `VAULT-TEST`
 5. **Kubernetes Secret**: Broker properties use `${VAULT_ADDRESS_NAME}` placeholder
 6. **ArkMQ Operator**: Mounts the secret via `extraMounts.secrets`

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,13 +2,13 @@
 
 This directory contains example YAML files to create and configure an Artemis broker on Kubernetes.
 
-If you are new to Artemis on Kubernetes, start with [a basic deployment](artemis/artemis_single.yaml):
+If you are new to Artemis on Kubernetes, start with [a basic deployment](broker/broker_single.yaml):
 
 1. Deploy the operator as described in the [Operator help](../docs/help/operator#deploy-the-operator).
 2. Create a basic broker deployment:
 
 ```bash
-kubectl create -f examples/artemis/artemis_single.yaml -n <namespace>
+kubectl create -f examples/broker/broker_single.yaml -n <namespace>
 ```
 
 See https://arkmq.org/ for tutorials and more information about Artemis.

--- a/examples/address/broker_properties_address.yaml
+++ b/examples/address/broker_properties_address.yaml
@@ -1,7 +1,7 @@
-apiVersion: broker.amq.io/v1beta1
-kind: ActiveMQArtemis
+apiVersion: broker.arkmq.org/v1beta2
+kind: Broker
 metadata:
-  name: artemis-broker-props-address
+  name: my-broker-props-address
 spec:
   brokerProperties:
    - "# anycast, consumers compete"

--- a/examples/artemis/artemis_single.yaml
+++ b/examples/artemis/artemis_single.yaml
@@ -1,4 +1,0 @@
-apiVersion: broker.amq.io/v1beta1
-kind: ActiveMQArtemis
-metadata:
-  name: artemis-broker

--- a/examples/broker/broker_address_settings.yaml
+++ b/examples/broker/broker_address_settings.yaml
@@ -1,7 +1,7 @@
-apiVersion: broker.amq.io/v1beta1
-kind: ActiveMQArtemis
+apiVersion: broker.arkmq.org/v1beta2
+kind: Broker
 metadata:
-  name: artemis-broker
+  name: my-broker
 spec:
   addressSettings:
     applyRule: merge_all # merge_replace| replace_all | See documentation for details

--- a/examples/broker/broker_broker_properties_json.yaml
+++ b/examples/broker/broker_broker_properties_json.yaml
@@ -1,7 +1,7 @@
-apiVersion: broker.amq.io/v1beta1
-kind: ActiveMQArtemis
+apiVersion: broker.arkmq.org/v1beta2
+kind: Broker
 metadata:
-  name: artemis-broker-props-json
+  name: my-broker-props-json
 spec:
   deploymentPlan:
     extraMounts:

--- a/examples/broker/broker_cluster_persistence.yaml
+++ b/examples/broker/broker_cluster_persistence.yaml
@@ -1,7 +1,7 @@
-apiVersion: broker.amq.io/v1beta1
-kind: ActiveMQArtemis
+apiVersion: broker.arkmq.org/v1beta2
+kind: Broker
 metadata:
-  name: artemis-broker
+  name: my-broker
 spec:
   deploymentPlan:
     size: 2

--- a/examples/broker/broker_custom_logging_configmap.yaml
+++ b/examples/broker/broker_custom_logging_configmap.yaml
@@ -1,10 +1,9 @@
-apiVersion: broker.amq.io/v1beta1
-kind: ActiveMQArtemis
+apiVersion: broker.arkmq.org/v1beta2
+kind: Broker
 metadata:
-  name: artemis-broker-logging
+  name: my-broker-logging
 spec:
   deploymentPlan:
     extraMounts:
       configMaps:
         - "newlog4j-logging-config"
-

--- a/examples/broker/broker_custom_logging_secret.yaml
+++ b/examples/broker/broker_custom_logging_secret.yaml
@@ -1,7 +1,7 @@
-apiVersion: broker.amq.io/v1beta1
-kind: ActiveMQArtemis
+apiVersion: broker.arkmq.org/v1beta2
+kind: Broker
 metadata:
-  name: artemis-broker-logging
+  name: my-broker-logging
 spec:
   deploymentPlan:
     extraMounts:

--- a/examples/broker/broker_enable_metrics_plugin.yaml
+++ b/examples/broker/broker_enable_metrics_plugin.yaml
@@ -1,7 +1,7 @@
-apiVersion: broker.amq.io/v1beta1
-kind: ActiveMQArtemis
+apiVersion: broker.arkmq.org/v1beta2
+kind: Broker
 metadata:
-  name: artemis-broker
+  name: my-broker
 spec:
   deploymentPlan:
     enableMetricsPlugin: true

--- a/examples/broker/broker_metrics_monitor.yaml
+++ b/examples/broker/broker_metrics_monitor.yaml
@@ -1,5 +1,5 @@
-apiVersion: broker.amq.io/v1beta1
-kind: ActiveMQArtemis
+apiVersion: broker.arkmq.org/v1beta2
+kind: Broker
 metadata:
   name: artemis-with-metrics
 spec:

--- a/examples/broker/broker_resources.yaml
+++ b/examples/broker/broker_resources.yaml
@@ -1,7 +1,7 @@
-apiVersion: broker.amq.io/v1beta1
-kind: ActiveMQArtemis
+apiVersion: broker.arkmq.org/v1beta2
+kind: Broker
 metadata:
-  name: artemis-broker-resources
+  name: my-broker-resources
 spec:
   deploymentPlan:
     resources:

--- a/examples/broker/broker_ssl_acceptor_cert_and_trust_managers.yaml
+++ b/examples/broker/broker_ssl_acceptor_cert_and_trust_managers.yaml
@@ -1,7 +1,7 @@
-apiVersion: broker.amq.io/v1beta1
-kind: ActiveMQArtemis
+apiVersion: broker.arkmq.org/v1beta2
+kind: Broker
 metadata:
-  name: artemis-broker
+  name: my-broker
 spec:
   acceptors:
   - name: ssl

--- a/examples/broker/broker_template.yaml
+++ b/examples/broker/broker_template.yaml
@@ -1,7 +1,7 @@
-apiVersion: broker.amq.io/v1beta1
-kind: ActiveMQArtemis
+apiVersion: broker.arkmq.org/v1beta2
+kind: Broker
 metadata:
-  name: artemis-broker-template
+  name: my-broker-template
 spec:
   resourceTemplates:
   - selector:
@@ -14,6 +14,6 @@ spec:
       template:
        spec:
         containers:
-        - name: "artemis-broker-template-container"
+        - name: "my-broker-template-container"
           securityContext:
            runAsNonRoot: true

--- a/helm-charts/arkmq-org-broker-operator/templates/crds.yaml
+++ b/helm-charts/arkmq-org-broker-operator/templates/crds.yaml
@@ -28,6 +28,8 @@ spec:
           jsonPath: .metadata.creationTimestamp
           name: Age
           type: date
+      deprecated: true
+      deprecationWarning: The ActiveMQArtemis CRD (activemqartemises.broker.amq.io) is deprecated. Use the Broker CRD (brokers.broker.arkmq.org) instead by updating apiVersion to broker.arkmq.org/v1beta2 and kind to Broker. The spec is compatible.
       name: v1beta1
       schema:
         openAPIV3Schema:


### PR DESCRIPTION
- Deprecated ActiveMQArtemis CRD (`activemqartemises.broker.amq.io`) in favour of Broker CRD (`brokers.broker.arkmq.org`).

Fixes: [issue#1329](https://github.com/arkmq-org/activemq-artemis-operator/issues/1329)