### PR TITLE
[#1479] extract mk-tests in its own pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,71 @@ jobs:
             echo "::notice::Lint debt decreased (${COUNT_BEFORE} → ${COUNT_AFTER}). Thank you."
           fi
 
+  unit-tests:
+    name: Unit tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version: '1.25.9'
+          cache: true
+
+      - name: Run unit tests
+        run: make test-unit-v
+
+  e2e-tests:
+    name: E2E tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version: '1.25.9'
+          cache: true
+
+      - name: Set up env
+        run: echo "HOSTNAME=${HOSTNAME}" >> ${GITHUB_ENV}
+
+      - name: Start minikube
+        uses: medyagh/setup-minikube@master
+        with:
+          cpus: 2
+          memory: 8g
+          addons: ingress
+          start-args: --extra-config=kubelet.sync-frequency=10s
+
+      - name: Enable SSL passthrough
+        run: >
+          minikube kubectl -- patch deployment -n ingress-nginx
+          ingress-nginx-controller --type='json'
+          -p='[{"op": "add", "path": "/spec/template/spec/containers/0/args/-",
+          "value":"--enable-ssl-passthrough"}]'
+
+      - name: Install cert-manager and trust-manager
+        run: |
+          helm repo add jetstack https://charts.jetstack.io --force-update
+          helm upgrade -i -n cert-manager cert-manager jetstack/cert-manager --set installCRDs=true --create-namespace --wait
+          helm upgrade -i -n cert-manager trust-manager jetstack/trust-manager --set secretTargets.enabled=true --set secretTargets.authorizedSecretsAll=true --wait
+
+      - name: Run PR-scoped E2E tests
+        if: ${{ github.event_name == 'pull_request' }}
+        run: make test-mk-pr-v
+        timeout-minutes: 55
+
+      - name: Run full E2E test suite
+        if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' && !inputs.skipTests }}
+        run: make test-mk-v
+        timeout-minutes: 130
+
   build:
     name: Build
     runs-on: ubuntu-latest
@@ -200,10 +265,6 @@ jobs:
           minikube kubectl -- wait pod -l app=olm-operator --for=condition=Ready --namespace=olm --timeout=2m
           minikube kubectl -- wait --for=condition=Established crd/catalogsources.operators.coreos.com --timeout=2m
           minikube kubectl -- wait --for=condition=Established crd/subscriptions.operators.coreos.com --timeout=2m
-
-      - name: Execute tests
-        if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' && !inputs.skipTests }}
-        run: IMG="${HOSTNAME}:5000/$IMAGE_NAME:dev.latest" make test-mk-v
 
       - name: Execute do tests
         if: ${{ github.event_name != 'workflow_dispatch' || !inputs.skipDOTests }}

--- a/Makefile
+++ b/Makefile
@@ -148,9 +148,16 @@ vet: ## Run go vet against code.
 ## Run tests.
 test test-v: TEST_VARS = KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" RECONCILE_RESYNC_PERIOD=5s
 
+## Run unit tests only (no cluster required, E2E specs self-skip)
+test-unit test-unit-v: TEST_VARS = USE_EXISTING_CLUSTER=false KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)"
+
 ## Run tests against minikube with local operator.
 test-mk test-mk-v: TEST_ARGS += -test.timeout=120m -ginkgo.label-filter='!do'
 test-mk test-mk-v: TEST_VARS = USE_EXISTING_CLUSTER=true RECONCILE_RESYNC_PERIOD=5s
+
+## PR-scoped E2E: broker-service and control plane (excludes verySlow)
+test-mk-pr test-mk-pr-v: TEST_ARGS += -test.timeout=50m -ginkgo.label-filter='!do && !verySlow' -ginkgo.focus='broker-service|restricted rbac'
+test-mk-pr test-mk-pr-v: TEST_VARS = USE_EXISTING_CLUSTER=true RECONCILE_RESYNC_PERIOD=5s
 
 ## Run tests against minikube with deployed operator(do)
 test-mk-do test-mk-do-v: TEST_ARGS += -test.timeout=60m -ginkgo.label-filter='do'
@@ -160,14 +167,21 @@ test-mk-do test-mk-do-v: TEST_VARS = DEPLOY_OPERATOR=true USE_EXISTING_CLUSTER=t
 test-mk-do-fast test-mk-do-fast-v: TEST_ARGS += -test.timeout=30m -ginkgo.label-filter='do && !slow'
 test-mk-do-fast test-mk-do-fast-v: TEST_VARS = DEPLOY_OPERATOR=true USE_EXISTING_CLUSTER=true
 
-test-v test-mk-v test-mk-do-v test-mk-do-fast-v: TEST_ARGS += -v
-test-v test-mk test-mk-v test-mk-do test-mk-do-v test-mk-do-fast test-mk-do-fast-v: TEST_ARGS += -ginkgo.poll-progress-after=150s -ginkgo.fail-fast -coverprofile cover-mk.out
+test-v test-mk-v test-mk-do-v test-mk-do-fast-v test-mk-pr-v test-unit-v: TEST_ARGS += -v
+test-v test-mk test-mk-v test-mk-do test-mk-do-v test-mk-do-fast test-mk-do-fast-v test-mk-pr test-mk-pr-v: TEST_ARGS += -ginkgo.poll-progress-after=150s -ginkgo.fail-fast -coverprofile cover-mk.out
 
 test test-v: manifests generate fmt vet envtest
 	$(TEST_VARS) go test ./... -p 1 $(TEST_ARGS) $(TEST_EXTRA_ARGS)
 
+test-unit test-unit-v: manifests generate fmt vet envtest
+	$(TEST_VARS) go test ./... -p 1 $(TEST_ARGS) $(TEST_EXTRA_ARGS)
+
 test-mk test-mk-v test-mk-do test-mk-do-v test-mk-do-fast test-mk-do-fast-v: TEST_VARS += HELM=$(HELM)
 test-mk test-mk-v test-mk-do test-mk-do-v test-mk-do-fast test-mk-do-fast-v: manifests generate fmt vet envtest helm
+	$(TEST_VARS) go test ./... -p 1 $(TEST_ARGS) $(TEST_EXTRA_ARGS)
+
+test-mk-pr test-mk-pr-v: TEST_VARS += HELM=$(HELM)
+test-mk-pr test-mk-pr-v: manifests generate fmt vet envtest helm
 	$(TEST_VARS) go test ./... -p 1 $(TEST_ARGS) $(TEST_EXTRA_ARGS)
 
 ##@ Debugging


### PR DESCRIPTION
Run the make test-mk-* tests on a seperate pipeline. These tests don't depend on the build to be executed.