### PR TITLE
[#1461] Update documentation for increased clarity.

### DIFF
--- a/docs/help/building.md
+++ b/docs/help/building.md
@@ -83,7 +83,17 @@ make OPERATOR_IMAGE_REPO=<your repo> OPERATOR_VERSION=<tag> docker-push
 
 Now follow the [quickstart](../getting-started/quick-start.md) to deploy the operator.
 
-## 3. Add .vscode/settings.json
+## Update operator with new image
+
+Once your custom image has been pushed to a registry, you must update the value of **spec.template.spec.containers.image** in **./deploy/operator.yaml**
+
+```$xslt
+        image: ${OPERATOR_IMAGE_REPO}:${TAG}
+```
+
+It is important to remember to build and push a new image whenever you pull new changes from the remote repository, or are testing local changes. 
+
+## Add .vscode/settings.json
 
 ```$xslt
 {


### PR DESCRIPTION
Slight update to the documentation to remind users to build and push a new image when pulling or testing changes, and then update the image reference in ./deploy/operator.yaml 