### PR TITLE
Fix issue #1440: Add golangci-lint with ratchet mechanism to enforce lint quality over time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,58 @@ jobs:
             fi
           done
 
+  lint:
+    name: Lint
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.25.9'
+          cache: true
+
+      - name: Install golangci-lint
+        run: make lint-install
+
+      - name: Layer 1 — hard gate on new code
+        run: |
+          MERGE_BASE=$(git merge-base HEAD origin/main)
+          ./bin/golangci-lint run --new-from-rev=${MERGE_BASE} ./...
+
+      - name: Layer 2 — ratchet on total codebase debt
+        run: |
+          # Skip entirely if no .go files changed
+          MERGE_BASE=$(git merge-base HEAD origin/main)
+          if ! git diff --name-only ${MERGE_BASE} HEAD | grep -q '\.go$'; then
+            echo "No .go files changed — skipping debt ratchet."
+            exit 0
+          fi
+
+          # Count findings at merge-base
+          git checkout --quiet ${MERGE_BASE}
+          COUNT_BEFORE=$(golangci-lint run ./... 2>/dev/null | grep -c ' (errcheck)\| (ineffassign)\| (staticcheck)\| (unused)' || true)
+          git checkout --quiet -
+
+          # Count findings at PR HEAD
+          COUNT_AFTER=$(golangci-lint run ./... 2>/dev/null | grep -c ' (errcheck)\| (ineffassign)\| (staticcheck)\| (unused)' || true)
+
+          echo "Lint debt: before=${COUNT_BEFORE} after=${COUNT_AFTER}"
+
+          if [ "${COUNT_AFTER}" -gt "${COUNT_BEFORE}" ]; then
+            echo "::error::Lint debt increased (${COUNT_BEFORE} → ${COUNT_AFTER}). Fix the new issues before merging."
+            exit 1
+          elif [ "${COUNT_AFTER}" -eq "${COUNT_BEFORE}" ]; then
+            echo "::warning::Lint debt unchanged (${COUNT_BEFORE} → ${COUNT_AFTER}). Consider fixing a nearby issue."
+          else
+            echo "::notice::Lint debt decreased (${COUNT_BEFORE} → ${COUNT_AFTER}). Thank you."
+          fi
+
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,70 @@
+version: "2"
+
+linters:
+  enable:
+    - govet
+    - errcheck
+    - ineffassign
+    - staticcheck
+    - unused
+
+  settings:
+    govet:
+      # Preserve existing `go vet -composites=false` behaviour.
+      disable:
+        - composites
+
+  exclusions:
+    generated: strict
+
+    paths:
+      - vendor
+      - bin
+      - bundle
+
+    rules:
+      # Pure style: explicit type can be inferred from RHS.
+      # This appears as ST1023 in the current Fedora golangci-lint build.
+      - linters:
+          - staticcheck
+        text: "ST1023"
+
+      # Same/similar type-inference quickfix seen in other staticcheck builds.
+      - linters:
+          - staticcheck
+        text: "QF1011"
+
+      # Style-only error string capitalization.
+      - linters:
+          - staticcheck
+        text: "ST1005"
+
+      # Duplicate import aliases. Low-value style cleanup for initial rollout.
+      - linters:
+          - staticcheck
+        text: "ST1019"
+
+      # Optional quickfix/style suggestions; low value during initial adoption.
+      - linters:
+          - staticcheck
+        text: "QF1008"
+
+      - linters:
+          - staticcheck
+        text: "QF1004"
+
+      - linters:
+          - staticcheck
+        text: "QF1012"
+
+      # Common cleanup pattern in tests.
+      - path: ".*_test\\.go"
+        linters:
+          - errcheck
+        text: "Error return value of `.+\\.Close` is not checked"
+
+      # Common setup/teardown pattern in tests.
+      - path: ".*_test\\.go"
+        linters:
+          - errcheck
+        text: "Error return value of `os\\.(Setenv|Unsetenv)` is not checked"

--- a/Makefile
+++ b/Makefile
@@ -275,6 +275,7 @@ $(LOCALBIN):
 KUSTOMIZE ?= $(LOCALBIN)/kustomize
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
+GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v3.8.7
@@ -289,6 +290,24 @@ $(KUSTOMIZE): $(LOCALBIN)
 		rm -rf $(LOCALBIN)/kustomize; \
 	fi
 	test -s $(LOCALBIN)/kustomize || { curl -Ss $(KUSTOMIZE_INSTALL_SCRIPT) | bash -s -- $(subst v,,$(KUSTOMIZE_VERSION)) $(LOCALBIN); }
+
+LINT_VERSION ?= v2.11.3
+LINT_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh"
+
+.PHONY: lint lint-install
+
+lint-install: $(GOLANGCI_LINT) # Download golangci-lint locally if necessary
+$(GOLANGCI_LINT): $(LOCALBIN)
+	@if test -x $(LOCALBIN)/golangci-lint && ! $(LOCALBIN)/golangci-lint version | grep -q $(LINT_VERSION); then \
+		echo "$(LOCALBIN)/golangci-lint version is not expected $(LINT_VERSION). Removing it before installing."; \
+        rm -f $(LOCALBIN)/golangci-lint; \
+	fi
+	echo "curl -Ss ${LINT_INSTALL_SCRIPT} | bash -s -- $(subst v,,$(LINT_VERSION)) $(LOCALBIN);"
+	test -s $(LOCALBIN)/golangci-lint || { curl -Ss ${LINT_INSTALL_SCRIPT} | bash -s -- v$(subst v,,$(LINT_VERSION)) $(LOCALBIN); }	
+	
+
+lint: lint-install
+	$(LOCALBIN)/golangci-lint run ./...
 
 .PHONY: controller-gen
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary. If wrong version is installed, it will be overwritten.

--- a/docs/help/building.md
+++ b/docs/help/building.md
@@ -82,3 +82,14 @@ make OPERATOR_IMAGE_REPO=<your repo> OPERATOR_VERSION=<tag> docker-push
 ```
 
 Now follow the [quickstart](../getting-started/quick-start.md) to deploy the operator.
+
+## 3. Add .vscode/settings.json
+
+```$xslt
+{
+  "go.lintTool": "golangci-lint",
+  "go.lintFlags": ["--fast"]
+}
+```
+
+This ensures Cursor and VS Code users see the same findings as CI. Required for golangci-lint with ratchet mechanism to enforce lint quality over time.


### PR DESCRIPTION
Fix issue #1440: Add golangci-lint with ratchet mechanism to enforce lint quality over time

- Added lint command to makefile. 
- Excluded '.vscode/settings.json' from .gitignore and added lines to ensureCursor and VS Code users see the same findings as CI without manual configuration.
- Made changes to '.github/workflows/ci.yaml' to allow for two layer CI enforcement. 
- Added golang ci yaml file. 