### PR TITLE
[NO-ISSUE] don't use .yaml suffix for restricted mode prometheus conf…

### DIFF
--- a/controllers/broker_reconciler.go
+++ b/controllers/broker_reconciler.go
@@ -98,6 +98,8 @@ const (
 	javaOptsEnvVarName       = "JAVA_OPTS"
 	jdkJavaOptionsEnvVarName = "JDK_JAVA_OPTIONS"
 
+	PrometheusConfigFileName = "_prometheus_exporter_config"
+
 	ScaleDownConfigTrigger        = "HAPolicyConfiguration.scaleDownConfiguration.enabled=false"
 	ScaleDownConfigTriggerOn      = "HAPolicyConfiguration.scaleDownConfiguration.enabled=true"
 	OrdinalPropertiesSuffix       = "for_ordinal_"
@@ -2386,7 +2388,7 @@ func (reconciler *BrokerReconcilerImpl) PodTemplateSpecForCR(customResource *v1b
 		fmt.Fprintf(prometheus_config, "    name: artemis_total_produced_message_count\n")
 		fmt.Fprintf(prometheus_config, "    type: COUNTER\n")
 
-		brokerPropertiesMapData["_prometheus_exporter.yaml"] = prometheus_config.Bytes()
+		brokerPropertiesMapData[PrometheusConfigFileName] = prometheus_config.Bytes()
 
 		// Apply control plane overrides if they exist
 		if err := applyControlPlaneOverrides(customResource, client, brokerPropertiesMapData); err != nil {
@@ -2403,7 +2405,7 @@ func (reconciler *BrokerReconcilerImpl) PodTemplateSpecForCR(customResource *v1b
 		additionalSystemPropsForRestricted = append(additionalSystemPropsForRestricted, fmt.Sprintf("-javaagent:/opt/agents/jolokia.jar=host=$HOSTNAME,config=%s/_jolokia.config", mountPathRoot))
 
 		// install prometheus agent
-		additionalSystemPropsForRestricted = append(additionalSystemPropsForRestricted, fmt.Sprintf("-javaagent:/opt/agents/prometheus.jar=$HOSTNAME:8888:%s/_prometheus_exporter.yaml", mountPathRoot))
+		additionalSystemPropsForRestricted = append(additionalSystemPropsForRestricted, fmt.Sprintf("-javaagent:/opt/agents/prometheus.jar=$HOSTNAME:8888:%s/%s", mountPathRoot, PrometheusConfigFileName))
 
 		// non boot jar isolation classpath
 		additionalSystemPropsForRestricted = append(additionalSystemPropsForRestricted, "-classpath /opt/amq/lib/*:/opt/amq/lib/extra/*")

--- a/controllers/brokerservice_controller.go
+++ b/controllers/brokerservice_controller.go
@@ -1049,7 +1049,7 @@ func (reconciler *BrokerServiceInstanceReconciler) processControlPlaneOverrideSe
 
 	// Generate prometheus exporter yaml with queue-level metrics
 	prometheusConfig := reconciler.generatePrometheusConfig(consumerAddresses)
-	desired.Data["_prometheus_exporter.yaml"] = prometheusConfig
+	desired.Data[PrometheusConfigFileName] = prometheusConfig
 
 	reconciler.TrackDesired(desired)
 	return nil

--- a/controllers/brokerservice_controller_unit_test.go
+++ b/controllers/brokerservice_controller_unit_test.go
@@ -939,8 +939,8 @@ func TestBrokerServiceReconcilePrometheusOverrideSecret(t *testing.T) {
 	assert.NoError(t, err, "control-plane-override secret should exist")
 
 	// Verify prometheus config exists in the secret
-	prometheusYaml, ok := overrideSecret.Data["_prometheus_exporter.yaml"]
-	assert.True(t, ok, "should have _prometheus_exporter.yaml key")
+	prometheusYaml, ok := overrideSecret.Data[PrometheusConfigFileName]
+	assert.True(t, ok, "should have prometheus key")
 	assert.NotEmpty(t, prometheusYaml)
 
 	prometheusConfig := string(prometheusYaml)
@@ -1029,8 +1029,8 @@ func TestBrokerServiceReconcilePrometheusOverrideNoApps(t *testing.T) {
 	assert.NoError(t, err, "control-plane-override secret should exist even without apps")
 
 	// Verify prometheus config exists with queue-level metrics
-	prometheusYaml, ok := overrideSecret.Data["_prometheus_exporter.yaml"]
-	assert.True(t, ok, "should have _prometheus_exporter.yaml key")
+	prometheusYaml, ok := overrideSecret.Data[PrometheusConfigFileName]
+	assert.True(t, ok, "should have prometheus key")
 	assert.NotEmpty(t, prometheusYaml)
 
 	prometheusConfig := string(prometheusYaml)

--- a/controllers/brokerservice_security_test.go
+++ b/controllers/brokerservice_security_test.go
@@ -698,8 +698,8 @@ func TestBrokerServiceRejectsAppsFromPrometheusConfig(t *testing.T) {
 	assert.NoError(t, err, "control-plane-override secret should be created")
 
 	// Verify Prometheus config exists
-	prometheusYaml, ok := overrideSecret.Data["_prometheus_exporter.yaml"]
-	assert.True(t, ok, "should have _prometheus_exporter.yaml key")
+	prometheusYaml, ok := overrideSecret.Data[PrometheusConfigFileName]
+	assert.True(t, ok, "should have prometheus key")
 	assert.NotEmpty(t, prometheusYaml)
 
 	prometheusConfig := string(prometheusYaml)

--- a/controllers/brokerservice_test.go
+++ b/controllers/brokerservice_test.go
@@ -768,8 +768,8 @@ var _ = Describe("broker-service-poc", func() {
 				g.Expect(k8sClient.Get(ctx, overrideSecretKey, overrideSecret)).Should(Succeed())
 
 				// Verify the secret contains the prometheus exporter config
-				prometheusYaml, ok := overrideSecret.Data["_prometheus_exporter.yaml"]
-				g.Expect(ok).Should(BeTrue(), "should have _prometheus_exporter.yaml key")
+				prometheusYaml, ok := overrideSecret.Data[PrometheusConfigFileName]
+				g.Expect(ok).Should(BeTrue(), "should have prometheus key")
 
 				prometheusConfig := string(prometheusYaml)
 				if verbose {


### PR DESCRIPTION
…ig because the broker will support reading yaml from properties secrets