### PR TITLE
[#1479] CI failure caused by stale operator cert secrets leaking btw …

### DIFF
--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -915,6 +915,22 @@ var _ = BeforeSuite(func() {
 	}
 })
 
+func cleanUpOperatorCertSecrets() {
+	bundle := tm.Bundle{}
+	if k8sClient.Get(ctx, types.NamespacedName{Name: common.DefaultOperatorCASecretName}, &bundle) == nil {
+		err := k8sClient.Delete(ctx, &bundle)
+		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
+	}
+	for _, secretName := range []string{common.DefaultOperatorCASecretName, common.DefaultOperatorCertSecretName} {
+		secret := corev1.Secret{}
+		key := types.NamespacedName{Name: secretName, Namespace: defaultNamespace}
+		if k8sClient.Get(ctx, key, &secret) == nil {
+			err := k8sClient.Delete(ctx, &secret)
+			Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
+		}
+	}
+}
+
 func cleanUpPVC() {
 	pvcs := &corev1.PersistentVolumeClaimList{}
 	opts := []client.ListOption{}
@@ -930,6 +946,7 @@ var _ = AfterSuite(func() {
 	if os.Getenv("USE_EXISTING_CLUSTER") == "true" {
 		cleanUpPVC()
 		cleanUpTestProxy()
+		cleanUpOperatorCertSecrets()
 	}
 
 	os.Unsetenv("OPERATOR_WATCH_NAMESPACE")


### PR DESCRIPTION
…test phases

Cert-manager tests in phase 1 create the arkmq-org-broker-manager-ca and arkmq-org-broker-manager-cert resources. Their AfterEach cleanup is disabled (`if false &&`)  - each test's BeforeEach cleans up the previous test's resources instead. But the last cert-manager test in Phase 1 has no successor to perform this cleanup, so its secrets persist into the next phase.

Changes: Added cleanUpOperatorCertSecrets() to AfterSuite to delete the leaked Bundle CR and operator certificate secrets after all tests complete.

**Local Run after changes:** 

Ran 263 of 277 Specs in 4229.673 seconds
  SUCCESS! -- 263 Passed | 0 Failed | 0 Pending | 14 Skipped
  
  Ran 13 of 277 Specs in 658.494 seconds
  SUCCESS! -- 13 Passed | 0 Failed | 0 Pending | 264 Skipped