### PR TITLE
[#1391] Update apiVersion group name with 'broker' prefix in Broker, BrokerApp, and BrokerService docs and examples

### DIFF
--- a/config/crs/broker_broker_cr.yaml
+++ b/config/crs/broker_broker_cr.yaml
@@ -1,4 +1,4 @@
-apiVersion: arkmq.org/v1beta2
+apiVersion: broker.arkmq.org/v1beta2
 kind: Broker
 metadata:
   name: ex-broker

--- a/controllers/broker_controller.go
+++ b/controllers/broker_controller.go
@@ -40,7 +40,7 @@ import (
 	"github.com/arkmq-org/activemq-artemis-operator/pkg/utils/common"
 )
 
-// BrokerReconciler reconciles a Broker object (arkmq.org/v1beta2)
+// BrokerReconciler reconciles a Broker object (broker.arkmq.org/v1beta2)
 type BrokerReconciler struct {
 	rtclient.Client
 	Scheme        *runtime.Scheme

--- a/docs/examples/brokerservice-appselector.yaml
+++ b/docs/examples/brokerservice-appselector.yaml
@@ -11,7 +11,7 @@
 
 ---
 # Default - Same namespace only (secure by default)
-apiVersion: arkmq.org/v1beta2
+apiVersion: broker.arkmq.org/v1beta2
 kind: BrokerService
 metadata:
   name: isolated-broker
@@ -22,7 +22,7 @@ spec:
   # Equivalent to: appSelectorExpression: "app.metadata.namespace == service.metadata.namespace"
   image: quay.io/artemiscloud/activemq-artemis-broker-kubernetes:latest
 ---
-apiVersion: arkmq.org/v1beta2
+apiVersion: broker.arkmq.org/v1beta2
 kind: BrokerApp
 metadata:
   name: app-same-ns
@@ -33,7 +33,7 @@ spec:
 
 ---
 # Open access - Allow all namespaces
-apiVersion: arkmq.org/v1beta2
+apiVersion: broker.arkmq.org/v1beta2
 kind: BrokerService
 metadata:
   name: dev-broker
@@ -44,7 +44,7 @@ spec:
   appSelectorExpression: "true"  # Allow all namespaces
   image: quay.io/artemiscloud/activemq-artemis-broker-kubernetes:latest
 ---
-apiVersion: arkmq.org/v1beta2
+apiVersion: broker.arkmq.org/v1beta2
 kind: BrokerApp
 metadata:
   name: app1
@@ -56,7 +56,7 @@ spec:
   acceptor:
     port: 61616
 ---
-apiVersion: arkmq.org/v1beta2
+apiVersion: broker.arkmq.org/v1beta2
 kind: BrokerApp
 metadata:
   name: app2
@@ -70,7 +70,7 @@ spec:
 
 ---
 # Namespace pattern matching
-apiVersion: arkmq.org/v1beta2
+apiVersion: broker.arkmq.org/v1beta2
 kind: BrokerService
 metadata:
   name: prod-broker
@@ -83,7 +83,7 @@ spec:
     (app.metadata.namespace.endsWith("-prod") || app.metadata.namespace.endsWith("-staging"))
   image: quay.io/artemiscloud/activemq-artemis-broker-kubernetes:latest
 ---
-apiVersion: arkmq.org/v1beta2
+apiVersion: broker.arkmq.org/v1beta2
 kind: BrokerApp
 metadata:
   name: payment-service
@@ -95,7 +95,7 @@ spec:
   acceptor:
     port: 61616
 ---
-apiVersion: arkmq.org/v1beta2
+apiVersion: broker.arkmq.org/v1beta2
 kind: BrokerApp
 metadata:
   name: test-service
@@ -107,7 +107,7 @@ spec:
   acceptor:
     port: 61617
 ---
-apiVersion: arkmq.org/v1beta2
+apiVersion: broker.arkmq.org/v1beta2
 kind: BrokerApp
 metadata:
   name: dev-app
@@ -121,7 +121,7 @@ spec:
 
 ---
 # App label-based selection
-apiVersion: arkmq.org/v1beta2
+apiVersion: broker.arkmq.org/v1beta2
 kind: BrokerService
 metadata:
   name: premium-broker
@@ -132,7 +132,7 @@ spec:
     app.metadata.labels["tier"] == "premium"
   image: quay.io/artemiscloud/activemq-artemis-broker-kubernetes:latest
 ---
-apiVersion: arkmq.org/v1beta2
+apiVersion: broker.arkmq.org/v1beta2
 kind: BrokerApp
 metadata:
   name: premium-app
@@ -143,7 +143,7 @@ spec:
   acceptor:
     port: 61616
 ---
-apiVersion: arkmq.org/v1beta2
+apiVersion: broker.arkmq.org/v1beta2
 kind: BrokerApp
 metadata:
   name: standard-app
@@ -156,7 +156,7 @@ spec:
 
 ---
 # Namespace label-based selection
-apiVersion: arkmq.org/v1beta2
+apiVersion: broker.arkmq.org/v1beta2
 kind: BrokerService
 metadata:
   name: environment-broker
@@ -172,7 +172,7 @@ spec:
 
 ---
 # Team-based multi-tenancy
-apiVersion: arkmq.org/v1beta2
+apiVersion: broker.arkmq.org/v1beta2
 kind: BrokerService
 metadata:
   name: team-broker

--- a/docs/help/brokerservice-appselector.md
+++ b/docs/help/brokerservice-appselector.md
@@ -18,7 +18,7 @@ BrokerService app selector provides flexible access control for BrokerApps using
 The `appSelectorExpression` field in `BrokerServiceSpec` contains a CEL expression that determines whether a BrokerApp can use the service.
 
 ```yaml
-apiVersion: arkmq.org/v1beta2
+apiVersion: broker.arkmq.org/v1beta2
 kind: BrokerService
 metadata:
   name: my-broker

--- a/docs/tutorials/service_app_crd_round_trip.md
+++ b/docs/tutorials/service_app_crd_round_trip.md
@@ -217,7 +217,7 @@ kubectl wait certificate messaging-service-broker-cert -n service-app-project --
 
 ```bash {"stage":"deploy_service", "label":"deploy service crd", "runtime":"bash"}
 kubectl apply -f - <<EOF
-apiVersion: arkmq.org/v1beta2
+apiVersion: broker.arkmq.org/v1beta2
 kind: BrokerService
 metadata:
   name: messaging-service
@@ -262,7 +262,7 @@ EOF
 
 ```bash {"stage":"deploy_app", "label":"deploy app crd", "runtime":"bash"}
 kubectl apply -f - <<EOF
-apiVersion: arkmq.org/v1beta2
+apiVersion: broker.arkmq.org/v1beta2
 kind: BrokerApp
 metadata:
   name: first-app

--- a/examples/broker/broker_single.yaml
+++ b/examples/broker/broker_single.yaml
@@ -1,4 +1,4 @@
-apiVersion: arkmq.org/v1beta2
+apiVersion: broker.arkmq.org/v1beta2
 kind: Broker
 metadata:
   name: my-broker


### PR DESCRIPTION
fixes: [issue#1391](https://github.com/arkmq-org/activemq-artemis-operator/issues/1391)