### PR TITLE
[#1496] Order prometheus config keys for consistent reconcile

### DIFF
--- a/controllers/brokerservice_controller.go
+++ b/controllers/brokerservice_controller.go
@@ -1114,7 +1114,7 @@ func (reconciler *BrokerServiceInstanceReconciler) generatePrometheusConfig(appQ
 	// Add queue-level attributes for specific queues with exact ObjectNames (include quotes) for canonocial string match, this restricts the attribute load
 	if len(appQueues) > 0 {
 		fmt.Fprintf(buf, "includeObjectNameAttributes:\n")
-		for address := range appQueues {
+		for _, address := range brokerproperties.SortedKeysBool(appQueues) {
 			fqqn := strings.SplitN(address, "::", 2)
 			if len(fqqn) > 1 {
 				fmt.Fprintf(buf, "  org.apache.activemq.artemis:broker=\"%s\",component=addresses,address=\"%s\",subcomponent=queues,routing-type=\"multicast\",queue=\"%s\":\n",

--- a/pkg/brokerproperties/brokerproperties.go
+++ b/pkg/brokerproperties/brokerproperties.go
@@ -124,6 +124,15 @@ func SortedKeysByteValue(props map[string][]byte) []string {
 	return keys
 }
 
+func SortedKeysBool(props map[string]bool) []string {
+	keys := make([]string, 0, len(props))
+	for k := range props {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
 func KeyValuePairs(data []byte) []string {
 	keyValuePairs := []string{}
 	for _, lineToTrim := range strings.Split(string(data), "\n") {

--- a/pkg/brokerproperties/brokerproperties_test.go
+++ b/pkg/brokerproperties/brokerproperties_test.go
@@ -271,6 +271,17 @@ var _ = Describe("SortedKeysByteValue", func() {
 	})
 })
 
+var _ = Describe("SortedKeysBool", func() {
+	It("returns keys in alphabetical order", func() {
+		props := map[string]bool{"c": true, "a": true, "b": false}
+		Expect(SortedKeysBool(props)).To(Equal([]string{"a", "b", "c"}))
+	})
+
+	It("returns an empty slice for an empty map", func() {
+		Expect(SortedKeysBool(map[string]bool{})).To(BeEmpty())
+	})
+})
+
 var _ = Describe("KeyValuePairs", func() {
 	It("returns key=value lines, stripping leading whitespace", func() {
 		raw := []byte("  foo=bar\n")


### PR DESCRIPTION
Fixes #1496

## Summary
- `generatePrometheusConfig` iterated `appQueues` with an unordered `range` over a map, so prometheus YAML could differ across reconciles.
- Added `brokerproperties.SortedKeysBool` (same pattern as `SortedKeys` / `SortedKeysByteValue`) and use it when emitting `includeObjectNameAttributes`.

## Test plan
- [x] Unit coverage for `SortedKeysBool` ordering and empty map
- [ ] Existing BrokerService prometheus/reconcile tests still pass