### PR TITLE
[#1334] Dev.latest build references dev.latest operand snapshots

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,8 +241,22 @@ jobs:
           podman login --username=${{ secrets.QUAY_USERNAME }} --password=${{ secrets.QUAY_PASSWORD }} quay.io
           podman manifest push $IMAGE_NAME:dev.latest docker://quay.io/${{ secrets.QUAY_NAMESPACE }}/$IMAGE_NAME:dev.latest
 
+      - name: Resolve dev.latest operand digests
+        if: ${{ github.event_name == 'push' }}
+        id: operand-digests
+        run: |
+          INIT_DIGEST="$(skopeo inspect docker://quay.io/arkmq-org/arkmq-org-broker-init:dev.latest | jq -r '.Digest')"
+          KUBE_DIGEST="$(skopeo inspect docker://quay.io/arkmq-org/arkmq-org-broker-kubernetes:dev.latest | jq -r '.Digest')"
+          echo "init=quay.io/arkmq-org/arkmq-org-broker-init@${INIT_DIGEST}" >> $GITHUB_OUTPUT
+          echo "kube=quay.io/arkmq-org/arkmq-org-broker-kubernetes@${KUBE_DIGEST}" >> $GITHUB_OUTPUT
+          echo "Resolved init: quay.io/arkmq-org/arkmq-org-broker-init@${INIT_DIGEST}"
+          echo "Resolved kube: quay.io/arkmq-org/arkmq-org-broker-kubernetes@${KUBE_DIGEST}"
+
       - name: Push dev-latest helm chart
         if: ${{ github.event_name == 'push' }}
+        env:
+          DEV_INIT_IMAGE: ${{ steps.operand-digests.outputs.init }}
+          DEV_KUBE_IMAGE: ${{ steps.operand-digests.outputs.kube }}
         run: |
           # Create a temporary copy for the dev chart
           cp -r helm-charts/arkmq-org-broker-operator helm-charts/arkmq-org-broker-operator-dev
@@ -251,16 +265,30 @@ jobs:
           yq -i '.appVersion="dev.latest"' helm-charts/arkmq-org-broker-operator-dev/Chart.yaml
           yq -i '.controllerManager.manager.image.tag="dev.latest"' helm-charts/arkmq-org-broker-operator-dev/values.yaml
           yq -i '.controllerManager.manager.image.pullPolicy="Always"' helm-charts/arkmq-org-broker-operator-dev/values.yaml
+          # Add dev.latest operand images as version 0.0.0 (digest-pinned)
+          DEV_INIT_IMAGE="$DEV_INIT_IMAGE" yq -i '.controllerManager.manager.relatedImages.brokerInit000.digest=env(DEV_INIT_IMAGE)' helm-charts/arkmq-org-broker-operator-dev/values.yaml
+          DEV_KUBE_IMAGE="$DEV_KUBE_IMAGE" yq -i '.controllerManager.manager.relatedImages.brokerKubernetes000.digest=env(DEV_KUBE_IMAGE)' helm-charts/arkmq-org-broker-operator-dev/values.yaml
+          sed -i '/- name: OPERATOR_NAME/i\        - name: DEFAULT_BROKER_VERSION\n          value: "0.0.0"\n        - name: DEFAULT_BROKER_COMPACT_VERSION\n          value: "000"\n        - name: DEFAULT_BROKER_KUBE_IMAGE\n          value: {{ quote .Values.controllerManager.manager.relatedImages.brokerKubernetes000.digest }}\n        - name: DEFAULT_BROKER_INIT_IMAGE\n          value: {{ quote .Values.controllerManager.manager.relatedImages.brokerInit000.digest }}\n        - name: RELATED_IMAGE_BROKER_INIT_000\n          value: {{ quote .Values.controllerManager.manager.relatedImages.brokerInit000.digest }}\n        - name: RELATED_IMAGE_BROKER_KUBERNETES_000\n          value: {{ quote .Values.controllerManager.manager.relatedImages.brokerKubernetes000.digest }}' helm-charts/arkmq-org-broker-operator-dev/templates/deployment.yaml
           # Package and push
           helm package helm-charts/arkmq-org-broker-operator-dev/
           helm registry login --username=${{ secrets.QUAY_USERNAME }} --password=${{ secrets.QUAY_PASSWORD }} quay.io
           helm push arkmq-org-broker-operator-0.0.0-dev.latest.tgz oci://quay.io/${{ secrets.QUAY_NAMESPACE }}/helm-charts
 
       - name: Build the bundle image
+        env:
+          DEV_INIT_IMAGE: ${{ steps.operand-digests.outputs.init }}
+          DEV_KUBE_IMAGE: ${{ steps.operand-digests.outputs.kube }}
         run: |
           IMG="${HOSTNAME}:5000/$IMAGE_NAME:dev.latest"
-          IMG="$IMG" yq -i '.metadata.annotations.containerImage=env(IMG)' bundle/manifests/arkmq-org-broker-operator.clusterserviceversion.yaml
-          IMG="$IMG" yq -i '.spec.install.spec.deployments[].spec.template.spec.containers[].image=env(IMG)' bundle/manifests/arkmq-org-broker-operator.clusterserviceversion.yaml
+          CSV=bundle/manifests/arkmq-org-broker-operator.clusterserviceversion.yaml
+          IMG="$IMG" yq -i '.metadata.annotations.containerImage=env(IMG)' "$CSV"
+          IMG="$IMG" yq -i '.spec.install.spec.deployments[].spec.template.spec.containers[].image=env(IMG)' "$CSV"
+          if [ -n "$DEV_INIT_IMAGE" ] && [ -n "$DEV_KUBE_IMAGE" ]; then
+            # Add dev.latest overrides to bundle CSV
+            yq -i '(.spec.install.spec.deployments[].spec.template.spec.containers[].env) += [{"name": "DEFAULT_BROKER_VERSION", "value": "0.0.0"}, {"name": "DEFAULT_BROKER_COMPACT_VERSION", "value": "000"}, {"name": "DEFAULT_BROKER_KUBE_IMAGE", "value": env(DEV_KUBE_IMAGE)}, {"name": "DEFAULT_BROKER_INIT_IMAGE", "value": env(DEV_INIT_IMAGE)}, {"name": "RELATED_IMAGE_BROKER_INIT_000", "value": env(DEV_INIT_IMAGE)}, {"name": "RELATED_IMAGE_BROKER_KUBERNETES_000", "value": env(DEV_KUBE_IMAGE)}]' "$CSV"
+            # Add dev.latest overrides to kustomize overlay
+            yq -i '(.spec.template.spec.containers[].env) += [{"name": "DEFAULT_BROKER_VERSION", "value": "0.0.0"}, {"name": "DEFAULT_BROKER_COMPACT_VERSION", "value": "000"}, {"name": "DEFAULT_BROKER_KUBE_IMAGE", "value": env(DEV_KUBE_IMAGE)}, {"name": "DEFAULT_BROKER_INIT_IMAGE", "value": env(DEV_INIT_IMAGE)}, {"name": "RELATED_IMAGE_BROKER_INIT_000", "value": env(DEV_INIT_IMAGE)}, {"name": "RELATED_IMAGE_BROKER_KUBERNETES_000", "value": env(DEV_KUBE_IMAGE)}]' config/manager/manager_related_images.yaml
+          fi
           podman build --file bundle.Dockerfile --label git-sha=$GITHUB_SHA --tag $IMAGE_NAME-bundle:dev.latest .
 
       - name: Check the bundle image

--- a/controllers/broker_controller.go
+++ b/controllers/broker_controller.go
@@ -1948,6 +1948,10 @@ func (reconciler *BrokerReconcilerImpl) AssertBrokerImageVersion(cr *v1beta2.Bro
 
 	statusError := reconciler.CheckStatus(cr, client, func(brokerStatus *brokerStatus, jk *jolokia_client.JkInfo) ArtemisError {
 
+		if version.IsDevLatestBuild() {
+			reqLogger.V(1).Info("Skipping broker version alignment check on dev.latest build", "jolokiaVersion", brokerStatus.ServerStatus.Version)
+			return nil
+		}
 		if brokerStatus.ServerStatus.Version != resolvedFullVersion {
 			err := errors.Errorf("broker version non aligned on pod %s-%s, the detected version [%s] doesn't match the spec.version [%s] resolved as [%s]",
 				namer.CrToSS(cr.Name), jk.Ordinal, brokerStatus.ServerStatus.Version, cr.Spec.Version, resolvedFullVersion)

--- a/controllers/brokercluster_reconciler.go
+++ b/controllers/brokercluster_reconciler.go
@@ -3502,6 +3502,10 @@ func (reconciler *BrokerClusterReconcilerImpl) AssertBrokerImageVersion(cr *v1be
 
 	statusError := reconciler.CheckStatus(cr, client, func(brokerStatus *brokerStatus, jk *jolokia_client.JkInfo) ArtemisError {
 
+		if version.IsDevLatestBuild() {
+			reqLogger.V(1).Info("Skipping broker version alignment check on dev.latest build", "jolokiaVersion", brokerStatus.ServerStatus.Version)
+			return nil
+		}
 		if brokerStatus.ServerStatus.Version != resolvedFullVersion {
 			err := errors.Errorf("broker version non aligned on pod %s-%s, the detected version [%s] doesn't match the spec.version [%s] resolved as [%s]",
 				namer.CrToSS(cr.Name), jk.Ordinal, brokerStatus.ServerStatus.Version, cr.Spec.Version, resolvedFullVersion)

--- a/controllers/brokerservice_multi_app_test.go
+++ b/controllers/brokerservice_multi_app_test.go
@@ -902,7 +902,7 @@ var _ = Describe("broker-service multi-app scenarios", func() {
 
 			By("verify an app1 and app2 client can consume a message produced by app3")
 
-			brokerImage := version.LatestKubeImage
+			brokerImage := version.GetDefaultKubeImage()
 
 			By("provisioning pemcfg secret for client certs in both namespaces")
 			boolFalse := false

--- a/controllers/brokerservice_test.go
+++ b/controllers/brokerservice_test.go
@@ -148,7 +148,7 @@ var _ = Describe("broker-service-poc", func() {
 				}
 			})
 
-			brokerImage := version.LatestKubeImage
+			brokerImage := version.GetDefaultKubeImage()
 			jvmRemoteDebug := false
 			crd := broker.BrokerService{
 				TypeMeta: metav1.TypeMeta{
@@ -657,7 +657,7 @@ var _ = Describe("broker-service-poc", func() {
 				}
 			})
 
-			brokerImage := version.LatestKubeImage
+			brokerImage := version.GetDefaultKubeImage()
 			crd := broker.BrokerService{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "BrokerService",

--- a/pkg/utils/common/common.go
+++ b/pkg/utils/common/common.go
@@ -246,8 +246,8 @@ func ResolveBrokerVersion(versions []semver.Version, desired string) *semver.Ver
 		return nil
 	}
 	if desired == "" {
-		// latest
-		return &versions[len(versions)-1]
+		v := semver.MustParse(version.GetDefaultVersion())
+		return &v
 	}
 
 	major, minor, patch := resolveVersionComponents(desired)

--- a/pkg/utils/common/common_test.go
+++ b/pkg/utils/common/common_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/RHsyseng/operator-utils/pkg/olm"
 	"github.com/arkmq-org/arkmq-org-broker-operator/v2/api/v1beta2"
+	"github.com/arkmq-org/arkmq-org-broker-operator/v2/version"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -281,6 +282,63 @@ var _ = Describe("Common Test", func() {
 
 			_, err := GetOperatorClientCertSecret(fakeClient)
 			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("DetermineImageToUse dev.latest (0.0.0)", func() {
+		const devLatestKubeImage = "quay.io/arkmq-org/arkmq-org-broker-kubernetes@sha256:fakedevlatest"
+		const devLatestInitImage = "quay.io/arkmq-org/arkmq-org-broker-init@sha256:fakedevlatest"
+
+		AfterEach(func() {
+			os.Unsetenv("DEFAULT_BROKER_VERSION")
+			os.Unsetenv("RELATED_IMAGE_BROKER_KUBERNETES_000")
+			os.Unsetenv("RELATED_IMAGE_BROKER_INIT_000")
+			version.ResetDefaults()
+		})
+
+		It("should use 0.0.0 images when DEFAULT_BROKER_VERSION=0.0.0 and RELATED_IMAGE_BROKER_*_000 are set", func() {
+			os.Setenv("DEFAULT_BROKER_VERSION", "0.0.0")
+			os.Setenv("RELATED_IMAGE_BROKER_KUBERNETES_000", devLatestKubeImage)
+			os.Setenv("RELATED_IMAGE_BROKER_INIT_000", devLatestInitImage)
+			version.ResetDefaults()
+
+			cr := &v1beta2.BrokerCluster{}
+
+			kubeImage := DetermineImageToUse(cr, BrokerImageKey)
+			Expect(kubeImage).To(Equal(devLatestKubeImage))
+
+			initImage := DetermineImageToUse(cr, InitImageKey)
+			Expect(initImage).To(Equal(devLatestInitImage))
+		})
+
+		It("should not use 0.0.0 images when CR pins an older version", func() {
+			os.Setenv("DEFAULT_BROKER_VERSION", "0.0.0")
+			os.Setenv("RELATED_IMAGE_BROKER_KUBERNETES_000", devLatestKubeImage)
+			version.ResetDefaults()
+
+			cr := &v1beta2.BrokerCluster{
+				Spec: v1beta2.BrokerClusterSpec{
+					Version: "2.52.0",
+				},
+			}
+
+			kubeImage := DetermineImageToUse(cr, BrokerImageKey)
+			Expect(kubeImage).NotTo(Equal(devLatestKubeImage))
+		})
+
+		It("should not use 0.0.0 images when CR explicitly requests latest released version", func() {
+			os.Setenv("DEFAULT_BROKER_VERSION", "0.0.0")
+			os.Setenv("RELATED_IMAGE_BROKER_KUBERNETES_000", devLatestKubeImage)
+			version.ResetDefaults()
+
+			cr := &v1beta2.BrokerCluster{
+				Spec: v1beta2.BrokerClusterSpec{
+					Version: version.LatestVersion,
+				},
+			}
+
+			kubeImage := DetermineImageToUse(cr, BrokerImageKey)
+			Expect(kubeImage).NotTo(Equal(devLatestKubeImage))
 		})
 	})
 })

--- a/version/test_helpers.go
+++ b/version/test_helpers.go
@@ -1,0 +1,18 @@
+package version
+
+// ResetDefaults clears cached version/image defaults so they are re-derived
+// from the current environment. Needed in tests that modify env vars after
+// package init has already cached the values.
+func ResetDefaults() {
+	defaultVersion = ""
+	defaultCompactVersion = ""
+	defaultKubeImage = ""
+	defaultInitImage = ""
+	if IsDevLatestBuild() {
+		FullVersionFromCompactVersion["000"] = "0.0.0"
+		YacfgProfileVersionFromFullVersion["0.0.0"] = YacfgProfileVersionFromFullVersion[LatestVersion]
+		if !IsSupportedActiveMQArtemisVersion("0.0.0") {
+			SupportedActiveMQArtemisVersions = append(SupportedActiveMQArtemisVersions, "0.0.0")
+		}
+	}
+}

--- a/version/version.go
+++ b/version/version.go
@@ -31,6 +31,18 @@ var (
 	defaultInitImage string
 )
 
+func IsDevLatestBuild() bool {
+	return os.Getenv("DEFAULT_BROKER_VERSION") == "0.0.0"
+}
+
+func init() {
+	if IsDevLatestBuild() {
+		FullVersionFromCompactVersion["000"] = "0.0.0"
+		YacfgProfileVersionFromFullVersion["0.0.0"] = YacfgProfileVersionFromFullVersion[LatestVersion]
+		SupportedActiveMQArtemisVersions = append(SupportedActiveMQArtemisVersions, "0.0.0")
+	}
+}
+
 func GetDefaultVersion() string {
 	if defaultVersion == "" {
 		defaultVersion = os.Getenv("DEFAULT_BROKER_VERSION")


### PR DESCRIPTION
    CI resolves dev.latest operand tags to sha256 digests via skopeo and
    injects DEFAULT_BROKER_VERSION=0.0.0, DEFAULT_BROKER_COMPACT_VERSION,
    DEFAULT_BROKER_KUBE_IMAGE, DEFAULT_BROKER_INIT_IMAGE, and
    RELATED_IMAGE_BROKER_*_000 env vars into the dev helm chart, bundle
    CSV, and kustomize overlay.
    
    At startup, if DEFAULT_BROKER_VERSION is 0.0.0, the operator registers
    version 0.0.0 in the supported version maps. ResolveBrokerVersion uses
    GetDefaultVersion() for the no-version-specified case, so a default CR
    resolves to 0.0.0 and picks up the dev.latest operand digests. CRs
    that pin an explicit version are unaffected.
