### PR TITLE
[#1464] Update deprecated CRD warning

### DIFF
--- a/api/v1beta1/activemqartemis_types.go
+++ b/api/v1beta1/activemqartemis_types.go
@@ -772,7 +772,7 @@ type ExternalConfigStatus struct {
 //+operator-sdk:csv:customresourcedefinitions:resources={{"ConfigMap", "v1"}}
 //+operator-sdk:csv:customresourcedefinitions:resources={{"StatefulSet", "apps/v1"}}
 
-// +kubebuilder:deprecatedversion:warning="The ActiveMQArtemis CRD (activemqartemises.broker.amq.io) is deprecated. Use the Broker CRD (brokers.broker.arkmq.org) instead by updating apiVersion to broker.arkmq.org/v1beta2 and kind to Broker. The spec is compatible."
+// +kubebuilder:deprecatedversion:warning="The ActiveMQArtemis CRD (activemqartemises.broker.amq.io) is deprecated. Use the BrokerCluster CRD (brokerclusters.broker.arkmq.org) instead by updating apiVersion to broker.arkmq.org/v1beta2 and kind to BrokerCluster. The spec is compatible."
 // A stateful deployment of one or more brokers
 // +operator-sdk:csv:customresourcedefinitions:displayName="ActiveMQ Artemis"
 type ActiveMQArtemis struct {

--- a/bundle/manifests/broker.amq.io_activemqartemises.yaml
+++ b/bundle/manifests/broker.amq.io_activemqartemises.yaml
@@ -26,8 +26,9 @@ spec:
       type: date
     deprecated: true
     deprecationWarning: The ActiveMQArtemis CRD (activemqartemises.broker.amq.io)
-      is deprecated. Use the Broker CRD (brokers.broker.arkmq.org) instead by updating
-      apiVersion to broker.arkmq.org/v1beta2 and kind to Broker. The spec is compatible.
+      is deprecated. Use the BrokerCluster CRD (brokerclusters.broker.arkmq.org) instead
+      by updating apiVersion to broker.arkmq.org/v1beta2 and kind to BrokerCluster.
+      The spec is compatible.
     name: v1beta1
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/broker.amq.io_activemqartemises.yaml
+++ b/config/crd/bases/broker.amq.io_activemqartemises.yaml
@@ -27,8 +27,9 @@ spec:
       type: date
     deprecated: true
     deprecationWarning: The ActiveMQArtemis CRD (activemqartemises.broker.amq.io)
-      is deprecated. Use the Broker CRD (brokers.broker.arkmq.org) instead by updating
-      apiVersion to broker.arkmq.org/v1beta2 and kind to Broker. The spec is compatible.
+      is deprecated. Use the BrokerCluster CRD (brokerclusters.broker.arkmq.org) instead
+      by updating apiVersion to broker.arkmq.org/v1beta2 and kind to BrokerCluster.
+      The spec is compatible.
     name: v1beta1
     schema:
       openAPIV3Schema:

--- a/deploy/arkmq-org-broker-operator.yaml
+++ b/deploy/arkmq-org-broker-operator.yaml
@@ -677,7 +677,7 @@ spec:
       name: Age
       type: date
     deprecated: true
-    deprecationWarning: The ActiveMQArtemis CRD (activemqartemises.broker.amq.io) is deprecated. Use the Broker CRD (brokers.broker.arkmq.org) instead by updating apiVersion to broker.arkmq.org/v1beta2 and kind to Broker. The spec is compatible.
+    deprecationWarning: The ActiveMQArtemis CRD (activemqartemises.broker.amq.io) is deprecated. Use the BrokerCluster CRD (brokerclusters.broker.arkmq.org) instead by updating apiVersion to broker.arkmq.org/v1beta2 and kind to BrokerCluster. The spec is compatible.
     name: v1beta1
     schema:
       openAPIV3Schema:

--- a/deploy/crds/broker_activemqartemis_crd.yaml
+++ b/deploy/crds/broker_activemqartemis_crd.yaml
@@ -25,7 +25,7 @@ spec:
       name: Age
       type: date
     deprecated: true
-    deprecationWarning: The ActiveMQArtemis CRD (activemqartemises.broker.amq.io) is deprecated. Use the Broker CRD (brokers.broker.arkmq.org) instead by updating apiVersion to broker.arkmq.org/v1beta2 and kind to Broker. The spec is compatible.
+    deprecationWarning: The ActiveMQArtemis CRD (activemqartemises.broker.amq.io) is deprecated. Use the BrokerCluster CRD (brokerclusters.broker.arkmq.org) instead by updating apiVersion to broker.arkmq.org/v1beta2 and kind to BrokerCluster. The spec is compatible.
     name: v1beta1
     schema:
       openAPIV3Schema:

--- a/helm-charts/arkmq-org-broker-operator/templates/crds.yaml
+++ b/helm-charts/arkmq-org-broker-operator/templates/crds.yaml
@@ -29,7 +29,7 @@ spec:
           name: Age
           type: date
       deprecated: true
-      deprecationWarning: The ActiveMQArtemis CRD (activemqartemises.broker.amq.io) is deprecated. Use the Broker CRD (brokers.broker.arkmq.org) instead by updating apiVersion to broker.arkmq.org/v1beta2 and kind to Broker. The spec is compatible.
+      deprecationWarning: The ActiveMQArtemis CRD (activemqartemises.broker.amq.io) is deprecated. Use the BrokerCluster CRD (brokerclusters.broker.arkmq.org) instead by updating apiVersion to broker.arkmq.org/v1beta2 and kind to BrokerCluster. The spec is compatible.
       name: v1beta1
       schema:
         openAPIV3Schema:


### PR DESCRIPTION
Fixes #1464

Updates the ActiveMQArtemis deprecation warning to direct users to the BrokerCluster CRD and its correct resource name and kind. The generated CRD manifest is included.

Testing:
- `GOTOOLCHAIN=go1.25.9 make manifests`
- `GOTOOLCHAIN=go1.25.9 go test ./api/v1beta1`
- `GOTOOLCHAIN=go1.25.9 go vet ./api/v1beta1`
- `GOTOOLCHAIN=go1.25.9 golangci-lint run --new-from-rev=HEAD ./...`
