### PR TITLE
[#1417]  Event-driven broker status via sidecar reconciliation

### DIFF
--- a/bundle/manifests/arkmq-org-broker-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/arkmq-org-broker-operator.clusterserviceversion.yaml
@@ -7289,6 +7289,9 @@ spec:
           - create
           - delete
           - get
+          - list
+          - patch
+          - watch
         - apiGroups:
           - route.openshift.io
           resources:
@@ -7330,7 +7333,7 @@ spec:
   - email: info@arkmq.org
     name: ArkMQ
   maturity: beta
-  minKubeVersion: 1.22.0
+  minKubeVersion: 1.33.0
   provider:
     name: ArkMQ
     url: https://arkmq.org

--- a/config/manifests/bases/arkmq-org-broker-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/arkmq-org-broker-operator.clusterserviceversion.yaml
@@ -7580,7 +7580,7 @@ spec:
   - email: info@arkmq.org
     name: ArkMQ
   maturity: beta
-  minKubeVersion: 1.22.0
+  minKubeVersion: 1.33.0
   provider:
     name: ArkMQ
     url: https://arkmq.org

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -174,6 +174,9 @@ rules:
   - create
   - delete
   - get
+  - list
+  - patch
+  - watch
 - apiGroups:
   - route.openshift.io
   resources:

--- a/controllers/broker_controller.go
+++ b/controllers/broker_controller.go
@@ -5,10 +5,12 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509/pkix"
+	_ "embed"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"maps"
+	"path"
 	"sort"
 
 	"github.com/RHsyseng/operator-utils/pkg/resource/compare"
@@ -39,7 +41,12 @@ import (
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	ctrl "sigs.k8s.io/controller-runtime"
 
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	rtclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/arkmq-org/arkmq-org-broker-operator/v2/pkg/resources/environments"
 	svc "github.com/arkmq-org/arkmq-org-broker-operator/v2/pkg/resources/services"
@@ -50,6 +57,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	routev1 "github.com/openshift/api/route/v1"
@@ -62,6 +70,22 @@ import (
 
 	policyv1 "k8s.io/api/policy/v1"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
+)
+
+//go:embed broker_status_script.sh
+var brokerStatusScript string
+
+const (
+	sidecarSecretSuffix         = "-sidecar"
+	brokerStatusScriptKey       = "broker-status.sh"
+	sidecarContainerName        = "broker-status"
+	log4j2ConfigurationFileFlag = "-Dlog4j2.configurationFile="
+
+	// ReconcileMeAnnotationKey is the Pod annotation the sidecar script writes
+	// when it detects AMQ221007 (server active) or AMQ221087 (config reload
+	// completed). The operator watches for this annotation and triggers a
+	// reconcile + Jolokia status fetch.
+	ReconcileMeAnnotationKey = "broker.arkmq.org/request-reconcile"
 )
 
 // BrokerReconciler reconciles a Broker object (broker.arkmq.org/v1beta2)
@@ -84,6 +108,8 @@ func NewBrokerReconciler(cluster cluster.Cluster, logger logr.Logger, isOpenShif
 //+kubebuilder:rbac:groups=broker.arkmq.org,namespace=arkmq-org-broker-operator,resources=brokers,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=broker.arkmq.org,namespace=arkmq-org-broker-operator,resources=brokers/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=broker.arkmq.org,namespace=arkmq-org-broker-operator,resources=brokers/finalizers,verbs=update
+//+kubebuilder:rbac:groups="",namespace=arkmq-org-broker-operator,resources=pods,verbs=get;list;watch
+//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,namespace=arkmq-org-broker-operator,resources=roles;rolebindings,verbs=create;delete;get;list;patch;watch
 
 func (r *BrokerReconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
 	reqLogger := r.log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name, "Reconciling", "Broker")
@@ -119,9 +145,7 @@ func (r *BrokerReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 		if !reconcileBlocked {
 			err = reconciler.Process(customResource, *namer, r.Client, r.Scheme)
 		}
-		if reconciler.ProcessBrokerStatus(customResource, r.Client, r.Scheme) {
-			requeueRequest = true
-		}
+		reconciler.ProcessBrokerStatus(customResource, r.Client, r.Scheme)
 	}
 
 	brokerstatus.UpdateBlockedStatus(customResource, reconcileBlocked)
@@ -129,11 +153,6 @@ func (r *BrokerReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 
 	crStatusUpdateErr := r.UpdateBrokerCRStatus(customResource, r.Client, namespacedName)
 	if crStatusUpdateErr != nil {
-		requeueRequest = true
-	}
-
-	if !requeueRequest && !reconcileBlocked && hasExtraMountsForBroker(customResource) {
-		reqLogger.V(1).Info("resource has extraMounts, requeuing")
 		requeueRequest = true
 	}
 
@@ -152,18 +171,77 @@ func (r *BrokerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	builder := ctrl.NewControllerManagedBy(mgr).
 		For(&v1beta2.Broker{}).
 		Owns(&appsv1.StatefulSet{}).
-		Owns(&corev1.Pod{}).
 		Owns(&corev1.Secret{}).
 		Owns(&corev1.ConfigMap{}).
 		Owns(&corev1.Service{}).
 		Owns(&netv1.Ingress{}).
-		Owns(&policyv1.PodDisruptionBudget{})
+		Owns(&policyv1.PodDisruptionBudget{}).
+		Watches(&corev1.Pod{},
+			handler.EnqueueRequestsFromMapFunc(r.mapPodToBrokerCR),
+			builder.WithPredicates(reconcileMeAnnotationPredicate()),
+		)
 
 	if r.isOnOpenShift {
 		builder.Owns(&routev1.Route{})
 	}
 
 	return builder.Complete(r)
+}
+
+// reconcileMeAnnotationPredicate filters Pod events to only those where the
+// request-reconcile annotation was added or changed.
+func reconcileMeAnnotationPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			_, exists := e.Object.GetAnnotations()[ReconcileMeAnnotationKey]
+			return exists
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldVal := e.ObjectOld.GetAnnotations()[ReconcileMeAnnotationKey]
+			newVal := e.ObjectNew.GetAnnotations()[ReconcileMeAnnotationKey]
+			return newVal != "" && newVal != oldVal
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return false
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return false
+		},
+	}
+}
+
+// mapPodToBrokerCR maps a Pod event to the owning Broker CR by traversing the
+// ownership chain: Pod -> StatefulSet -> Broker CR. All lookups hit the
+// informer cache (no API round-trips).
+func (r *BrokerReconciler) mapPodToBrokerCR(ctx context.Context, obj rtclient.Object) []reconcile.Request {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		return nil
+	}
+
+	for _, ownerRef := range pod.GetOwnerReferences() {
+		if ownerRef.Kind != "StatefulSet" {
+			continue
+		}
+		ss := &appsv1.StatefulSet{}
+		if err := r.Get(ctx, types.NamespacedName{
+			Namespace: pod.Namespace,
+			Name:      ownerRef.Name,
+		}, ss); err != nil {
+			return nil
+		}
+		for _, ssOwner := range ss.GetOwnerReferences() {
+			if ssOwner.Kind == "Broker" {
+				return []reconcile.Request{{
+					NamespacedName: types.NamespacedName{
+						Namespace: pod.Namespace,
+						Name:      ssOwner.Name,
+					},
+				}}
+			}
+		}
+	}
+	return nil
 }
 
 func (r *BrokerReconciler) UpdateBrokerCRStatus(desired *v1beta2.Broker, client rtclient.Client, namespacedName types.NamespacedName) error {
@@ -267,6 +345,10 @@ func (reconciler *BrokerReconcilerImpl) Process(customResource *v1beta2.Broker, 
 	reconciler.log.V(2).Info("Reconciler Processing...", "CRD ver", customResource.ResourceVersion, "CRD Gen", customResource.Generation)
 
 	reconciler.CurrentDeployedResources(customResource, client)
+
+	if err := reconciler.ensureSidecarConfig(client); err != nil {
+		return err
+	}
 
 	// currentStateful Set is a clone of what exists if already deployed
 	// what follows should transform the resources using the crd
@@ -918,7 +1000,7 @@ func (reconciler *BrokerReconcilerImpl) PodTemplateSpecForCR(customResource *v1b
 
 		// jmx_exporter metrics perms
 		fmt.Fprintln(rbac, "securityRoles.\"mops.mbeanserver.queryMBeans\".metrics.view=true")
-		fmt.Fprintln(rbac, "securityRoles.\"mops.broker\".metrics.view=true") // for query remove filter
+		fmt.Fprintln(rbac, "securityRoles.\"mops.broker\".metrics.view=true") // we need view permission on the broker in order to locate through a query and retrieve it.
 		fmt.Fprintln(rbac, "securityRoles.\"mops.broker.getTotalMessageCount\".metrics.view=true")
 		fmt.Fprintln(rbac, "securityRoles.\"mops.broker.getTotalMessagesAcknowledged\".metrics.view=true")
 		fmt.Fprintln(rbac, "securityRoles.\"mops.broker.getTotalMessagesAdded\".metrics.view=true")
@@ -1070,6 +1152,14 @@ func (reconciler *BrokerReconcilerImpl) PodTemplateSpecForCR(customResource *v1b
 		podSpec.Tolerations = customResource.Spec.Tolerations
 	}
 
+	sidecarSecretName := customResource.Name + sidecarSecretSuffix
+	sidecarSecretPath := path.Join(common.SecretPathBase, sidecarSecretName)
+
+	sidecarVolume := volumes.MakeVolumeForSecret(sidecarSecretName)
+	sidecarVolumeMount := volumes.MakeVolumeMountForCfg(sidecarVolume.Name, sidecarSecretPath, true)
+	container.VolumeMounts = append(container.VolumeMounts, sidecarVolumeMount)
+	extraVolumes = append(extraVolumes, sidecarVolume)
+
 	newContainersArray := []corev1.Container{}
 	podSpec.Containers = append(newContainersArray, *container)
 	brokerVolumes := brokervolumes.MakeVolumes(customResource.Name, customResource.Spec.PersistenceEnabled, customResource.Spec.ExtraVolumes, customResource.Spec.ExtraVolumeClaimTemplates)
@@ -1106,19 +1196,14 @@ func (reconciler *BrokerReconcilerImpl) PodTemplateSpecForCR(customResource *v1b
 		environments.CreateOrAppend(podSpec.Containers, &debugArgs)
 	}
 
-	if loggingConfigPath, found := brokerproperties.GetLoggingConfigExtraMountPath(customResource.Spec.ExtraMounts); found {
-		loggerOpts := corev1.EnvVar{
-			Name:  getLoginConfigEnvVarNameForBroker(),
-			Value: fmt.Sprintf("-Dlog4j2.configurationFile=%v", loggingConfigPath),
-		}
-		environments.CreateOrAppend(podSpec.Containers, &loggerOpts)
-	} else {
-		loggerOpts := corev1.EnvVar{
-			Name:  getLoginConfigEnvVarNameForBroker(),
-			Value: "-Dlog4j2.level=INFO",
-		}
-		environments.CreateOrAppend(podSpec.Containers, &loggerOpts)
-	}
+	// Configure the Log4j with the sidecar's required configuration
+	// Users can override with JAVA_ARGS_APPEND
+	environments.CreateOrAppend(
+		podSpec.Containers,
+		&corev1.EnvVar{
+			Name:  jdkJavaOptionsEnvVarName,
+			Value: log4j2ConfigurationFileFlag + path.Join(sidecarSecretPath, LoggingConfigKey),
+		})
 
 	// add TopologySpreadConstraints config
 	podSpec.TopologySpreadConstraints = customResource.Spec.TopologySpreadConstraints
@@ -1155,7 +1240,42 @@ func (reconciler *BrokerReconcilerImpl) PodTemplateSpecForCR(customResource *v1b
 		fmt.Sprintf("export STATEFUL_SET_ORDINAL=${HOSTNAME##*-}; %s exec java %s $JAVA_ARGS_APPEND org.apache.activemq.artemis.core.server.embedded.Main", reEvalJdkOpts, strings.Join(additionalSystemProps, " ")),
 	}
 
-	reqLogger.V(2).Info("Final Init spec", "Detail", podSpec.InitContainers)
+	// The sidecar reuses the broker image to avoid an additional image pull.
+	// Since the main container already pulls this image, all layers are cached
+	// on the node — the sidecar rootfs is a zero-cost overlay mount. The
+	// command override runs only the status script, not the broker. Both
+	// containers share the same pod (network, SA token, volumes), so using
+	// the broker image does not widen the attack surface.
+	sidecarRestartPolicy := corev1.ContainerRestartPolicyAlways
+	sidecarContainer := corev1.Container{
+		Name:          sidecarContainerName,
+		Image:         brokerversion.ResolveImage(customResource, common.BrokerImageKey),
+		Command:       []string{"/bin/bash", path.Join(sidecarSecretPath, brokerStatusScriptKey)},
+		RestartPolicy: &sidecarRestartPolicy,
+		Env: []corev1.EnvVar{
+			{Name: "POD_NAME", ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{APIVersion: "v1", FieldPath: "metadata.name"},
+			}},
+			{Name: "POD_NAMESPACE", ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{APIVersion: "v1", FieldPath: "metadata.namespace"},
+			}},
+			{Name: "RELOAD_LOG_PATH", Value: path.Join(brokervolumes.DataMountPath, "log", "event_stream.log")},
+		},
+		VolumeMounts: []corev1.VolumeMount{
+			{Name: customResource.Name, MountPath: brokervolumes.DataMountPath, ReadOnly: true},
+			sidecarVolumeMount,
+		},
+		Resources: corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("8Mi"),
+				corev1.ResourceCPU:    resource.MustParse("10m"),
+			},
+		},
+	}
+	reconciler.configureContainerSecurityContext(&sidecarContainer, customResource.Spec.ContainerSecurityContext)
+	pts.Spec.InitContainers = []corev1.Container{sidecarContainer}
+
+	reqLogger.V(2).Info("Final Init spec", "Detail", pts.Spec.InitContainers)
 
 	return pts, nil
 }
@@ -1163,10 +1283,6 @@ func (reconciler *BrokerReconcilerImpl) PodTemplateSpecForCR(customResource *v1b
 // support ${STATEFUL_SET_ORDINAL} replacement in JDK options from CR env if necessary
 
 func getJaasConfigEnvVarNameForBroker() string {
-	return jdkJavaOptionsEnvVarName
-}
-
-func getLoginConfigEnvVarNameForBroker() string {
 	return jdkJavaOptionsEnvVarName
 }
 
@@ -1429,7 +1545,8 @@ func (reconciler *BrokerReconcilerImpl) configPodSecurity(podSpec *corev1.PodSpe
 		reconciler.log.V(2).Info("Pod serviceAccountName specified", "existing", podSpec.ServiceAccountName, "new", *podSecurity.ServiceAccountName)
 		podSpec.ServiceAccountName = *podSecurity.ServiceAccountName
 	} else {
-		autoMount := false
+		// The sidecar script needs the service account token to patch pod annotations via the K8s API
+		autoMount := true
 		podSpec.AutomountServiceAccountToken = &autoMount
 	}
 	if podSecurity.RunAsUser != nil {
@@ -1796,7 +1913,7 @@ func (reconciler *BrokerReconcilerImpl) CheckStatus(cr *v1beta2.Broker, client r
 	reconciler.resolveJolokiaEndpoints(cr, client)
 
 	if len(reconciler.jolokiaEndpoints) == 0 {
-		reconciler.log.V(1).Info("no Jolokia Clients available. requeing")
+		reconciler.log.V(1).Info("no Jolokia Clients available")
 		return NewJolokiaClientsNotFoundError(errors.New("Waiting for Jolokia Clients to become available"))
 	}
 
@@ -1839,7 +1956,7 @@ func (reconciler *BrokerReconcilerImpl) GetAndCacheBrokerStatus(jk *jolokia_clie
 
 	reconciler.log.V(2).Info("raw json status", "IP", jk.IP, "ordinal", jk.Ordinal, "status json", currentJSON)
 
-	brokerStatus, err := unmarshallStatus(currentJSON)
+	status, err := unmarshallStatus(currentJSON)
 	if err != nil {
 		reconciler.log.Error(err, "unable to unmarshall broker status", "json", currentJSON)
 		artemisError := NewArtemisStatusError(err, false)
@@ -1847,10 +1964,10 @@ func (reconciler *BrokerReconcilerImpl) GetAndCacheBrokerStatus(jk *jolokia_clie
 		return nil, artemisError
 	}
 
-	reconciler.log.V(2).Info("cached broker status", "ordinal", jk.Ordinal, "status", brokerStatus)
-	reconciler.cachedBrokerStatus[jk.Ordinal] = brokerStatus
+	reconciler.log.V(2).Info("cached broker status", "ordinal", jk.Ordinal, "status", status)
+	reconciler.cachedBrokerStatus[jk.Ordinal] = status
 
-	return &brokerStatus, nil
+	return &status, nil
 
 }
 
@@ -2259,13 +2376,6 @@ func validateExtraMountsForBroker(customResource *v1beta2.Broker, client rtclien
 	return nil, false
 }
 
-func hasExtraMountsForBroker(cr *v1beta2.Broker) bool {
-	if cr == nil {
-		return false
-	}
-	return brokerproperties.HasExtraMounts(cr.Spec.ExtraMounts)
-}
-
 func MakeNamersForBroker(customResource *v1beta2.Broker) *common.Namers {
 	newNamers := common.Namers{
 		SsGlobalName:                  "",
@@ -2297,6 +2407,128 @@ func GetDefaultLabelsForBroker(cr *v1beta2.Broker) map[string]string {
 	defaultLabelData := selectors.NewBrokerLabeler()
 	defaultLabelData.Base(cr.Name).Suffix("app").Generate()
 	return defaultLabelData.Labels()
+}
+
+const brokerReloadLogAppenderFragment = `
+appender.stdout.name = STDOUT
+appender.stdout.type = Console
+rootLogger = info, STDOUT
+appender.event_stream.type = RollingFile
+appender.event_stream.name = EventStream
+appender.event_stream.fileName = /app/log/event_stream.log
+appender.event_stream.filePattern = /app/log/event_stream.log.%i
+appender.event_stream.layout.type = PatternLayout
+appender.event_stream.layout.pattern = %d %-5level [%logger] %msg%n
+appender.event_stream.policies.type = Policies
+appender.event_stream.policies.size.type = SizeBasedTriggeringPolicy
+appender.event_stream.policies.size.size = 1KB
+appender.event_stream.strategy.type = DefaultRolloverStrategy
+appender.event_stream.strategy.max = 1
+logger.event_stream.name = org.apache.activemq.artemis.core.server
+logger.event_stream.level = INFO
+logger.event_stream.appenderRef.event_stream.ref = EventStream
+`
+
+func (reconciler *BrokerReconcilerImpl) ensureSidecarConfig(client rtclient.Client) error {
+	cr := reconciler.customResource
+	sidecarName := cr.Name + sidecarSecretSuffix
+
+	desired := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      sidecarName,
+			Namespace: cr.Namespace,
+		},
+		Data: map[string][]byte{
+			brokerStatusScriptKey: []byte(brokerStatusScript),
+			LoggingConfigKey:      []byte(brokerReloadLogAppenderFragment),
+		},
+	}
+
+	reconciler.trackDesired(desired)
+
+	ctx := context.TODO()
+
+	ownerRef := metav1.OwnerReference{
+		APIVersion: cr.APIVersion,
+		Kind:       cr.Kind,
+		Name:       cr.Name,
+		UID:        cr.UID,
+	}
+	if (ownerRef.APIVersion == "" || ownerRef.Kind == "") && reconciler.scheme != nil {
+		gvks, _, _ := reconciler.scheme.ObjectKinds(cr)
+		if len(gvks) > 0 {
+			ownerRef.APIVersion = gvks[0].GroupVersion().String()
+			ownerRef.Kind = gvks[0].Kind
+		}
+	}
+
+	podNames := []string{fmt.Sprintf("%s-ss-0", cr.Name)}
+
+	role := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            sidecarName,
+			Namespace:       cr.Namespace,
+			OwnerReferences: []metav1.OwnerReference{ownerRef},
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups:     []string{""},
+				Resources:     []string{"pods"},
+				ResourceNames: podNames,
+				Verbs:         []string{"patch"},
+			},
+		},
+	}
+
+	existing := &rbacv1.Role{}
+	if err := client.Get(ctx, types.NamespacedName{Name: sidecarName, Namespace: cr.Namespace}, existing); err != nil {
+		if k8serrors.IsNotFound(err) {
+			if err := client.Create(ctx, role); err != nil && !k8serrors.IsAlreadyExists(err) {
+				return fmt.Errorf("failed to create status-script Role: %w", err)
+			}
+		} else {
+			return err
+		}
+	} else if !reflect.DeepEqual(existing.Rules, role.Rules) {
+		patch := rtclient.MergeFrom(existing.DeepCopy())
+		existing.Rules = role.Rules
+		if err := client.Patch(ctx, existing, patch); err != nil {
+			return fmt.Errorf("failed to patch status-script Role: %w", err)
+		}
+	}
+
+	binding := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            sidecarName,
+			Namespace:       cr.Namespace,
+			OwnerReferences: []metav1.OwnerReference{ownerRef},
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      "default",
+				Namespace: cr.Namespace,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "Role",
+			Name:     sidecarName,
+		},
+	}
+
+	existingBinding := &rbacv1.RoleBinding{}
+	if err := client.Get(ctx, types.NamespacedName{Name: sidecarName, Namespace: cr.Namespace}, existingBinding); err != nil {
+		if k8serrors.IsNotFound(err) {
+			if err := client.Create(ctx, binding); err != nil && !k8serrors.IsAlreadyExists(err) {
+				return fmt.Errorf("failed to create status-script RoleBinding: %w", err)
+			}
+		} else {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // Controller Errors

--- a/controllers/broker_controller_unit_test.go
+++ b/controllers/broker_controller_unit_test.go
@@ -16,23 +16,37 @@ package controllers
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"path"
+	"strings"
 	"testing"
+	"time"
 
 	brokerv1beta1 "github.com/arkmq-org/arkmq-org-broker-operator/v2/api/v1beta1"
 	v1beta2 "github.com/arkmq-org/arkmq-org-broker-operator/v2/api/v1beta2"
+	"github.com/arkmq-org/arkmq-org-broker-operator/v2/pkg/brokerproperties"
 	"github.com/arkmq-org/arkmq-org-broker-operator/v2/pkg/utils/common"
+	"github.com/arkmq-org/arkmq-org-broker-operator/v2/pkg/utils/jolokia_client"
 	"github.com/arkmq-org/arkmq-org-broker-operator/v2/pkg/utils/selectors"
 	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/scheme"
 )
 
 func TestErrOnNotFoundSecret(t *testing.T) {
@@ -213,4 +227,350 @@ func TestValidateReservedLabelsForBroker(t *testing.T) {
 		assert.Equal(t, v1beta2.ValidConditionFailedReservedLabelReason, condition.Reason)
 		assert.Contains(t, condition.Message, "Spec.ResourceTemplates[0].Labels")
 	})
+}
+
+func TestReconcileMeAnnotationPredicate(t *testing.T) {
+	pred := reconcileMeAnnotationPredicate()
+
+	t.Run("CreateFunc with annotation present", func(t *testing.T) {
+		pod := &corev1.Pod{ObjectMeta: v1.ObjectMeta{
+			Annotations: map[string]string{ReconcileMeAnnotationKey: "1719300000"},
+		}}
+		assert.True(t, pred.Create(event.CreateEvent{Object: pod}))
+	})
+
+	t.Run("CreateFunc without annotation", func(t *testing.T) {
+		pod := &corev1.Pod{ObjectMeta: v1.ObjectMeta{}}
+		assert.False(t, pred.Create(event.CreateEvent{Object: pod}))
+	})
+
+	t.Run("UpdateFunc annotation value changed", func(t *testing.T) {
+		oldPod := &corev1.Pod{ObjectMeta: v1.ObjectMeta{
+			Annotations: map[string]string{ReconcileMeAnnotationKey: "1719300000"},
+		}}
+		newPod := &corev1.Pod{ObjectMeta: v1.ObjectMeta{
+			Annotations: map[string]string{ReconcileMeAnnotationKey: "1719300005"},
+		}}
+		assert.True(t, pred.Update(event.UpdateEvent{ObjectOld: oldPod, ObjectNew: newPod}))
+	})
+
+	t.Run("UpdateFunc annotation added", func(t *testing.T) {
+		oldPod := &corev1.Pod{ObjectMeta: v1.ObjectMeta{}}
+		newPod := &corev1.Pod{ObjectMeta: v1.ObjectMeta{
+			Annotations: map[string]string{ReconcileMeAnnotationKey: "1719300000"},
+		}}
+		assert.True(t, pred.Update(event.UpdateEvent{ObjectOld: oldPod, ObjectNew: newPod}))
+	})
+
+	t.Run("UpdateFunc annotation unchanged", func(t *testing.T) {
+		oldPod := &corev1.Pod{ObjectMeta: v1.ObjectMeta{
+			Annotations: map[string]string{ReconcileMeAnnotationKey: "1719300000"},
+		}}
+		newPod := &corev1.Pod{ObjectMeta: v1.ObjectMeta{
+			Annotations: map[string]string{ReconcileMeAnnotationKey: "1719300000"},
+		}}
+		assert.False(t, pred.Update(event.UpdateEvent{ObjectOld: oldPod, ObjectNew: newPod}))
+	})
+
+	t.Run("UpdateFunc annotation removed", func(t *testing.T) {
+		oldPod := &corev1.Pod{ObjectMeta: v1.ObjectMeta{
+			Annotations: map[string]string{ReconcileMeAnnotationKey: "1719300000"},
+		}}
+		newPod := &corev1.Pod{ObjectMeta: v1.ObjectMeta{}}
+		assert.False(t, pred.Update(event.UpdateEvent{ObjectOld: oldPod, ObjectNew: newPod}))
+	})
+
+	t.Run("DeleteFunc always false", func(t *testing.T) {
+		pod := &corev1.Pod{ObjectMeta: v1.ObjectMeta{
+			Annotations: map[string]string{ReconcileMeAnnotationKey: "1719300000"},
+		}}
+		assert.False(t, pred.Delete(event.DeleteEvent{Object: pod}))
+	})
+}
+
+func TestMapPodToBrokerCR(t *testing.T) {
+	s := scheme.Scheme
+	_ = appsv1.AddToScheme(s)
+	_ = v1beta2.SchemeBuilder.AddToScheme(s)
+
+	ss := &appsv1.StatefulSet{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "my-broker-ss",
+			Namespace: "test-ns",
+			OwnerReferences: []v1.OwnerReference{
+				{Kind: "Broker", Name: "my-broker", APIVersion: "broker.arkmq.org/v1beta2"},
+			},
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "my-broker-ss-0",
+			Namespace: "test-ns",
+			OwnerReferences: []v1.OwnerReference{
+				{Kind: "StatefulSet", Name: "my-broker-ss", APIVersion: "apps/v1"},
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(s).WithObjects(ss).Build()
+	r := &BrokerReconciler{Client: fakeClient, Scheme: s}
+
+	requests := r.mapPodToBrokerCR(context.TODO(), pod)
+	assert.Equal(t, 1, len(requests))
+	assert.Equal(t, "my-broker", requests[0].Name)
+	assert.Equal(t, "test-ns", requests[0].Namespace)
+}
+
+func TestMapPodToBrokerCR_NoBrokerOwner(t *testing.T) {
+	s := scheme.Scheme
+	_ = appsv1.AddToScheme(s)
+
+	ss := &appsv1.StatefulSet{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "my-broker-ss",
+			Namespace: "test-ns",
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "my-broker-ss-0",
+			Namespace: "test-ns",
+			OwnerReferences: []v1.OwnerReference{
+				{Kind: "StatefulSet", Name: "my-broker-ss", APIVersion: "apps/v1"},
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(s).WithObjects(ss).Build()
+	r := &BrokerReconciler{Client: fakeClient, Scheme: s}
+
+	requests := r.mapPodToBrokerCR(context.TODO(), pod)
+	assert.Equal(t, 0, len(requests))
+}
+
+func TestCheckProjectionStatus(t *testing.T) {
+	checksum := brokerproperties.Alder32FromData([]byte("globalMaxSize=128m"))
+
+	extractStatus := func(bs *brokerStatus, fileName string) (propertiesStatus, bool) {
+		current, present := bs.BrokerConfigStatus.PropertiesStatus[fileName]
+		return current, present
+	}
+
+	newReconcilerWithStatus := func(props map[string]propertiesStatus) (*BrokerReconcilerImpl, *v1beta2.Broker, client.Client) {
+		cr := &v1beta2.Broker{
+			ObjectMeta: v1.ObjectMeta{Name: "test", Namespace: "test-ns"},
+		}
+		cached := brokerStatus{
+			BrokerConfigStatus: brokerConfigStatus{
+				PropertiesStatus: props,
+			},
+		}
+		ri := &BrokerReconcilerImpl{
+			customResource:     cr,
+			log:                ctrl.Log,
+			cachedBrokerStatus: map[string]any{"0": cached},
+			jolokiaEndpoints:   []*jolokia_client.JkInfo{{Ordinal: "0"}},
+		}
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).Build()
+		return ri, cr, fakeClient
+	}
+
+	t.Run("all synced returns nil", func(t *testing.T) {
+		proj := &projection{
+			Name:            "test-props",
+			ResourceVersion: "1",
+			Files:           map[string]propertyFile{"broker.properties": {Alder32: checksum}},
+		}
+		ri, cr, fakeClient := newReconcilerWithStatus(map[string]propertiesStatus{
+			"broker.properties": {Alder32: checksum},
+		})
+		result := ri.checkProjectionStatus(cr, fakeClient, proj, extractStatus)
+		assert.Nil(t, result)
+	})
+
+	t.Run("checksum mismatch returns OutOfSync", func(t *testing.T) {
+		proj := &projection{
+			Name:            "test-props",
+			ResourceVersion: "1",
+			Files:           map[string]propertyFile{"broker.properties": {Alder32: checksum}},
+		}
+		ri, cr, fakeClient := newReconcilerWithStatus(map[string]propertiesStatus{
+			"broker.properties": {Alder32: "99999"},
+		})
+		result := ri.checkProjectionStatus(cr, fakeClient, proj, extractStatus)
+		assert.NotNil(t, result)
+		_, ok := result.(statusOutOfSyncError)
+		assert.True(t, ok, "expected statusOutOfSyncError, got %T", result)
+	})
+
+	t.Run("synced with apply errors returns InSyncApplyError", func(t *testing.T) {
+		proj := &projection{
+			Name:            "test-props",
+			ResourceVersion: "1",
+			Files:           map[string]propertyFile{"broker.properties": {Alder32: checksum}},
+		}
+		ri, cr, fakeClient := newReconcilerWithStatus(map[string]propertiesStatus{
+			"broker.properties": {
+				Alder32: checksum,
+				ApplyErrors: []applyError{
+					{PropKeyValue: "addressFullMessagePolicy=INVALID", Reason: "IllegalArgumentException"},
+				},
+			},
+		})
+		result := ri.checkProjectionStatus(cr, fakeClient, proj, extractStatus)
+		assert.NotNil(t, result)
+		_, ok := result.(inSyncApplyError)
+		assert.True(t, ok, "expected inSyncApplyError, got %T", result)
+		assert.Contains(t, result.Error(), "addressFullMessagePolicy=INVALID")
+	})
+
+	t.Run("unchecked prefix files are ignored when missing", func(t *testing.T) {
+		proj := &projection{
+			Name:            "test-props",
+			ResourceVersion: "1",
+			Files: map[string]propertyFile{
+				"broker.properties":         {Alder32: checksum},
+				"_jolokia.config":           {Alder32: "ignored"},
+				"_prometheus_exporter.yaml": {Alder32: "ignored"},
+			},
+		}
+		ri, cr, fakeClient := newReconcilerWithStatus(map[string]propertiesStatus{
+			"broker.properties": {Alder32: checksum},
+		})
+		result := ri.checkProjectionStatus(cr, fakeClient, proj, extractStatus)
+		assert.Nil(t, result, "underscore-prefixed files should not cause missing key errors")
+	})
+
+	t.Run("missing file returns OutOfSyncMissingKey", func(t *testing.T) {
+		proj := &projection{
+			Name:            "test-props",
+			ResourceVersion: "1",
+			Files: map[string]propertyFile{
+				"broker.properties": {Alder32: checksum},
+				"other.properties":  {Alder32: "other"},
+			},
+		}
+		ri, cr, fakeClient := newReconcilerWithStatus(map[string]propertiesStatus{
+			"broker.properties": {Alder32: checksum},
+		})
+		result := ri.checkProjectionStatus(cr, fakeClient, proj, extractStatus)
+		assert.NotNil(t, result)
+		_, ok := result.(statusOutOfSyncMissingKeyError)
+		assert.True(t, ok, "expected statusOutOfSyncMissingKeyError, got %T", result)
+	})
+}
+
+func TestPodTemplateSpecForCR_SidecarInitContainer(t *testing.T) {
+	certPEM, keyPEM := mustTestKeyPair(t)
+
+	ns := "test"
+	cr := &v1beta2.Broker{
+		ObjectMeta: v1.ObjectMeta{Name: "my-broker", Namespace: ns},
+	}
+
+	operandSecret := &corev1.Secret{
+		ObjectMeta: v1.ObjectMeta{Name: common.DefaultOperandCertSecretName, Namespace: ns},
+		Data:       map[string][]byte{"tls.crt": certPEM, "tls.key": keyPEM},
+	}
+	operatorCert := &corev1.Secret{
+		ObjectMeta: v1.ObjectMeta{Name: common.DefaultOperatorCertSecretName, Namespace: ns},
+		Data:       map[string][]byte{"tls.crt": certPEM, "tls.key": keyPEM},
+	}
+	operatorCA := &corev1.Secret{
+		ObjectMeta: v1.ObjectMeta{Name: common.DefaultOperatorCASecretName, Namespace: ns},
+		Data:       map[string][]byte{"ca.pem": certPEM},
+	}
+
+	common.SetOperatorNameSpace(ns)
+	t.Cleanup(common.UnsetOperatorNameSpace)
+
+	k8sClient := fake.NewClientBuilder().WithObjects(operandSecret, operatorCert, operatorCA).Build()
+	reconciler := NewBrokerReconcilerImpl(cr, NewBrokerReconciler(&NillCluster{}, ctrl.Log, isOpenshift))
+	namer := MakeNamersForBroker(cr)
+
+	pts, err := reconciler.PodTemplateSpecForCR(cr, *namer, &appsv1.StatefulSet{}, k8sClient)
+	assert.NoError(t, err)
+	assert.NotNil(t, pts)
+
+	t.Run("sidecar init container exists with restartPolicy Always", func(t *testing.T) {
+		assert.Equal(t, 1, len(pts.Spec.InitContainers))
+		sidecar := pts.Spec.InitContainers[0]
+		assert.Equal(t, sidecarContainerName, sidecar.Name)
+		assert.NotEmpty(t, sidecar.Image, "sidecar image should be resolved from init image")
+		assert.NotNil(t, sidecar.RestartPolicy)
+		assert.Equal(t, corev1.ContainerRestartPolicyAlways, *sidecar.RestartPolicy)
+	})
+
+	t.Run("sidecar has required env vars", func(t *testing.T) {
+		sidecar := pts.Spec.InitContainers[0]
+		envMap := make(map[string]corev1.EnvVar)
+		for _, e := range sidecar.Env {
+			envMap[e.Name] = e
+		}
+		assert.Contains(t, envMap, "POD_NAME")
+		assert.Contains(t, envMap, "POD_NAMESPACE")
+		assert.Contains(t, envMap, "RELOAD_LOG_PATH")
+		assert.Equal(t, "/app/log/event_stream.log", envMap["RELOAD_LOG_PATH"].Value)
+	})
+
+	t.Run("broker container mounts sidecar secret", func(t *testing.T) {
+		broker := pts.Spec.Containers[0]
+		mountNames := make(map[string]bool)
+		for _, vm := range broker.VolumeMounts {
+			mountNames[vm.Name] = true
+		}
+		assert.True(t, mountNames["secret-"+cr.Name+sidecarSecretSuffix], "broker should mount the sidecar secret")
+	})
+
+	t.Run("broker container command does not contain status script launch", func(t *testing.T) {
+		assert.NotEmpty(t, pts.Spec.Containers[0].Command)
+		cmd := strings.Join(pts.Spec.Containers[0].Command, " ")
+		assert.NotContains(t, cmd, "broker-status.sh")
+		assert.NotContains(t, cmd, "status-script")
+	})
+
+	t.Run("sidecar has security context", func(t *testing.T) {
+		sidecar := pts.Spec.InitContainers[0]
+		assert.NotNil(t, sidecar.SecurityContext)
+		assert.True(t, *sidecar.SecurityContext.RunAsNonRoot)
+		assert.False(t, *sidecar.SecurityContext.AllowPrivilegeEscalation)
+	})
+
+	t.Run("sidecar has resource limits", func(t *testing.T) {
+		sidecar := pts.Spec.InitContainers[0]
+		assert.NotNil(t, sidecar.Resources.Limits)
+	})
+
+	t.Run("broker container has log4j2 configurationFile with default and operator URIs", func(t *testing.T) {
+		var jdkOpts string
+		for _, env := range pts.Spec.Containers[0].Env {
+			if env.Name == jdkJavaOptionsEnvVarName {
+				jdkOpts = env.Value
+				break
+			}
+		}
+		sidecarSecretPath := path.Join(common.SecretPathBase, cr.Name+sidecarSecretSuffix)
+		operatorURI := path.Join(sidecarSecretPath, LoggingConfigKey)
+		assert.Contains(t, jdkOpts, log4j2ConfigurationFileFlag+operatorURI)
+	})
+}
+
+func mustTestKeyPair(t *testing.T) (certPEM, keyPEM []byte) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	assert.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	assert.NoError(t, err)
+
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+	return certPEM, keyPEM
 }

--- a/controllers/broker_status_script.sh
+++ b/controllers/broker_status_script.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Signal the operator to reconcile on broker lifecycle events.
+#
+# Watched log codes (from org.apache.activemq.artemis.core.server):
+#   AMQ221007  - Server is now active            (startup)
+#   AMQ221087  - Configuration reload completed  (Artemis 2.54+, ARTEMIS-6099)
+#
+# Runs as a native sidecar (init container with restartPolicy: Always).
+# Kubelet restarts the container on exit.
+
+PATCH_URL="https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}/api/v1/namespaces/${POD_NAMESPACE}/pods/${POD_NAME}"
+TOKEN_PATH=/var/run/secrets/kubernetes.io/serviceaccount/token
+CA_CERT=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+
+signal_reconcile() {
+  curl -sf --cacert "$CA_CERT" -X PATCH \
+    -H "Authorization: Bearer $(cat "$TOKEN_PATH")" \
+    -H "Content-Type: application/merge-patch+json" \
+    -d '{"metadata":{"annotations":{"broker.arkmq.org/request-reconcile":"'"$(cat /proc/sys/kernel/random/uuid)"'"}}}' \
+    "$PATCH_URL" > /dev/null
+}
+
+tail -F "$RELOAD_LOG_PATH" 2>/dev/null | grep -E --line-buffered 'AMQ221007|AMQ221087' | while read -r; do
+  signal_reconcile
+done

--- a/deploy/arkmq-org-broker-operator.yaml
+++ b/deploy/arkmq-org-broker-operator.yaml
@@ -18754,6 +18754,9 @@ rules:
   - create
   - delete
   - get
+  - list
+  - patch
+  - watch
 - apiGroups:
   - route.openshift.io
   resources:

--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -172,6 +172,9 @@ rules:
   - create
   - delete
   - get
+  - list
+  - patch
+  - watch
 - apiGroups:
   - route.openshift.io
   resources:

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -172,6 +172,9 @@ rules:
   - create
   - delete
   - get
+  - list
+  - patch
+  - watch
 - apiGroups:
   - route.openshift.io
   resources:

--- a/helm-charts/arkmq-org-broker-operator/templates/operator-rbac.yaml
+++ b/helm-charts/arkmq-org-broker-operator/templates/operator-rbac.yaml
@@ -174,6 +174,9 @@ rules:
   - create
   - delete
   - get
+  - list
+  - patch
+  - watch
 - apiGroups:
   - route.openshift.io
   resources:


### PR DESCRIPTION
Replace periodic requeue-based Jolokia polling with an event-driven
model. A native sidecar container monitors the broker log for lifecycle
events and patches the request-reconcile annotation on its own pod with
a unique UUID. The operator watches for annotation changes, reconciles,
and performs its standard mTLS Jolokia call to fetch status.

BEFORE (main):
  Operator --[periodic requeue]--> Jolokia mTLS --> Broker :8778
  (polls on timer regardless of broker state change)

AFTER (this branch):
```
  Pod
  +---------------------------------------------------+
  |  initContainers (restartPolicy: Always):          |
  |    broker-status sidecar:                         |
  |      tail reload.log for AMQ221007 | AMQ221087   |
  |        |                                          |
  |        +---> K8s API PATCH: pod annotation        |
  |              broker.arkmq.org/request-reconcile   |
  |                                                   |
  |  containers:                                      |
  |    broker (Jolokia on :8778)                      |
  +---------------------------------------------------+
                        |
                  predicate fires
                        |
                        v
                    Operator
              (Jolokia mTLS, same as before)
```

Watched log codes:
  AMQ221007 - Server is now active (startup)
  AMQ221087 - Configuration reload completed (Artemis 2.54+)

The sidecar runs as a K8s native sidecar (init container with
restartPolicy: Always, stable since K8s 1.33). Kubelet manages
restarts. The script reads the SA token fresh on each call to
survive kubelet token rotation.

The sidecar reuses the broker image (resolved per CR version via
RELATED_IMAGE_BROKER_KUBERNETES). Since the main container already
pulls it, all layers are cached — zero additional download. The
command override runs the status script, not the broker. Both
containers share the same pod boundary (network, SA token, volumes),
so reusing the image does not widen the attack surface. No separate
sidecar image to track, mirror, or configure.

Key changes:
- broker-status.sh delivered via Secret, runs in a dedicated
  sidecar init container (broker image, identical security context)
- Dedicated Pod watch with request-reconcile annotation predicate
  (Watches + EnqueueRequestsFromMapFunc + mapPodToBrokerCR)
- Remove periodic requeues from ProcessBrokerStatus
- UUID-based annotation values (no clearing needed — each event
  writes a new UUID, which fires the update predicate)
- RBAC: Role/RoleBinding scoped to specific pod names (resourceNames)
- minKubeVersion bumped to 1.33.0

Assisted-by: Cursor/Claude