### PR TITLE
Add EXTRA_BROKER_PROPERTIES env var to extend broker.properties paths

### DIFF
--- a/controllers/activemqartemis_controller_test.go
+++ b/controllers/activemqartemis_controller_test.go
@@ -9047,6 +9047,68 @@ var _ = Describe("artemis controller", func() {
 		CleanResource(createdCrd, createdCrd.Name, defaultNamespace)
 	})
 
+	It("EXTRA_BROKER_PROPERTIES extends broker properties paths", Label("extra-broker-properties"), func() {
+		ctx := context.Background()
+		const extraPaths = "/my/extra/path/"
+
+		By("creating a CR with EXTRA_BROKER_PROPERTIES set")
+		crd, createdCrd := DeployCustomBroker(defaultNamespace, func(candidate *brokerv1beta1.ActiveMQArtemis) {
+			candidate.Spec.Env = []corev1.EnvVar{
+				{
+					Name:  "EXTRA_BROKER_PROPERTIES",
+					Value: extraPaths,
+				},
+			}
+		})
+
+		ssKey := types.NamespacedName{Name: namer.CrToSS(createdCrd.Name), Namespace: defaultNamespace}
+		createdSs := &appsv1.StatefulSet{}
+
+		By("checking EXTRA_BROKER_PROPERTIES has user value and precedes JDK_JAVA_OPTIONS")
+		Eventually(func(g Gomega) {
+			g.Expect(k8sClient.Get(ctx, ssKey, createdSs)).Should(Succeed())
+
+			env := createdSs.Spec.Template.Spec.Containers[0].Env
+
+			extraPathsIdx := -1
+			jdkOptsIdx := -1
+			for i, e := range env {
+				if e.Name == "EXTRA_BROKER_PROPERTIES" {
+					g.Expect(e.Value).To(Equal(extraPaths))
+					extraPathsIdx = i
+				}
+				if e.Name == "JDK_JAVA_OPTIONS" {
+					g.Expect(e.Value).To(ContainSubstring(",$(EXTRA_BROKER_PROPERTIES)"))
+					jdkOptsIdx = i
+				}
+			}
+			g.Expect(extraPathsIdx).NotTo(Equal(-1), "EXTRA_BROKER_PROPERTIES must be in container env")
+			g.Expect(jdkOptsIdx).NotTo(Equal(-1), "JDK_JAVA_OPTIONS must be in container env")
+			g.Expect(extraPathsIdx).To(BeNumerically("<", jdkOptsIdx),
+				"EXTRA_BROKER_PROPERTIES must precede JDK_JAVA_OPTIONS for k8s substitution")
+		}, timeout, interval).Should(Succeed())
+
+		if os.Getenv("USE_EXISTING_CLUSTER") == "true" {
+			By("verifying Kubernetes has resolved $(EXTRA_BROKER_PROPERTIES) on the running pod")
+			podWithOrdinal := namer.CrToSS(crd.Name) + "-0"
+			Eventually(func(g Gomega) {
+				result := ExecOnPod(podWithOrdinal, crd.Name, defaultNamespace, []string{"env"}, g)
+				// After k8s substitution JDK_JAVA_OPTIONS must contain the resolved path, not the token
+				for _, line := range strings.Split(result, "\n") {
+					if strings.HasPrefix(line, "JDK_JAVA_OPTIONS") {
+						g.Expect(line).To(ContainSubstring(extraPaths))
+						g.Expect(line).NotTo(ContainSubstring("$(EXTRA_BROKER_PROPERTIES)"))
+					}
+				}
+			}, existingClusterTimeout, existingClusterInterval).Should(Succeed())
+		}
+
+		By("deleting the CR")
+		CleanResource(createdCrd, createdCrd.Name, defaultNamespace)
+	})
+
+
+
 	It("enable JVM metrics by using broker properties", func() {
 		ctx := context.Background()
 		crd := generateArtemisSpec(defaultNamespace)

--- a/controllers/broker_controller.go
+++ b/controllers/broker_controller.go
@@ -1184,6 +1184,11 @@ func (reconciler *BrokerReconcilerImpl) brokerPropertiesConfigSystemPropValue(mo
 		}
 	}
 
+	// Append user-defined extra paths via Kubernetes env var substitution.
+	// The trailing comma is safe: Java String.split(",") strips trailing empty tokens,
+	// so Artemis parseProperties receives no empty path when the var is unset.
+	result = result + ",$(EXTRA_BROKER_PROPERTIES)"
+
 	return result
 }
 
@@ -1635,6 +1640,12 @@ func MakeEnvVarArrayForCRForBroker(customResource *v1beta2.Broker, namer common.
 
 	envVarArrayForMetricsPlugin := environments.AddEnvVarForMetricsPlugin(metricsPluginEnabled)
 	envVar = append(envVar, envVarArrayForMetricsPlugin...)
+
+	// Default empty value so that $(EXTRA_BROKER_PROPERTIES) in JDK_JAVA_OPTIONS
+	// always resolves via Kubernetes substitution. Must appear before ReplaceOrAppend
+	// so the user's Spec.Env entry can override it, and before JDK_JAVA_OPTIONS is
+	// appended by CreateOrAppend so the k8s substitution order is guaranteed.
+	envVar = append(envVar, environments.AddEnvVarForExtraBrokerProperties()...)
 
 	// Env from CR will override
 	envVar = environments.ReplaceOrAppend(envVar, customResource.Spec.Env...)
@@ -2102,9 +2113,10 @@ func validateReservedLabelsForBroker(customResource *v1beta2.Broker) *metav1.Con
 func validateEnvVarsForBroker(customResource *v1beta2.Broker) (*metav1.Condition, bool) {
 
 	internalVarNames := map[string]string{
-		debugArgsEnvVarName:      debugArgsEnvVarName,
-		javaOptsEnvVarName:       javaOptsEnvVarName,
-		javaArgsAppendEnvVarName: javaArgsAppendEnvVarName,
+		debugArgsEnvVarName:                          debugArgsEnvVarName,
+		javaOptsEnvVarName:                           javaOptsEnvVarName,
+		javaArgsAppendEnvVarName:                     javaArgsAppendEnvVarName,
+		environments.ExtraBrokerPropertiesEnvVar: environments.ExtraBrokerPropertiesEnvVar,
 	}
 
 	invalidVars := []string{}

--- a/controllers/broker_controller_unit_test.go
+++ b/controllers/broker_controller_unit_test.go
@@ -16,10 +16,12 @@ package controllers
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	brokerv1beta1 "github.com/arkmq-org/arkmq-org-broker-operator/v2/api/v1beta1"
 	v1beta2 "github.com/arkmq-org/arkmq-org-broker-operator/v2/api/v1beta2"
+	"github.com/arkmq-org/arkmq-org-broker-operator/v2/pkg/resources/environments"
 	"github.com/arkmq-org/arkmq-org-broker-operator/v2/pkg/utils/common"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -138,4 +140,90 @@ func TestValidateRestrictedNeedsSecret(t *testing.T) {
 	assert.True(t, valid)
 	assert.False(t, retry)
 	assert.True(t, meta.IsStatusConditionTrue(cr.Status.Conditions, brokerv1beta1.ValidConditionType))
+}
+
+func TestBrokerCR_ExtraBrokerPropertiesDefaultIsEmpty(t *testing.T) {
+
+	cr := &v1beta2.Broker{
+		ObjectMeta: v1.ObjectMeta{Name: "broker"},
+		Spec:       v1beta2.BrokerSpec{},
+	}
+
+	namer := MakeNamersForBroker(cr)
+	envVars := MakeEnvVarArrayForCRForBroker(cr, *namer)
+
+	// EXTRA_BROKER_PROPERTIES must be present with an empty default
+	extraPathsIdx := -1
+	for i, e := range envVars {
+		if e.Name == environments.ExtraBrokerPropertiesEnvVar {
+			assert.Equal(t, "", e.Value)
+			extraPathsIdx = i
+			break
+		}
+	}
+	assert.True(t, extraPathsIdx != -1, "EXTRA_BROKER_PROPERTIES must be in env array")
+
+	// brokerPropertiesConfigSystemPropValue must embed the token
+	r := NewBrokerReconciler(&NillCluster{}, ctrl.Log, isOpenshift)
+	ri := NewBrokerReconcilerImpl(cr, r)
+	result := ri.brokerPropertiesConfigSystemPropValue("/config/", "my-resource",
+		map[string][]byte{"broker.properties": []byte("")})
+	assert.True(t, strings.HasSuffix(result, ",$(EXTRA_BROKER_PROPERTIES)"),
+		"brokerPropertiesConfigSystemPropValue must end with ,$(EXTRA_BROKER_PROPERTIES)")
+}
+
+func TestBrokerCR_ExtraBrokerPropertiesUserValueOverrides(t *testing.T) {
+
+	const extraPaths = "/my/extra/path/"
+
+	cr := &v1beta2.Broker{
+		ObjectMeta: v1.ObjectMeta{Name: "broker"},
+		Spec: v1beta2.BrokerSpec{
+			Env: []corev1.EnvVar{
+				{
+					Name:  environments.ExtraBrokerPropertiesEnvVar,
+					Value: extraPaths,
+				},
+			},
+		},
+	}
+
+	namer := MakeNamersForBroker(cr)
+	envVars := MakeEnvVarArrayForCRForBroker(cr, *namer)
+
+	// User's value must replace the operator default
+	found := false
+	for _, e := range envVars {
+		if e.Name == environments.ExtraBrokerPropertiesEnvVar {
+			assert.Equal(t, extraPaths, e.Value)
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "EXTRA_BROKER_PROPERTIES with user value must be in env array")
+}
+
+func TestBrokerCR_ExtraBrokerPropertiesValueFromIsRejected(t *testing.T) {
+
+	cr := &v1beta2.Broker{
+		ObjectMeta: v1.ObjectMeta{Name: "broker"},
+		Spec: v1beta2.BrokerSpec{
+			Env: []corev1.EnvVar{
+				{
+					Name: environments.ExtraBrokerPropertiesEnvVar,
+					ValueFrom: &corev1.EnvVarSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "some-secret"},
+							Key:                  "paths",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	condition, _ := validateEnvVarsForBroker(cr)
+	assert.NotNil(t, condition)
+	assert.Equal(t, brokerv1beta1.ValidConditionInvalidInternalVarUsage, condition.Reason)
+	assert.Contains(t, condition.Message, environments.ExtraBrokerPropertiesEnvVar)
 }

--- a/controllers/brokercluster_reconciler.go
+++ b/controllers/brokercluster_reconciler.go
@@ -2465,6 +2465,11 @@ func (reconciler *BrokerClusterReconcilerImpl) brokerPropertiesConfigSystemPropV
 		result = fmt.Sprintf("%s,%s%s/?filter=.*\\.%s${STATEFUL_SET_ORDINAL}%s", result, mountPoint, resourceName, OrdinalPropertiesSuffix, OrdinalPropertiesSuffixEnd)
 	}
 
+	// Append user-defined extra paths via Kubernetes env var substitution.
+	// The trailing comma is safe: Java String.split(",") strips trailing empty tokens,
+	// so Artemis parseProperties receives no empty path when the var is unset.
+	result = result + ",$(EXTRA_BROKER_PROPERTIES)"
+
 	return result
 }
 
@@ -3019,6 +3024,12 @@ func MakeEnvVarArrayForCR(customResource *v1beta2.BrokerCluster, namer common.Na
 
 	envVarArrayForMetricsPlugin := environments.AddEnvVarForMetricsPlugin(metricsPluginEnabled)
 	envVar = append(envVar, envVarArrayForMetricsPlugin...)
+
+	// Default empty value so that $(EXTRA_BROKER_PROPERTIES) in JDK_JAVA_OPTIONS
+	// always resolves via Kubernetes substitution. Must appear before ReplaceOrAppend
+	// so the user's Spec.Env entry can override it, and before JDK_JAVA_OPTIONS is
+	// appended by CreateOrAppend so the k8s substitution order is guaranteed.
+	envVar = append(envVar, environments.AddEnvVarForExtraBrokerProperties()...)
 
 	// Env from CR will override
 	envVar = environments.ReplaceOrAppend(envVar, customResource.Spec.Env...)
@@ -3841,9 +3852,10 @@ func (r *BrokerClusterReconcilerImpl) validateExposeModes(customResource *v1beta
 func (r *BrokerClusterReconcilerImpl) validateEnvVars(customResource *v1beta2.BrokerCluster) (*metav1.Condition, bool) {
 
 	internalVarNames := map[string]string{
-		debugArgsEnvVarName:      debugArgsEnvVarName,
-		javaOptsEnvVarName:       javaOptsEnvVarName,
-		javaArgsAppendEnvVarName: javaArgsAppendEnvVarName,
+		debugArgsEnvVarName:                          debugArgsEnvVarName,
+		javaOptsEnvVarName:                           javaOptsEnvVarName,
+		javaArgsAppendEnvVarName:                     javaArgsAppendEnvVarName,
+		environments.ExtraBrokerPropertiesEnvVar: environments.ExtraBrokerPropertiesEnvVar,
 	}
 
 	invalidVars := []string{}

--- a/controllers/brokercluster_reconciler_test.go
+++ b/controllers/brokercluster_reconciler_test.go
@@ -15,6 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	"github.com/arkmq-org/arkmq-org-broker-operator/v2/pkg/resources/environments"
 	"github.com/arkmq-org/arkmq-org-broker-operator/v2/pkg/utils/common"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -601,6 +602,122 @@ func Test_Respect_existing_JAVA_OPTS_properties_def(t *testing.T) {
 	assert.True(t, index != -1)
 	assert.True(t, strings.Contains(newSS.Spec.Template.Spec.InitContainers[0].Env[index].Value, "properties"))
 }
+
+
+func Test_ExtraBrokerPropertiesDefaultIsEmpty(t *testing.T) {
+
+	cr := &v1beta2.BrokerCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "cr"},
+		Spec:       v1beta2.BrokerClusterSpec{},
+	}
+
+	outer := NewBrokerClusterReconciler(&NillCluster{}, ctrl.Log.WithName("Test_ExtraBrokerPropertiesDefaultIsEmpty"), isOpenshift)
+	reconciler := NewBrokerClusterReconcilerImpl(cr, outer)
+
+	newSS, err := reconciler.ProcessStatefulSet(cr, *MakeNamers(cr), nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, newSS)
+
+	containers := newSS.Spec.Template.Spec.Containers
+	assert.NotEmpty(t, containers)
+
+	env := containers[0].Env
+
+	// EXTRA_BROKER_PROPERTIES must be present with an empty default value
+	extraPathsIdx := -1
+	jdkOptsIdx := -1
+	for i, e := range env {
+		if e.Name == environments.ExtraBrokerPropertiesEnvVar {
+			assert.Equal(t, "", e.Value)
+			extraPathsIdx = i
+		}
+		if e.Name == jdkJavaOptionsEnvVarName {
+			jdkOptsIdx = i
+		}
+	}
+	assert.True(t, extraPathsIdx != -1, "EXTRA_BROKER_PROPERTIES must be present in container env")
+	assert.True(t, jdkOptsIdx != -1, "JDK_JAVA_OPTIONS must be present in container env")
+
+	// EXTRA_BROKER_PROPERTIES must be declared before JDK_JAVA_OPTIONS so that
+	// Kubernetes $(VAR_NAME) substitution resolves correctly
+	assert.True(t, extraPathsIdx < jdkOptsIdx, "EXTRA_BROKER_PROPERTIES must precede JDK_JAVA_OPTIONS in env list")
+
+	// JDK_JAVA_OPTIONS must contain the token so Kubernetes resolves it at pod start time
+	assert.True(t, strings.Contains(env[jdkOptsIdx].Value, ",$(EXTRA_BROKER_PROPERTIES)"),
+		"JDK_JAVA_OPTIONS must contain ,$(EXTRA_BROKER_PROPERTIES) token")
+}
+
+func Test_ExtraBrokerPropertiesUserValueAppearsInEnv(t *testing.T) {
+
+	const extraPaths = "/my/custom/path/,/my/other/path/"
+
+	cr := &v1beta2.BrokerCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "cr"},
+		Spec: v1beta2.BrokerClusterSpec{
+			Env: []v1.EnvVar{
+				{
+					Name:  environments.ExtraBrokerPropertiesEnvVar,
+					Value: extraPaths,
+				},
+			},
+		},
+	}
+
+	outer := NewBrokerClusterReconciler(&NillCluster{}, ctrl.Log.WithName("Test_ExtraBrokerPropertiesUserValueAppearsInEnv"), isOpenshift)
+	reconciler := NewBrokerClusterReconcilerImpl(cr, outer)
+
+	newSS, err := reconciler.ProcessStatefulSet(cr, *MakeNamers(cr), nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, newSS)
+
+	env := newSS.Spec.Template.Spec.Containers[0].Env
+
+	// User's value must replace the operator default
+	extraPathsIdx := -1
+	jdkOptsIdx := -1
+	for i, e := range env {
+		if e.Name == environments.ExtraBrokerPropertiesEnvVar {
+			assert.Equal(t, extraPaths, e.Value)
+			extraPathsIdx = i
+		}
+		if e.Name == jdkJavaOptionsEnvVarName {
+			jdkOptsIdx = i
+		}
+	}
+	assert.True(t, extraPathsIdx != -1)
+	assert.True(t, jdkOptsIdx != -1)
+	assert.True(t, extraPathsIdx < jdkOptsIdx, "EXTRA_BROKER_PROPERTIES must precede JDK_JAVA_OPTIONS in env list")
+	assert.True(t, strings.Contains(env[jdkOptsIdx].Value, ",$(EXTRA_BROKER_PROPERTIES)"))
+}
+
+func Test_ExtraBrokerPropertiesValueFromIsRejected(t *testing.T) {
+
+	cr := &v1beta2.BrokerCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "cr"},
+		Spec: v1beta2.BrokerClusterSpec{
+			Env: []v1.EnvVar{
+				{
+					Name: environments.ExtraBrokerPropertiesEnvVar,
+					ValueFrom: &v1.EnvVarSource{
+						SecretKeyRef: &v1.SecretKeySelector{
+							LocalObjectReference: v1.LocalObjectReference{Name: "some-secret"},
+							Key:                  "paths",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	outer := NewBrokerClusterReconciler(&NillCluster{}, ctrl.Log.WithName("Test_ExtraBrokerPropertiesValueFromIsRejected"), isOpenshift)
+	reconciler := NewBrokerClusterReconcilerImpl(cr, outer)
+
+	condition, _ := reconciler.validateEnvVars(cr)
+	assert.NotNil(t, condition, "validation condition must be set when valueFrom is used")
+	assert.Equal(t, v1beta2.ValidConditionInvalidInternalVarUsage, condition.Reason)
+	assert.Contains(t, condition.Message, environments.ExtraBrokerPropertiesEnvVar)
+}
+
 
 func TestProcess_TemplateKeyValue(t *testing.T) {
 

--- a/docs/help/operator.md
+++ b/docs/help/operator.md
@@ -847,6 +847,7 @@ There are a few well-known environment variables that are used by the operator i
 * JAVA_ARGS_APPEND
 * JAVA_OPTS
 * DEBUG_ARGS
+* EXTRA_BROKER_PROPERTIES
 
 If you want to add some values to any of them, make sure you define it in **spec.env** using `value` field. If you use `valueFrom` for the env var you will get validation error condition in your CR's status.
 
@@ -897,6 +898,56 @@ For example:
 ```
 
 **Note: the broker pods must be restarted to apply the acceptor broker properties!**
+
+## Providing additional brokerProperties paths via environment variable
+
+When broker properties files are already available inside the container at runtime — for
+example written by a Vault agent sidecar, an init container, or any other injector — you
+can use the `EXTRA_BROKER_PROPERTIES` environment variable to tell the operator to
+append those paths to the broker properties search path it manages.
+
+Set `EXTRA_BROKER_PROPERTIES` in `spec.env` with a comma-separated list of paths.
+Each entry can be a file path or a directory path (ending with `/`), using the same
+format that Apache Artemis accepts for `broker.properties`:
+
+```yaml
+apiVersion: broker.arkmq.org/v1beta2
+kind: BrokerCluster
+metadata:
+  name: ex-aao
+spec:
+  env:
+    - name: EXTRA_BROKER_PROPERTIES
+      value: "/vault/secrets/my-broker.properties,/my/extra/config-dir/"
+```
+
+The operator appends this value to the end of the `-Dbroker.properties=` JVM system
+property it manages, using **Kubernetes environment variable substitution** — no
+reconcile-time parsing is needed. The operator's own paths are always present; the
+user's paths are appended last so any key defined in them overrides keys from earlier
+sources.
+
+> **NOTE**: `EXTRA_BROKER_PROPERTIES` must be set using a plain `value` string,
+> not `valueFrom`. If you need to source the path dynamically from a Secret, declare
+> a helper env var with `valueFrom` and reference it:
+>
+> ```yaml
+> spec:
+>   env:
+>     - name: MY_EXTRA_PATH
+>       valueFrom:
+>         secretKeyRef:
+>           name: my-secret
+>           key: props-path
+>     - name: EXTRA_BROKER_PROPERTIES
+>       value: "$(MY_EXTRA_PATH)"
+> ```
+
+This mechanism complements `extraMounts.secrets` with the `-bp` suffix. Use **`-bp`
+secrets** when you want Kubernetes to mount the properties files into the pod. Use
+**`EXTRA_BROKER_PROPERTIES`** when the files are already present in the container
+at runtime (e.g. written by a Vault agent sidecar as in the
+[Vault tutorial](../tutorials/vault_broker_properties.md)).
 
 ## Providing additional brokerProperties configuration from a secret
 In order to provide a way to split or organise these properties by file or by secret, an extra mount can be used to provide a secret that will be treated as an additional source of broker properties configuration.

--- a/docs/tutorials/vault_broker_properties.md
+++ b/docs/tutorials/vault_broker_properties.md
@@ -250,7 +250,11 @@ The Vault Agent Injector is the official HashiCorp solution for injecting secret
 
 ### Deploy the broker (hashicorp-broker)
 
-Create the broker CR with Vault Agent Injector annotations. The template constructs the broker properties using the address name from Vault with the path `secret/data/broker`:
+Create the broker CR with Vault Agent Injector annotations. The template constructs the broker properties using the address name from Vault with the path `secret/data/broker`.
+
+`EXTRA_BROKER_PROPERTIES` tells the operator to append the Vault-injected file to
+its own broker properties search path. No manual `-Dbroker.properties=` override is
+needed — the operator's paths remain intact and the Vault file is loaded on top:
 
 ```{"stage":"agent-injector", "runtime":"bash", "label":"deploy hashicorp broker"}
 kubectl apply -f - << EOF
@@ -273,8 +277,8 @@ spec:
     podSecurity:
       serviceAccountName: vault-broker-sa
   env:
-  - name: JAVA_ARGS_APPEND
-    value: "-Dbroker.properties=/amq/extra/secrets/hashicorp-broker-props/broker.properties,/vault/secrets/vault-broker.properties"
+  - name: EXTRA_BROKER_PROPERTIES
+    value: "/vault/secrets/vault-broker.properties"
 EOF
 ```
 ```shell markdown_runner
@@ -496,6 +500,7 @@ Both brokers successfully created the same `VAULT-TEST` queue and address from t
 - Supports secret rotation
 - Better for production environments
 - Properties injected at `/vault/secrets/vault-broker.properties`
+- Path added via `EXTRA_BROKER_PROPERTIES` — operator's own paths are preserved
 
 **Banzai Secret Injection Webhook (`banzai-broker`):**
 - Webhook intercepts pod creation
@@ -520,7 +525,9 @@ This tutorial demonstrates two approaches for injecting the **same Vault secret*
 2. **Vault Auth**: Kubernetes auth method with simple policy allowing read access to broker secrets
 3. **Vault Agent**: Sidecar container injected into broker pod via annotations
 4. **Template Processing**: Agent uses Go template to fetch `addressName` and construct complete broker properties
-5. **Artemis Broker**: Loads constructed properties from `/vault/secrets/vault-broker.properties` via `JAVA_ARGS_APPEND`
+5. **Artemis Broker**: Loads constructed properties from `/vault/secrets/vault-broker.properties`.
+   The path is appended to the operator's own search path via `EXTRA_BROKER_PROPERTIES`,
+   so the operator's required configuration remains intact and the Vault file is applied on top.
 
 #### Banzai Secret Injection Webhook (`banzai-broker`)
 
@@ -542,11 +549,20 @@ Both brokers create the same infrastructure from the Vault-injected address name
   - HashiCorp: Vault agent authenticates continuously during pod runtime (sidecar container)
   - Banzai: Webhook authenticates once during pod creation (mutating webhook)
 - **Secret injection method**:
-  - HashiCorp: Template-based construction using Go templates to build complete properties file
-  - Banzai: Injects Vault value into environment variable, Artemis resolves `${VAR}` placeholders at runtime
+  - HashiCorp: Template-based construction using Go templates to build complete properties file,
+    path registered via `EXTRA_BROKER_PROPERTIES`
+  - Banzai: Injects Vault value into environment variable, Artemis resolves `${VAR}` placeholders
+    at runtime; path registered via `extraMounts.secrets` with `-bp` suffix
 - **Resource usage**:
   - HashiCorp: Additional sidecar container per pod
   - Banzai: Single webhook deployment for all pods
+
+> **Why `EXTRA_BROKER_PROPERTIES` instead of `JAVA_ARGS_APPEND` for the HashiCorp approach?**
+> Setting `-Dbroker.properties=...` directly in `JAVA_ARGS_APPEND` **replaces** the operator's
+> own path list, losing the operator-managed configuration. `EXTRA_BROKER_PROPERTIES` is
+> designed for exactly this use case: it appends user-supplied paths to the operator's list via
+> Kubernetes env var substitution, so both the operator's paths and the Vault-injected file are
+> always active.
 
 This approach provides:
 - **Secure secret management**: Sensitive data never stored in Kubernetes

--- a/pkg/resources/environments/environment.go
+++ b/pkg/resources/environments/environment.go
@@ -9,6 +9,12 @@ import (
 const (
 	NameEnvVar             = "AMQ_NAME"
 	NameEnvVarDefaultValue = "amq-broker"
+
+	// ExtraBrokerPropertiesEnvVar is an operator-consumed env var that the user
+	// can set in Spec.Env with a comma-separated list of extra broker.properties paths
+	// (files or directories). The operator appends it to its own -Dbroker.properties=
+	// value via Kubernetes $(VAR_NAME) substitution so no reconcile-time parsing is needed.
+	ExtraBrokerPropertiesEnvVar = "EXTRA_BROKER_PROPERTIES"
 )
 
 func ResolveBrokerNameFromEnvs(envs []corev1.EnvVar, defaultValue string) string {
@@ -20,6 +26,18 @@ func ResolveBrokerNameFromEnvs(envs []corev1.EnvVar, defaultValue string) string
 		}
 	}
 	return defaultValue
+}
+
+// AddEnvVarForExtraBrokerProperties returns an env var with an empty default
+// for EXTRA_BROKER_PROPERTIES. The empty default ensures the Kubernetes
+// $(EXTRA_BROKER_PROPERTIES) reference in JDK_JAVA_OPTIONS always resolves
+// (to an empty string) rather than being left as a literal token when the user
+// has not set a custom value.
+func AddEnvVarForExtraBrokerProperties() []corev1.EnvVar {
+	return []corev1.EnvVar{{
+		Name:  ExtraBrokerPropertiesEnvVar,
+		Value: "",
+	}}
 }
 
 func AddEnvVarForBasic(requireLogin string, journalType string, svcPingName string) []corev1.EnvVar {


### PR DESCRIPTION
Introduce EXTRA_BROKER_PROPERTIES, a new operator-internal env var that users can set in spec.env with a comma-separated list of extra .properties file or directory paths. The operator appends ,$(EXTRA_BROKER_PROPERTIES) to its own -Dbroker.properties= value; Kubernetes resolves the $(VAR_NAME) reference at pod admission time so the operator's paths always come first.